### PR TITLE
ci: publish previews with pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,9 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Build
+        run: pnpm prepack
+
+      - name: Publish preview
+        run: pnpm dlx pkg-pr-new publish

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export default defineNuxtConfig({
 
 ## Content sources
 
-**`'auto'` / `@nuxt/content`** (default when the module is installed): queries every `type: 'page'` collection with `queryCollection()` and stringifies with `minimark/stringify`, resolved from `@nuxt/content` itself rather than from this module, so the stringifier is always the one that produced the tree. Mirrors the raw markdown route `@nuxt/content` registers itself when `nuxt-llms` is present, so nothing changes for agents when this module takes over. A site that needs to transform MDC components into plain markdown can hook `agent-discovery:document` before the tree is stringified:
+**`'auto'` / `@nuxt/content`** (default when the module is installed): queries every `type: 'page'` collection with `queryCollection()` and stringifies with `minimark/stringify`, resolved from `@nuxt/content` itself rather than from this module, so the stringifier is always the one that produced the tree. It also drops the `<style>` node syntax highlighters append, which carries per-document CSS variables that mean nothing in markdown. Mirrors the raw markdown route `@nuxt/content` registers itself when `nuxt-llms` is present, including the related links appended from a page's `links` frontmatter, so nothing changes for agents when this module takes over. A site that needs to transform MDC components into plain markdown can hook `agent-discovery:document` before the tree is stringified:
 
 ```ts
 // server/plugins/agent-discovery.ts

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ export default defineEventHandler(event => `# Docs\n\n${renderAgentResources(eve
 
 Detected automatically, never a dependency:
 
-- **`@nuxtjs/robots`** takes over `robots.txt`, and the shared user-agent list is fed into its `groups` instead of this module registering a competing route.
+- **`@nuxtjs/robots`** takes over `robots.txt`, and the shared user-agent list is contributed through its `robots:config` hook instead of this module registering a competing route. `robots.contentSignal` rides along on the wildcard group, so the directive survives the handoff.
 - **`@nuxtjs/sitemap`** owns `sitemap.xml`, and the raw markdown prefix is added to its `exclude`. The raw twins are alternate representations of pages already in the sitemap, not pages of their own, so listing them separately would be wrong on every site that pairs the two.
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export default defineNuxtConfig({
 
 ## Content sources
 
-**`'auto'` / `@nuxt/content`** (default when the module is installed): queries every `type: 'page'` collection with `queryCollection()` and stringifies with `minimark/stringify`. Mirrors the raw markdown route `@nuxt/content` registers itself when `nuxt-llms` is present, so nothing changes for agents when this module takes over. A site that needs to transform MDC components into plain markdown can hook `agent-discovery:document` before the tree is stringified:
+**`'auto'` / `@nuxt/content`** (default when the module is installed): queries every `type: 'page'` collection with `queryCollection()` and stringifies with `minimark/stringify`, resolved from `@nuxt/content` itself rather than from this module, so the stringifier is always the one that produced the tree. Mirrors the raw markdown route `@nuxt/content` registers itself when `nuxt-llms` is present, so nothing changes for agents when this module takes over. A site that needs to transform MDC components into plain markdown can hook `agent-discovery:document` before the tree is stringified:
 
 ```ts
 // server/plugins/agent-discovery.ts

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Markdown content negotiation, CDN-level rewrites, and discovery documents for AI
 - A `nuxt-llms` bridge: `/llms.txt` and `/llms-full.txt` stay owned by `nuxt-llms`, this module never registers them, but their links get rewritten to the `/raw` twins and the raw route survives a content-backend swap
 - Markdown error bodies with recovery links for agents hitting a 404 or other error
 - `/.well-known/api-catalog` (RFC 9727) and an optional MCP server card
-- `/sitemap.md`, a markdown index of every page
+- `/sitemap.md`, a markdown index of every page, grouped into sections you control
 - Agent Skills served under `/.well-known/skills/`, with the index generated from the directory on disk instead of hand-maintained
 - `robots.txt` AI policy generated from the same user-agent list negotiation matches, so the two can't drift apart
 - A `useCanonical()` composable for canonical and markdown-alternate `<link>` tags
@@ -105,7 +105,7 @@ export default defineNuxtConfig({
 - **`discovery.mcpServerCard`** Given an `McpServerCardOptions` object (`endpoint`, `name`, and optionally `title`, `description`, `documentation`, `repository`, `license`, `version`), serves `/.well-known/mcp/server-card.json`. `false` to disable.
 - **`discovery.links`** Site-specific discovery links: OpenAPI documents, service docs, anything else worth advertising. Rels are validated against the IANA registry, an invented one fails the build. Other modules can push into the same list through the `agent-discovery:extend` hook.
 - **`errors`** Chains a markdown error handler ahead of any existing Nitro `errorHandler`, answering with a markdown body carrying recovery links when the request prefers it.
-- **`sitemap.markdown`** Serve `/sitemap.md`, a markdown index of every page, from the content adapter.
+- **`sitemap.markdown`** Serve `/sitemap.md`, a markdown index of every page, from the content adapter. Pass an object to control the grouping: `expand` lists path prefixes whose children each get their own section (`['/docs']` turns one "Docs" section into "Components", "Composables", ... while `/blog/**` stays a single "Blog"), and `labels` overrides the heading derived from a segment. Top-level pages share one "Pages" section.
 - **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with `name` and `description` frontmatter becomes a skill; its files are listed from disk into a generated `/.well-known/skills/index.json`, so the index can never fall behind the files actually served. Names are validated against the Agent Skills spec. `false` to disable; the feature turns itself off when the directory does not exist. Skills are pushed into the discovery registry, so they reach the api-catalog and the error-body recovery links.
 - **`robots.aiPolicy`** Feeds the shared user-agent list into `@nuxtjs/robots` when it's installed. Otherwise generates `/robots.txt`, skipped (with a warning) if a static `public/robots.txt` already exists.
 - **`robots.contentSignal`** The `Content-Signal` line added to the wildcard group. `false` to omit it.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,32 @@ export default defineAgentContentSource({
 
 `routes()` lists every markdown-representable route, `get()` resolves one to its markdown. An optional `list()` returns routes with metadata in one call, used by `sitemap.md` and the `nuxt-llms` bridge to avoid a `get()` per page; both fall back to `routes()` + `get()` when it's absent.
 
+## Extending
+
+Two Nitro hooks and one helper let a site contribute what only it knows, without the module depending on its tooling.
+
+**`agent-discovery:mcp-server-card`** enriches the served card with live tools, resources and prompts:
+
+```ts
+// server/plugins/agent-discovery.ts
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('agent-discovery:mcp-server-card', async (event, card) => {
+    const { tools } = await listMcpDefinitions({ event })
+    card.tools = tools.map(tool => ({ name: tool.name, description: tool.description }))
+  })
+})
+```
+
+**`renderAgentResources()`** renders the discovery registry as a markdown block, for sites that hand-write an agent-facing homepage. It is the same list the `Link` header and the api-catalog are built from, so a resource can't be advertised in one place and missed in another:
+
+```ts
+import { renderAgentResources } from '#agent-discovery'
+
+export default defineEventHandler(event => `# Docs\n\n${renderAgentResources(event)}`)
+```
+
+**`agent-discovery:document`** transforms a page before it is stringified, covered under [Content sources](#content-sources).
+
 ## Companion modules
 
 Detected automatically, never a dependency:

--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ export default defineAgentContentSource({
 
 `routes()` lists every markdown-representable route, `get()` resolves one to its markdown. An optional `list()` returns routes with metadata in one call, used by `sitemap.md` and the `nuxt-llms` bridge to avoid a `get()` per page; both fall back to `routes()` + `get()` when it's absent.
 
+## Companion modules
+
+Detected automatically, never a dependency:
+
+- **`@nuxtjs/robots`** takes over `robots.txt`, and the shared user-agent list is fed into its `groups` instead of this module registering a competing route.
+- **`@nuxtjs/sitemap`** owns `sitemap.xml`, and the raw markdown prefix is added to its `exclude`. The raw twins are alternate representations of pages already in the sitemap, not pages of their own, so listing them separately would be wrong on every site that pairs the two.
+
 ## Deployment
 
 ### Vercel

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Markdown content negotiation, CDN-level rewrites, and discovery documents for AI
 - Markdown error bodies with recovery links for agents hitting a 404 or other error
 - `/.well-known/api-catalog` (RFC 9727) and an optional MCP server card
 - `/sitemap.md`, a markdown index of every page
+- Agent Skills served under `/.well-known/skills/`, with the index generated from the directory on disk instead of hand-maintained
 - `robots.txt` AI policy generated from the same user-agent list negotiation matches, so the two can't drift apart
 - A `useCanonical()` composable for canonical and markdown-alternate `<link>` tags
 - An `agent-discovery:extend` hook so other modules can add discovery links and user agents
@@ -85,7 +86,8 @@ export default defineNuxtConfig({
     },
     errors: true,
     sitemap: { markdown: true },
-    robots: { aiPolicy: true, contentSignal: 'search=yes, ai-train=yes, ai-input=yes' }
+    robots: { aiPolicy: true, contentSignal: 'search=yes, ai-train=yes, ai-input=yes' },
+    skills: { dir: 'skills' }
   }
 })
 ```
@@ -104,6 +106,7 @@ export default defineNuxtConfig({
 - **`discovery.links`** Site-specific discovery links: OpenAPI documents, service docs, anything else worth advertising. Rels are validated against the IANA registry, an invented one fails the build. Other modules can push into the same list through the `agent-discovery:extend` hook.
 - **`errors`** Chains a markdown error handler ahead of any existing Nitro `errorHandler`, answering with a markdown body carrying recovery links when the request prefers it.
 - **`sitemap.markdown`** Serve `/sitemap.md`, a markdown index of every page, from the content adapter.
+- **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with `name` and `description` frontmatter becomes a skill; its files are listed from disk into a generated `/.well-known/skills/index.json`, so the index can never fall behind the files actually served. Names are validated against the Agent Skills spec. `false` to disable; the feature turns itself off when the directory does not exist. Skills are pushed into the discovery registry, so they reach the api-catalog and the error-body recovery links.
 - **`robots.aiPolicy`** Feeds the shared user-agent list into `@nuxtjs/robots` when it's installed. Otherwise generates `/robots.txt`, skipped (with a warning) if a static `public/robots.txt` already exists.
 - **`robots.contentSignal`** The `Content-Signal` line added to the wildcard group. `false` to omit it.
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@nuxt/kit": "^4.5.2",
     "defu": "^6.1.4",
     "pathe": "^2.0.3",
-    "ufo": "^1.6.4"
+    "ufo": "^1.6.4",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@nuxt/content": "^3.15.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@nuxt/kit": "^4.5.2",
     "defu": "^6.1.4",
-    "minimark": "^1.0.0",
     "pathe": "^2.0.3",
     "ufo": "^1.6.4"
   },
@@ -58,6 +57,7 @@
     "better-sqlite3": "^13.0.3",
     "eslint": "^10.9.1",
     "h3": "^1.15.4",
+    "minimark": "^1.0.0",
     "nuxt": "^4.5.2",
     "nuxt-llms": "^0.2.0",
     "release-it": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@nuxt/eslint-config": "^1.17.0",
     "@nuxt/module-builder": "^1.0.3",
     "@nuxt/schema": "^4.5.2",
+    "@nuxtjs/robots": "^6.2.0",
     "@nuxt/test-utils": "^4.1.0",
     "@release-it/conventional-changelog": "^12.0.0",
     "@types/node": "^26.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@nuxt/test-utils':
         specifier: ^4.1.0
         version: 4.1.0(esbuild@0.28.2)(magicast@0.5.4)(rolldown@1.2.5)(rollup@4.62.5)(typescript@5.9.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vitest@4.1.11(@types/node@26.2.0)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      '@nuxtjs/robots':
+        specifier: ^6.2.0
+        version: 6.2.0(d20ebc32674e35045d97786f77e88e64)
       '@release-it/conventional-changelog':
         specifier: ^12.0.0
         version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)(release-it@21.0.2(@types/node@26.2.0)(magicast@0.5.4)(supports-color@10.2.2))
@@ -678,6 +681,9 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@fingerprintjs/botd@2.0.0':
+    resolution: {integrity: sha512-yhuz23NKEcBDTHmGz/ULrXlGnbHenO+xZmVwuBkuqHUkqvaZ5TAA0kAgcRy4Wyo5dIBdkIf57UXX8/c9UlMLJg==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -946,6 +952,11 @@ packages:
     peerDependencies:
       vite: '>=6.0'
 
+  '@nuxt/devtools-kit@4.0.0-alpha.7':
+    resolution: {integrity: sha512-Tgh+tSejh1GnZjdjgWyc4qCxskeX08XuSQBYMn/4SIV5AubeqYeAOMBD2qSmHOXjMCUpgyzpEhODcP3sgdgGRA==}
+    peerDependencies:
+      vite: '>=6.0'
+
   '@nuxt/devtools-wizard@3.4.2':
     resolution: {integrity: sha512-U2G8fw7KW1rdECyJDho5N14z8hSllpTk430KG1QPLjrv5w3pDksZ+YcpITd0u762Vw3gq3Arpg65Bk6U4ua6aQ==}
     hasBin: true
@@ -1078,6 +1089,14 @@ packages:
 
   '@nuxtjs/mdc@0.22.2':
     resolution: {integrity: sha512-bGI/tXOB7iOMY5LBmSICTVE1l2MsNdLnbZDc+zbaeVv6EXz8V7oyJgi+Fe32qWTS+k5cNjAzj90gvlQfJ/RW9g==}
+
+  '@nuxtjs/robots@6.2.0':
+    resolution: {integrity: sha512-+y8BRDWOkSMofe0ewOlVQm6+VFd4Qh/I8kh9z/++VwfPlDtrU6BDhoobJ18eVDaMkf8gJl12dwKZziK8yU4c/g==}
+    peerDependencies:
+      zod: '>=3'
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -4256,6 +4275,14 @@ packages:
   nuxt-llms@0.2.0:
     resolution: {integrity: sha512-GoEW00x8zaZ1wS0R0aOYptt3b54JEaRwlyVtuAiQoH51BwYdjN5/3+00/+4wi39M5cT4j5XcnGwOxJ7v4WVb9A==}
 
+  nuxt-site-config-kit@4.2.3:
+    resolution: {integrity: sha512-xAU061MrxDlv1CjHjP9+Qg3mAdKxQgO9sFzoy+LblKW+DDLRMGjaEIna/QUk0F0kWzhrf4dSpOVTW8OZv26xVg==}
+
+  nuxt-site-config@4.2.3:
+    resolution: {integrity: sha512-m0CK1Q43T3qtVHSBYeDHav/hp8t/ahhlJGzwdBOQM6WcxeZpF1wcJazoGQAJEFamX1xcRAtA0ZuvvEkwHSMG0w==}
+    peerDependencies:
+      vue: ^3.5.30
+
   nuxt@4.5.2:
     resolution: {integrity: sha512-tR3fcqeHlHmmkLMpIg3V7Y+1ltr302lW8djMw/iy+myfo7QSSz+BVJDuQhg5j73b9oteSyBfOKTDYTgvMtj6TA==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
@@ -4268,6 +4295,20 @@ packages:
       '@parcel/watcher':
         optional: true
       '@types/node':
+        optional: true
+
+  nuxtseo-shared@5.3.14:
+    resolution: {integrity: sha512-kt3IrUILAD4ElsA5+3uroQUHmDLfQkiYWrdXm4Eb/tSm7L0ug2WQc6Okh9m/KtypCVBfwtChrAVMgSyT/VYP5w==}
+    peerDependencies:
+      '@nuxt/schema': ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt: ^3.16.0 || ^4.0.0 || ^5.0.0
+      nuxt-site-config: ^3.2.0 || ^4.0.0
+      vue: ^3.5.0
+      zod: ^3.23.0 || ^4.0.0
+    peerDependenciesMeta:
+      nuxt-site-config:
+        optional: true
+      zod:
         optional: true
 
   nypm@0.6.9:
@@ -5176,6 +5217,11 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  site-config-stack@4.2.3:
+    resolution: {integrity: sha512-9kJn4YoJvJqbxbE5T1WYl7ibL4SYngcKQ3sP8SfJcgzqtawMMwuBuC2h/DuFSLqVE5ZyMqGtMONm/ax8nSHVrw==}
+    peerDependencies:
+      vue: ^3.5.30
 
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
@@ -6630,6 +6676,8 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@fingerprintjs/botd@2.0.0': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -6979,6 +7027,18 @@ snapshots:
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       execa: 8.0.1
+      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
+  '@nuxt/devtools-kit@4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      tinyexec: 1.3.0
       vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - magic-string
@@ -7494,6 +7554,31 @@ snapshots:
       - rolldown
       - supports-color
       - unplugin
+
+  '@nuxtjs/robots@6.2.0(d20ebc32674e35045d97786f77e88e64)':
+    dependencies:
+      '@fingerprintjs/botd': 2.0.0
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      consola: 3.4.2
+      defu: 6.1.7
+      h3: 1.15.11
+      nuxt-site-config: 4.2.3(d20ebc32674e35045d97786f77e88e64)
+      nuxtseo-shared: 5.3.14(7aee94db16aeef2f7597748717842cb4)
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      ufo: 1.6.4
+    optionalDependencies:
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - vue
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -10939,6 +11024,45 @@ snapshots:
       - rolldown
       - unplugin
 
+  nuxt-site-config-kit@4.2.3(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3)):
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      site-config-stack: 4.2.3(vue@3.5.41(typescript@5.9.3))
+      std-env: 4.2.0
+      ufo: 1.6.4
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vue
+
+  nuxt-site-config@4.2.3(d20ebc32674e35045d97786f77e88e64):
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      consola: 3.4.2
+      defu: 6.1.7
+      h3: 1.15.11
+      nuxt-site-config-kit: 4.2.3(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vue@3.5.41(typescript@5.9.3))
+      nuxtseo-shared: 5.3.14(7aee94db16aeef2f7597748717842cb4)
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      site-config-stack: 4.2.3(vue@3.5.41(typescript@5.9.3))
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - zod
+
   nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.146.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(better-sqlite3@13.0.3)(db0@0.3.4(better-sqlite3@13.0.3))(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.5)(rollup@4.62.5))(rollup@4.62.5)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.10(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
@@ -11079,6 +11203,36 @@ snapshots:
       - webpack
       - xml2js
       - yaml
+
+  nuxtseo-shared@5.3.14(7aee94db16aeef2f7597748717842cb4):
+    dependencies:
+      '@clack/prompts': 1.7.0
+      '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      '@nuxt/schema': 4.5.2
+      birpc: 4.2.0
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.146.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(better-sqlite3@13.0.3)(db0@0.3.4(better-sqlite3@13.0.3))(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.5)(rollup@4.62.5))(rollup@4.62.5)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@5.9.3))(yaml@2.9.0)
+      nypm: 0.6.9
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sirv: 3.0.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
+    optionalDependencies:
+      nuxt-site-config: 4.2.3(d20ebc32674e35045d97786f77e88e64)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
 
   nypm@0.6.9:
     dependencies:
@@ -12135,6 +12289,11 @@ snapshots:
       totalist: 3.0.1
 
   sisteransi@1.0.5: {}
+
+  site-config-stack@4.2.3(vue@3.5.41(typescript@5.9.3)):
+    dependencies:
+      ufo: 1.6.4
+      vue: 3.5.41(typescript@5.9.3)
 
   skin-tone@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,15 +17,15 @@ importers:
       defu:
         specifier: ^6.1.4
         version: 6.1.7
-      minimark:
-        specifier: ^1.0.0
-        version: 1.0.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
       ufo:
         specifier: ^1.6.4
         version: 1.6.4
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@nuxt/content':
         specifier: ^3.15.2
@@ -57,6 +57,9 @@ importers:
       h3:
         specifier: ^1.15.4
         version: 1.15.11
+      minimark:
+        specifier: ^1.0.0
+        version: 1.0.0
       nuxt:
         specifier: ^4.5.2
         version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.146.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(better-sqlite3@13.0.3)(db0@0.3.4(better-sqlite3@13.0.3))(esbuild@0.28.2)(eslint@10.9.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.1.1(rolldown@1.2.5)(rollup@4.62.5))(rollup@4.62.5)(srvx@0.11.22)(supports-color@10.2.2)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue-tsc@3.3.11(typescript@5.9.3))(yaml@2.9.0)

--- a/src/module.ts
+++ b/src/module.ts
@@ -345,11 +345,15 @@ export default defineNuxtModule<ModuleOptions>({
         links.push({ href: '/sitemap.md', rel: 'sitemap', type: 'text/markdown', title: 'Sitemap (Markdown): every page on the site' })
       }
       if (options.discovery?.apiCatalog) {
-        links.push({ href: '/.well-known/api-catalog', rel: 'api-catalog', type: 'application/linkset+json' })
+        links.push({ href: '/.well-known/api-catalog', rel: 'api-catalog', type: 'application/linkset+json', title: 'API catalog: every service document this site publishes' })
       }
       if (options.discovery?.mcpServerCard) {
         const card = options.discovery.mcpServerCard
-        links.push({ href: '/.well-known/mcp/server-card.json', rel: 'service-desc', type: 'application/json', title: `MCP server card: MCP endpoint at ${card.endpoint}`, anchor: card.endpoint })
+        const endpoint = card.endpoint.startsWith('/') ? `${config.siteUrl}${card.endpoint}` : card.endpoint
+        links.push({ href: '/.well-known/mcp/server-card.json', rel: 'service-desc', type: 'application/json', title: `MCP server card: MCP endpoint at ${endpoint}`, anchor: card.endpoint })
+        // The endpoint itself, so an agent reading the resources block or the
+        // error body can reach it without fetching the card first.
+        links.push({ href: card.endpoint, rel: 'service', title: 'MCP endpoint (streamable HTTP)', header: false })
         if (card.documentation) {
           links.push({ href: card.documentation, rel: 'service-doc', type: 'text/html', anchor: card.endpoint, header: false })
         }

--- a/src/module.ts
+++ b/src/module.ts
@@ -209,12 +209,19 @@ export default defineNuxtModule<ModuleOptions>({
       sourcePath = await resolvePath(options.source)
     }
 
-    nuxt.options.nitro.alias = defu(nuxt.options.nitro.alias, {
-      ...(minimarkStringify ? { 'minimark/stringify': minimarkStringify } : {}),
+    const aliases = {
       '#agent-discovery/source': sourcePath || resolve('./runtime/server/sources/none'),
       '#agent-discovery/comark': resolve('./runtime/server/sources/comark'),
       '#agent-discovery': resolve('./runtime/server/utils/agent-discovery')
+    }
+    nuxt.options.nitro.alias = defu(nuxt.options.nitro.alias, {
+      ...(minimarkStringify ? { 'minimark/stringify': minimarkStringify } : {}),
+      ...aliases
     })
+    // Also aliased app-side, purely so a site whose `tsconfig.json` extends the
+    // app config (the common single-tsconfig setup) can typecheck a server
+    // route importing `#agent-discovery`. Nitro is what actually resolves it.
+    nuxt.options.alias = defu(nuxt.options.alias, aliases)
 
     /* ------------------------------- handlers ----------------------------- */
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,9 +19,9 @@ import { isValidRel } from './rels'
 import { scanSkills } from './skills'
 import { setupVercelPreset } from './presets/vercel'
 import { formatLinkHeader, matchRoute, rawDestination, MARKDOWN_VARY } from './runtime/shared/negotiation'
-import type { AgentRoute, DiscoveryLink, NegotiationConfig, SkillEntry } from './runtime/shared/types'
+import type { AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
-export type { AgentContentSource, AgentPage, AgentRoute, DiscoveryLink, NegotiationConfig, SkillEntry } from './runtime/shared/types'
+export type { AgentContentSource, AgentPage, AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
 export interface McpServerCardOptions {
   /** MCP endpoint the card describes, e.g. `/mcp`. */
@@ -84,8 +84,11 @@ export interface ModuleOptions {
   /** Answer errors with a markdown body when the client asked for markdown. */
   errors?: boolean
   sitemap?: {
-    /** Serve `/sitemap.md`, a markdown index of every page. */
-    markdown?: boolean
+    /**
+     * Serve `/sitemap.md`, a markdown index of every page. Pass an object to
+     * control how pages are grouped into sections.
+     */
+    markdown?: boolean | Partial<SitemapSections>
   }
   robots?: {
     /**
@@ -172,7 +175,11 @@ export default defineNuxtModule<ModuleOptions>({
       userAgents,
       excludePrefixes: options.excludePrefixes || EXCLUDE_PREFIXES,
       links: [],
-      cachedRoutes: []
+      cachedRoutes: [],
+      sitemapSections: {
+        expand: (typeof options.sitemap?.markdown === 'object' && options.sitemap.markdown.expand) || [],
+        labels: (typeof options.sitemap?.markdown === 'object' && options.sitemap.markdown.labels) || {}
+      }
     }
 
     /* ------------------------------- source ------------------------------- */

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,11 +16,12 @@ import { join } from 'pathe'
 import { withLeadingSlash, withoutTrailingSlash } from 'ufo'
 import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from './defaults'
 import { isValidRel } from './rels'
+import { scanSkills } from './skills'
 import { setupVercelPreset } from './presets/vercel'
 import { formatLinkHeader, matchRoute, rawDestination, MARKDOWN_VARY } from './runtime/shared/negotiation'
-import type { AgentRoute, DiscoveryLink, NegotiationConfig } from './runtime/shared/types'
+import type { AgentRoute, DiscoveryLink, NegotiationConfig, SkillEntry } from './runtime/shared/types'
 
-export type { AgentContentSource, AgentPage, AgentRoute, DiscoveryLink, NegotiationConfig } from './runtime/shared/types'
+export type { AgentContentSource, AgentPage, AgentRoute, DiscoveryLink, NegotiationConfig, SkillEntry } from './runtime/shared/types'
 
 export interface McpServerCardOptions {
   /** MCP endpoint the card describes, e.g. `/mcp`. */
@@ -96,6 +97,15 @@ export interface ModuleOptions {
     /** `Content-Signal` line for the wildcard group. `false` to omit. */
     contentSignal?: string | false
   }
+  /**
+   * Agent Skills served under `/.well-known/skills/`, with a generated
+   * `index.json`. `false` to disable; otherwise the directory is scanned and
+   * the feature turns itself off when it does not exist.
+   */
+  skills?: false | {
+    /** Directory holding one subdirectory per skill, relative to the root. */
+    dir?: string
+  }
 }
 
 declare module '@nuxt/schema' {
@@ -107,6 +117,7 @@ declare module '@nuxt/schema' {
     agentDiscovery: NegotiationConfig
     agentDiscoveryMcp?: McpServerCardOptions
     agentDiscoveryRobots?: { contentSignal: string }
+    agentDiscoverySkills?: { skills: SkillEntry[] }
   }
   interface PublicRuntimeConfig {
     agentDiscovery: { siteUrl: string, siteName: string, rawPrefix: string }
@@ -140,7 +151,8 @@ export default defineNuxtModule<ModuleOptions>({
     },
     errors: true,
     sitemap: { markdown: true },
-    robots: { aiPolicy: true, contentSignal: 'search=yes, ai-train=yes, ai-input=yes' }
+    robots: { aiPolicy: true, contentSignal: 'search=yes, ai-train=yes, ai-input=yes' },
+    skills: { dir: 'skills' }
   },
   async setup(options, nuxt) {
     const logger = useLogger('nuxt-agent-discovery')
@@ -250,6 +262,28 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
+    /* ------------------------------- skills ------------------------------- */
+
+    const skillsDir = join(nuxt.options.rootDir, (options.skills && options.skills.dir) || 'skills')
+    const skills: SkillEntry[] = options.skills === false ? [] : await scanSkills(skillsDir, logger)
+
+    if (skills.length) {
+      logger.info(`Found ${skills.length} agent skill${skills.length > 1 ? 's' : ''}: ${skills.map(skill => skill.name).join(', ')}`)
+      nuxt.options.runtimeConfig.agentDiscoverySkills = { skills }
+
+      nuxt.hook('nitro:config', (nitroConfig) => {
+        nitroConfig.serverAssets ||= []
+        nitroConfig.serverAssets.push({ baseName: 'agentSkills', dir: skillsDir })
+      })
+
+      addServerHandler({ route: '/.well-known/skills/index.json', handler: resolve('./runtime/server/routes/skills-index') })
+      addServerHandler({ route: '/.well-known/skills/**', handler: resolve('./runtime/server/routes/skills-files') })
+      addPrerenderRoutes([
+        '/.well-known/skills/index.json',
+        ...skills.flatMap(skill => skill.files.map(file => `/.well-known/skills/${skill.name}/${file}`))
+      ])
+    }
+
     /* ---------------------------- nuxt-llms bridge ------------------------- */
 
     const hasLlms = hasNuxtModule('nuxt-llms')
@@ -312,6 +346,14 @@ export default defineNuxtModule<ModuleOptions>({
             { href: '/llms-full.txt', rel: 'describedby', type: 'text/plain', title: 'llms-full.txt: the full documentation as a single file' },
             { href: '/llms-full.txt', rel: 'service-desc', type: 'text/plain', anchor: '/', header: false }
           )
+        }
+      }
+      if (skills.length) {
+        links.push({ href: '/.well-known/skills/index.json', rel: 'index', type: 'application/json', title: 'Agent skills index: every skill published by this site' })
+        // The skills themselves stay out of the `Link` header, which
+        // advertises the discovery documents rather than every resource.
+        for (const skill of skills) {
+          links.push({ href: `/.well-known/skills/${skill.name}/SKILL.md`, rel: 'service-doc', type: 'text/markdown', title: `Agent skill: ${skill.name}`, anchor: '/', header: false })
         }
       }
       if (matchRoute(routes, '/')) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -8,6 +8,7 @@ import {
   defineNuxtModule,
   hasNuxtModule,
   resolvePath,
+  tryResolveModule,
   useLogger
 } from '@nuxt/kit'
 import { defu } from 'defu'
@@ -166,9 +167,23 @@ export default defineNuxtModule<ModuleOptions>({
 
     let sourcePath: string | undefined
     let builtinContentSource = false
+    let minimarkStringify: string | undefined
     if (options.source === 'content' || (options.source === 'auto' && hasNuxtModule('@nuxt/content'))) {
       sourcePath = resolve('./runtime/server/sources/content')
       builtinContentSource = true
+      // `minimark` is the tree format `@nuxt/content` stores and serializes
+      // with, not a format this module owns: comark sources render through
+      // `comark/render` and custom sources bring their own. So the stringifier
+      // has to be the one that produced the tree. Resolved from this module's
+      // own dependencies it would pin a version that can disagree with the
+      // content backend's, and a major bump changes the markdown of every page
+      // (attribute serialization, code-fence meta, ...). Resolve it from
+      // `@nuxt/content` instead, so the two can never drift.
+      const contentEntry = await tryResolveModule('@nuxt/content', nuxt.options.modulesDir)
+      minimarkStringify = contentEntry ? await tryResolveModule('minimark/stringify', [contentEntry]) : undefined
+      if (!minimarkStringify) {
+        logger.warn('Could not resolve `minimark/stringify` from `@nuxt/content`; falling back to this module\'s own copy. Raw markdown may differ from what `@nuxt/content` produces.')
+      }
     } else if (options.source === 'comark') {
       throw new Error('[nuxt-agent-discovery] comark sites construct their content instance themselves, so pass a source file instead: `source: \'~~/server/utils/agent-source\'`, exporting `createComarkSource(() => getContent())` from `#agent-discovery/comark`.')
     } else if (typeof options.source === 'string' && options.source !== 'auto') {
@@ -176,6 +191,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
 
     nuxt.options.nitro.alias = defu(nuxt.options.nitro.alias, {
+      ...(minimarkStringify ? { 'minimark/stringify': minimarkStringify } : {}),
       '#agent-discovery/source': sourcePath || resolve('./runtime/server/sources/none'),
       '#agent-discovery/comark': resolve('./runtime/server/sources/comark'),
       '#agent-discovery': resolve('./runtime/server/utils/agent-discovery')
@@ -210,9 +226,6 @@ export default defineNuxtModule<ModuleOptions>({
           : []
         nitroConfig.errorHandler = [resolve('./runtime/server/error'), ...handlers]
       }
-      // The stringifier is a dependency of this module, not of the site, so
-      // it has to be bundled rather than traced.
-      nitroConfig.externals = defu(nitroConfig.externals, { inline: ['minimark'] })
     })
 
     addImports({ name: 'useCanonical', from: resolve('./runtime/app/composables/useCanonical') })

--- a/src/module.ts
+++ b/src/module.ts
@@ -255,9 +255,32 @@ export default defineNuxtModule<ModuleOptions>({
       if (hasNuxtModule('@nuxtjs/robots')) {
         // Feed the shared user-agent list into the robots module instead of
         // competing for the `/robots.txt` route.
-        const robotsOptions = nuxt.options as { robots?: { groups?: unknown[] } }
-        robotsOptions.robots = defu(robotsOptions.robots, {
-          groups: userAgents.map(userAgent => ({ userAgent, allow: '/' }))
+        //
+        // Through its hook, not `nuxt.options.robots`: that module reads its
+        // options during its own setup, so a site listing it first (which
+        // `@nuxtjs/sitemap` asks for) would silently get none of this.
+        const contentSignal = options.robots.contentSignal
+        const onRobotsConfig = nuxt.hook as unknown as (
+          name: 'robots:config',
+          cb: (config: { groups: { userAgent: string[], allow: string[], disallow: string[], comment: string[], contentSignal?: string[] }[] }) => void
+        ) => void
+        onRobotsConfig('robots:config', (robotsConfig) => {
+          // `Content-Signal` belongs on the wildcard group, which this module's
+          // own `robots.txt` route emits too. Without it the directive would be
+          // lost the moment a site adds `@nuxtjs/robots`.
+          if (contentSignal) {
+            for (const group of robotsConfig.groups) {
+              if (group.userAgent.includes('*')) {
+                group.contentSignal = [contentSignal]
+              }
+            }
+          }
+          robotsConfig.groups.push(...userAgents.map(userAgent => ({
+            userAgent: [userAgent],
+            allow: ['/'],
+            disallow: [],
+            comment: []
+          })))
         })
       } else if (existsSync(join(nuxt.options.rootDir, nuxt.options.dir?.public || 'public', 'robots.txt'))) {
         logger.warn('A static `public/robots.txt` exists, so the AI robots policy is not applied to it. Align its agent list with `agentDiscovery.userAgents` or remove the file.')

--- a/src/module.ts
+++ b/src/module.ts
@@ -269,6 +269,18 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
+    /* ------------------------------- sitemap ------------------------------ */
+
+    if (hasNuxtModule('@nuxtjs/sitemap')) {
+      // The raw markdown twins are alternate representations of pages already
+      // in the sitemap, not pages of their own, so they must never be listed
+      // as separate URLs. Every site that pairs a sitemap module with a raw
+      // markdown route needs this, so the module does it rather than leaving
+      // each one to remember.
+      const sitemapOptions = nuxt.options as { sitemap?: { exclude?: string[] } }
+      sitemapOptions.sitemap = defu(sitemapOptions.sitemap, { exclude: [`${rawPrefix}/**`] })
+    }
+
     /* ------------------------------- skills ------------------------------- */
 
     const skillsDir = join(nuxt.options.rootDir, (options.skills && options.skills.dir) || 'skills')

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -18,13 +18,13 @@ interface LlmsOptions {
   sections: LlmsSection[]
 }
 
-function toLocalPathname(href: string, domain: string): string | undefined {
+function toLocalUrl(href: string, domain: string): { pathname: string, suffix: string } | undefined {
   try {
     const url = new URL(href, domain)
     if (url.origin !== new URL(domain).origin) {
       return undefined
     }
-    return normalizePathname(url.pathname)
+    return { pathname: normalizePathname(url.pathname), suffix: url.search + url.hash }
   } catch {
     return undefined
   }
@@ -49,8 +49,8 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // negotiable pages count, so nuxt-llms's own llms-full.txt entry doesn't
     // mask an otherwise empty document.
     const hasPageLinks = options.sections.some(section => section.links?.some((link) => {
-      const pathname = toLocalPathname(link.href, domain)
-      return !!pathname && (pathname === '/' || !hasFileExtension(pathname))
+      const local = toLocalUrl(link.href, domain)
+      return !!local && (local.pathname === '/' || !hasFileExtension(local.pathname))
     }))
     if (source && !hasPageLinks) {
       const entries = source.list
@@ -73,17 +73,25 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         continue
       }
       section.links = section.links.map((link) => {
-        const pathname = toLocalPathname(link.href, domain)
-        if (!pathname || (pathname !== '/' && hasFileExtension(pathname))) {
+        const local = toLocalUrl(link.href, domain)
+        if (!local) {
           return link
         }
-        const route = matchRoute(config.routes, pathname)
+        const { pathname, suffix } = local
+
+        // Off-site links keep whatever they were written as, but a same-origin
+        // one has to come out absolute: `llms.txt` is read detached from the
+        // site, so a relative href in it points nowhere.
+        const route = pathname === '/' || !hasFileExtension(pathname)
+          ? matchRoute(config.routes, pathname)
+          : undefined
         if (!route) {
-          return link
+          return { ...link, href: withBase(pathname + suffix, domain) }
         }
+
         const raw = rawDestination(config, route, pathname)
         prerenderPaths.add(raw)
-        return { ...link, href: withBase(raw, domain) }
+        return { ...link, href: withBase(raw + suffix, domain) }
       })
     }
   }) as never)

--- a/src/runtime/server/routes/mcp-server-card.ts
+++ b/src/runtime/server/routes/mcp-server-card.ts
@@ -1,4 +1,5 @@
 import { defineEventHandler, setResponseHeader } from 'h3'
+import { useNitroApp } from 'nitropack/runtime'
 import { useRuntimeConfig } from '#imports'
 import { getAgentSiteUrl } from '../utils/agent-discovery'
 
@@ -14,17 +15,26 @@ interface McpServerCardConfig {
 }
 
 /**
- * Minimal MCP server card. Sites running `@nuxtjs/mcp-toolkit` usually serve
- * a richer card themselves (live tool listings) and keep this disabled,
- * registering only the discovery link.
+ * MCP server card. The static half comes from `discovery.mcpServerCard`; a
+ * site that knows its live tools, resources and prompts fills the rest in
+ * through the `agent-discovery:mcp-server-card` hook:
+ *
+ * ```ts
+ * nitroApp.hooks.hook('agent-discovery:mcp-server-card', async (event, card) => {
+ *   const { tools } = await listMcpDefinitions({ event })
+ *   card.tools = tools.map(tool => ({ name: tool.name, description: tool.description }))
+ * })
+ * ```
+ *
+ * Detecting an MCP module directly would make this module depend on one, which
+ * is exactly the coupling it exists to avoid.
  */
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
   const card = useRuntimeConfig(event).agentDiscoveryMcp as McpServerCardConfig
   const siteUrl = getAgentSiteUrl(event)
   const absolute = (href: string) => href.startsWith('/') ? `${siteUrl}${href}` : href
 
-  setResponseHeader(event, 'Content-Type', 'application/json; charset=utf-8')
-  return {
+  const serverCard: Record<string, unknown> = {
     $schema: 'https://modelcontextprotocol.io/schema/server-card/v1',
     serverInfo: {
       name: card.name,
@@ -46,4 +56,10 @@ export default defineEventHandler((event) => {
       required: false
     }
   }
+
+  const hooks = useNitroApp().hooks as unknown as { callHook: (name: string, ...args: unknown[]) => Promise<void> }
+  await hooks.callHook('agent-discovery:mcp-server-card', event, serverCard)
+
+  setResponseHeader(event, 'Content-Type', 'application/json; charset=utf-8')
+  return serverCard
 })

--- a/src/runtime/server/routes/sitemap.md.ts
+++ b/src/runtime/server/routes/sitemap.md.ts
@@ -23,10 +23,21 @@ export default defineEventHandler(async (event) => {
         : (await source.routes(event)).map(route => ({ route, title: undefined as string | undefined })))
     : []
 
+  const { expand, labels } = config.sitemapSections
+
+  // Top-level pages share one section; anything deeper is grouped by its first
+  // segment, or by its second when that prefix is expanded.
+  const sectionKey = (route: string): string => {
+    const parts = route.split('/').filter(Boolean)
+    if (parts.length < 2) {
+      return 'pages'
+    }
+    return expand.includes(`/${parts[0]}`) ? parts[1]! : parts[0]!
+  }
+
   const sections = new Map<string, { title: string, href: string }[]>()
   for (const entry of entries) {
-    const parts = entry.route.split('/').filter(Boolean)
-    const key = parts.length > 1 ? parts[0]! : 'pages'
+    const key = sectionKey(entry.route)
     const negotiated = matchRoute(config.routes, entry.route)
     const href = negotiated && entry.route !== '/'
       ? `${siteUrl}${entry.route}.md`
@@ -46,7 +57,7 @@ export default defineEventHandler(async (event) => {
   ]
 
   for (const [key, pages] of sections) {
-    const label = key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
+    const label = labels[key] || key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
     lines.push(`## ${label}`, '')
     for (const page of pages) {
       lines.push(`- [${escapeLabel(page.title)}](${page.href})`)

--- a/src/runtime/server/routes/skills-files.ts
+++ b/src/runtime/server/routes/skills-files.ts
@@ -1,0 +1,55 @@
+import { createError, defineEventHandler, getRequestURL, setResponseHeader } from 'h3'
+import { useStorage } from 'nitropack/runtime'
+import { useRuntimeConfig } from '#imports'
+import type { SkillEntry } from '../../shared/types'
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.md': 'text/markdown; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.yaml': 'text/yaml; charset=utf-8',
+  '.yml': 'text/yaml; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.py': 'text/plain; charset=utf-8',
+  '.sh': 'text/plain; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.ts': 'text/plain; charset=utf-8'
+}
+
+function contentType(path: string): string {
+  return CONTENT_TYPES[path.slice(path.lastIndexOf('.'))] || 'application/octet-stream'
+}
+
+/**
+ * Serves one file of a skill from the bundled server assets. Only paths under
+ * a skill listed in the catalog are reachable, so the route cannot be walked
+ * outside the skills directory.
+ */
+export default defineEventHandler(async (event) => {
+  const prefix = '/.well-known/skills/'
+  const pathname = getRequestURL(event).pathname
+  const index = pathname.indexOf(prefix)
+  if (index === -1) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const path = decodeURIComponent(pathname.slice(index + prefix.length))
+  if (!path || path.includes('..')) {
+    throw createError({ statusCode: 400, statusMessage: 'Bad Request' })
+  }
+
+  const { skills } = useRuntimeConfig(event).agentDiscoverySkills as { skills: SkillEntry[] }
+  const skill = skills.find(entry => entry.name === path.split('/')[0])
+  if (!skill || !skill.files.includes(path.slice(skill.name.length + 1))) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  const content = await useStorage('assets:agentSkills').getItemRaw<string>(path)
+  if (!content) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+
+  setResponseHeader(event, 'Content-Type', contentType(path))
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600')
+
+  return content
+})

--- a/src/runtime/server/routes/skills-index.ts
+++ b/src/runtime/server/routes/skills-index.ts
@@ -1,0 +1,16 @@
+import { defineEventHandler, setResponseHeader } from 'h3'
+import { useRuntimeConfig } from '#imports'
+import type { SkillEntry } from '../../shared/types'
+
+/**
+ * The Agent Skills catalog, generated from the skills directory at build time
+ * so it can never fall out of step with the files actually served.
+ */
+export default defineEventHandler((event) => {
+  const { skills } = useRuntimeConfig(event).agentDiscoverySkills as { skills: SkillEntry[] }
+
+  setResponseHeader(event, 'Content-Type', 'application/json; charset=utf-8')
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=3600')
+
+  return { skills }
+})

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -78,6 +78,17 @@ const source: AgentContentSource = {
     await hooks.callHook('agent-discovery:document', requireEvent(event), page)
 
     const value = page.body.value as unknown as MinimarkNode[]
+
+    // Syntax highlighters append a `<style>` node carrying the per-document
+    // CSS variables. It is meaningless in a markdown representation, and the
+    // stringifier only drops it while it is the last node, so anything
+    // appended below (the related links) would otherwise expose it.
+    for (let i = value.length - 1; i >= 0; i--) {
+      if (value[i]?.[0] === 'style') {
+        value.splice(i, 1)
+      }
+    }
+
     if (value[0]?.[0] !== 'h1') {
       if (page.description) {
         value.unshift(['blockquote', {}, page.description])

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -2,6 +2,7 @@ import type { H3Event } from 'h3'
 import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import type { AgentContentSource, NegotiationConfig } from '../../shared/types'
+import { hasFileExtension, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 export function useAgentDiscoveryConfig(event?: H3Event): NegotiationConfig {
   return useRuntimeConfig(event).agentDiscovery as NegotiationConfig
@@ -11,6 +12,59 @@ export function useAgentDiscoveryConfig(event?: H3Event): NegotiationConfig {
 export function getAgentSiteUrl(event: H3Event): string {
   const config = useAgentDiscoveryConfig(event)
   return config.siteUrl || getRequestURL(event).origin
+}
+
+/**
+ * Absolute URL of a page's raw markdown twin, from the same route config the
+ * negotiation and the CDN rewrites use. Pages that don't negotiate (and
+ * anything already pointing at a file) come back untouched, absolute.
+ *
+ * Sites hand-rolling this drift the moment `routes` changes: a hardcoded
+ * `/docs/` prefix keeps rewriting after the config has moved on.
+ */
+export function rawUrl(event: H3Event, path: string): string {
+  const config = useAgentDiscoveryConfig(event)
+  const siteUrl = getAgentSiteUrl(event)
+
+  let pathname = path
+  let suffix = ''
+  if (/^https?:\/\//.test(path)) {
+    const url = new URL(path)
+    if (url.origin !== new URL(siteUrl).origin) {
+      return path
+    }
+    pathname = url.pathname
+    suffix = url.search + url.hash
+  } else {
+    const separator = path.search(/[?#]/)
+    if (separator !== -1) {
+      pathname = path.slice(0, separator)
+      suffix = path.slice(separator)
+    }
+  }
+
+  pathname = normalizePathname(pathname)
+  const route = pathname === '/' || !hasFileExtension(pathname) ? matchRoute(config.routes, pathname) : undefined
+
+  return `${siteUrl}${route ? rawDestination(config, route, pathname) : pathname}${suffix}`
+}
+
+/**
+ * The discovery registry as a markdown block, for sites that hand-write an
+ * agent-facing homepage. Same list the `Link` header and the api-catalog are
+ * built from, so a resource can never be advertised in one place and missed
+ * in another.
+ */
+export function renderAgentResources(event: H3Event, options: { heading?: string } = {}): string {
+  const config = useAgentDiscoveryConfig(event)
+  const siteUrl = getAgentSiteUrl(event)
+  const heading = options.heading ?? 'Resources for Agents'
+
+  const lines = config.links
+    .filter(link => link.title)
+    .map(link => `- [${link.title}](${link.href.startsWith('/') ? `${siteUrl}${link.href}` : link.href})`)
+
+  return lines.length ? [`## ${heading}`, '', ...lines, ''].join('\n') : ''
 }
 
 /** Identity helper for typed custom content sources. */

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -43,6 +43,14 @@ export interface DiscoveryLink {
   header?: boolean
 }
 
+/** One Agent Skill published by the site, as listed in the skills index. */
+export interface SkillEntry {
+  name: string
+  description: string
+  /** Files the skill is made of, relative to its directory. `SKILL.md` first. */
+  files: string[]
+}
+
 /** What a content adapter returns for one route. */
 export interface AgentPage {
   markdown: string

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -43,6 +43,18 @@ export interface DiscoveryLink {
   header?: boolean
 }
 
+/** How `sitemap.md` groups pages into sections. */
+export interface SitemapSections {
+  /**
+   * Path prefixes whose children each get their own section, instead of the
+   * whole prefix being one. `['/docs']` turns a single "Docs" section into
+   * "Components", "Composables", ... while `/blog/**` stays one "Blog".
+   */
+  expand: string[]
+  /** Label overrides, keyed by the path segment the section groups. */
+  labels: Record<string, string>
+}
+
 /** One Agent Skill published by the site, as listed in the skills index. */
 export interface SkillEntry {
   name: string
@@ -87,6 +99,8 @@ export interface NegotiationConfig {
   /** Path prefixes that never negotiate and keep their JSON/HTML errors. */
   excludePrefixes: string[]
   links: DiscoveryLink[]
+  /** How `sitemap.md` groups pages into sections. */
+  sitemapSections: SitemapSections
   /**
    * Route-rule patterns with a response cache (`isr`, `swr`, `cache`) that
    * cannot vary on `Accept`/`User-Agent`. The Nitro middleware skips

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,0 +1,105 @@
+import { existsSync } from 'node:fs'
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'pathe'
+import { parse as parseYaml } from 'yaml'
+import type { ConsolaInstance } from 'consola'
+import type { SkillEntry } from './runtime/shared/types'
+
+/**
+ * Agent Skills discovery.
+ *
+ * A skill is a directory holding a `SKILL.md` with `name` and `description`
+ * frontmatter, plus any number of reference files. The catalog is scanned at
+ * build time so `/.well-known/skills/index.json` is generated rather than
+ * hand-maintained, which is where the three sites that ship skills today all
+ * drift: a reference file gets added and the index keeps listing the old set.
+ *
+ * Naming follows the Agent Skills spec: lowercase alphanumeric and single
+ * hyphens, 64 characters at most, matching the directory name.
+ */
+
+const SKILL_NAME_REGEX = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/
+const MAX_NAME_LENGTH = 64
+
+function parseFrontmatter(content: string): { name?: string, description?: string } | null {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
+  if (!match?.[1]) {
+    return null
+  }
+  try {
+    return parseYaml(match[1])
+  } catch {
+    return null
+  }
+}
+
+function isValidSkillName(name: string, dirName: string, logger: ConsolaInstance): boolean {
+  if (name.length > MAX_NAME_LENGTH) {
+    logger.warn(`Skill "${name}" exceeds the ${MAX_NAME_LENGTH} character limit.`)
+    return false
+  }
+  if (!SKILL_NAME_REGEX.test(name) || name.includes('--')) {
+    logger.warn(`Skill name "${name}" does not match the Agent Skills naming spec.`)
+    return false
+  }
+  if (name !== dirName) {
+    logger.warn(`Skill name "${name}" does not match its directory name "${dirName}".`)
+    return false
+  }
+  return true
+}
+
+async function listFiles(dir: string, base = ''): Promise<string[]> {
+  const files: string[] = []
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = base ? `${base}/${entry.name}` : entry.name
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(join(dir, entry.name), path))
+    } else {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+/** Every skill in `dir`, with its files listed from disk. `SKILL.md` first. */
+export async function scanSkills(dir: string, logger: ConsolaInstance): Promise<SkillEntry[]> {
+  if (!existsSync(dir)) {
+    return []
+  }
+
+  const catalog: SkillEntry[] = []
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const skillDir = join(dir, entry.name)
+    const skillMd = join(skillDir, 'SKILL.md')
+    if (!existsSync(skillMd)) {
+      continue
+    }
+
+    const frontmatter = parseFrontmatter(await readFile(skillMd, 'utf8'))
+    if (!frontmatter?.description) {
+      logger.warn(`Skipping skill "${entry.name}": no \`description\` in the \`SKILL.md\` frontmatter.`)
+      continue
+    }
+
+    const name = frontmatter.name || entry.name
+    if (!isValidSkillName(name, entry.name, logger)) {
+      continue
+    }
+
+    // Dotfiles are editor and tooling noise, never part of a published skill.
+    const files = (await listFiles(skillDir)).filter(file => !file.split('/').some(segment => segment.startsWith('.')))
+
+    catalog.push({
+      name,
+      description: frontmatter.description,
+      files: ['SKILL.md', ...files.filter(file => file !== 'SKILL.md').sort()]
+    })
+  }
+
+  return catalog.sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -202,6 +202,58 @@ describe('discovery documents', () => {
   })
 })
 
+describe('agent skills', () => {
+  it('generates the skills index from the directory on disk', async () => {
+    const response = await fetch('/.well-known/skills/index.json')
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('application/json')
+
+    const body = (await response.json()) as { skills: { name: string, description: string, files: string[] }[] }
+    expect(body.skills).toHaveLength(1)
+    expect(body.skills[0]).toEqual({
+      name: 'basic-site',
+      description: 'Fixture agent skill used to test the skills catalog and file serving.',
+      // Generated from disk, `SKILL.md` first, so it cannot drift from what is served.
+      files: ['SKILL.md', 'references/conventions.md']
+    })
+  })
+
+  it('serves each file of a skill with a useful content type', async () => {
+    const skill = await fetch('/.well-known/skills/basic-site/SKILL.md')
+    expect(skill.status).toBe(200)
+    expect(skill.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+    expect(await skill.text()).toContain('# Basic site')
+
+    const reference = await fetch('/.well-known/skills/basic-site/references/conventions.md')
+    expect(reference.status).toBe(200)
+    expect(await reference.text()).toContain('# Conventions')
+  })
+
+  it('ignores a directory without a `SKILL.md` and refuses to escape the skill', async () => {
+    expect((await fetch('/.well-known/skills/not-a-skill/README.md')).status).toBe(404)
+    expect((await fetch('/.well-known/skills/basic-site/../../../nuxt.config.ts')).status).not.toBe(200)
+  })
+
+  it('advertises the skills index in the discovery registry', async () => {
+    const link = (await fetch('/')).headers.get('link') || ''
+    expect(link).toContain('</.well-known/skills/index.json>; rel="index"; type="application/json"')
+
+    // The skill itself reaches the api-catalog, not the `Link` header.
+    expect(link).not.toContain('/.well-known/skills/basic-site/SKILL.md')
+    const linkset = (await (await fetch('/.well-known/api-catalog')).json()) as { linkset: { 'anchor': string, 'service-doc'?: { href: string }[] }[] }
+    const root = linkset.linkset.find(entry => entry.anchor === `${SITE_URL}/`)
+    expect(root!['service-doc']).toContainEqual({ href: `${SITE_URL}/.well-known/skills/basic-site/SKILL.md`, type: 'text/markdown' })
+  })
+
+  it('keeps skills out of markdown negotiation', async () => {
+    const response = await fetch('/.well-known/skills/basic-site/SKILL.md', { headers: { 'User-Agent': CLAUDE_BOT } })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('text/markdown; charset=utf-8')
+  })
+})
+
 describe('nuxt-llms bridge', () => {
   it('rewrites the `llms.txt` links to their raw markdown twins', async () => {
     const response = await fetch('/llms.txt')

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -202,6 +202,20 @@ describe('discovery documents', () => {
   })
 })
 
+describe('sitemap.md sections', () => {
+  it('expands the configured prefix into a section per area, with label overrides', async () => {
+    const body = await (await fetch('/sitemap.md')).text()
+
+    // `expand: ['/docs']` splits `/docs/**` by its second segment...
+    expect(body).toContain('## UI Components')
+    // ...and `labels` renames one of them, the rest deriving from the segment.
+    expect(body).not.toContain('## Docs')
+    // Top-level pages share one section.
+    expect(body).toContain('## Pages')
+    expect(body).toContain(`[Basic](${SITE_URL})`)
+  })
+})
+
 describe('agent skills', () => {
   it('generates the skills index from the directory on disk', async () => {
     const response = await fetch('/.well-known/skills/index.json')

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -129,6 +129,25 @@ describe('errors', () => {
   })
 })
 
+describe('@nuxt/content source', () => {
+  it('appends the page related links, like `@nuxt/content`\'s own raw route', async () => {
+    const body = await (await fetch('/raw/docs/components/badge.md')).text()
+
+    expect(body).toContain('\n---\n\n- [Reka UI](https://reka-ui.com/docs/components/badge)\n- [GitHub](https://github.com/nuxt/ui)')
+  })
+
+  it('strips the highlighter `<style>` node instead of exposing its CSS', async () => {
+    const body = await (await fetch('/raw/docs/components/badge.md')).text()
+
+    // The stringifier only drops a `<style>` node while it is last in the
+    // tree, so appending the related links above would otherwise dump the
+    // per-document shiki CSS variables into the markdown agents read.
+    expect(body).not.toMatch(/^<style>$/m)
+    expect(body).not.toContain('--shiki-')
+    expect(body).toContain('```ts\nconst label = \'Badge\'\n```')
+  })
+})
+
 describe('discovery documents', () => {
   it('emits the discovery `Link` header and `Vary` on the homepage', async () => {
     const response = await fetch('/')

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -216,6 +216,47 @@ describe('sitemap.md sections', () => {
   })
 })
 
+describe('mcp server card', () => {
+  it('serves the configured card, enriched through the hook', async () => {
+    const response = await fetch('/.well-known/mcp/server-card.json')
+
+    expect(response.status).toBe(200)
+
+    const card = (await response.json()) as { serverInfo: Record<string, string>, endpoints: unknown[], tools: unknown[] }
+    expect(card.serverInfo.name).toBe('Basic')
+    expect(card.serverInfo.documentation).toBe(`${SITE_URL}/docs/getting-started`)
+    expect(card.endpoints).toEqual([{ type: 'streamable-http', url: `${SITE_URL}/mcp` }])
+    // Contributed by the site, which is the only thing that knows its tools.
+    expect(card.tools).toEqual([{ name: 'search', description: 'Search the fixture.' }])
+  })
+})
+
+describe('rawUrl', () => {
+  it('maps a page to its raw twin and leaves everything else alone', async () => {
+    const body = await (await fetch('/raw-urls.json')).json() as Record<string, string>
+
+    expect(body.page).toBe(`${SITE_URL}/raw/docs/getting-started.md`)
+    expect(body.home).toBe(`${SITE_URL}/raw/index.md`)
+    expect(body.query).toBe(`${SITE_URL}/raw/docs/getting-started.md?x=1#y`)
+    // Not a page: no route matches, so it only becomes absolute.
+    expect(body.asset).toBe(`${SITE_URL}/openapi.json`)
+    // Off-site links are never rewritten.
+    expect(body.external).toBe('https://example.com/docs/x')
+  })
+})
+
+describe('agent resources block', () => {
+  it('renders the discovery registry as markdown', async () => {
+    const body = await (await fetch('/agent-resources.md')).text()
+
+    expect(body).toContain('## Resources for Agents')
+    expect(body).toContain(`- [llms.txt: index of the documentation for LLMs](${SITE_URL}/llms.txt)`)
+    expect(body).toContain(`- [Agent skills index: every skill published by this site](${SITE_URL}/.well-known/skills/index.json)`)
+    // Only titled resources are listed, so untitled registry entries stay internal.
+    expect(body).not.toContain('](/')
+  })
+})
+
 describe('agent skills', () => {
   it('generates the skills index from the directory on disk', async () => {
     const response = await fetch('/.well-known/skills/index.json')

--- a/test/e2e/custom-source.test.ts
+++ b/test/e2e/custom-source.test.ts
@@ -123,3 +123,17 @@ describe('discovery documents', () => {
     expect(body).toContain(`${SITE_URL}/raw/index.md`)
   })
 })
+
+describe('@nuxtjs/robots handoff', () => {
+  it('contributes the shared agent list and the Content-Signal to its robots.txt', async () => {
+    const body = await (await fetch('/robots.txt')).text()
+
+    // This module must not register a competing `/robots.txt`.
+    expect(body).toContain('nuxt-robots')
+    for (const userAgent of ['ClaudeBot', 'GPTBot', 'PerplexityBot', 'Bytespider']) {
+      expect(body).toContain(`User-agent: ${userAgent}`)
+    }
+    // Rides on the wildcard group, so adding `@nuxtjs/robots` cannot lose it.
+    expect(body).toContain('Content-Signal: search=yes, ai-train=yes, ai-input=yes')
+  })
+})

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -91,7 +91,8 @@ describe('O(1) route table', () => {
     userAgents: AGENT_USER_AGENTS,
     excludePrefixes: EXCLUDE_PREFIXES,
     links: [{ href: '/llms.txt', rel: 'describedby', type: 'text/plain', title: 'llms.txt' }],
-    cachedRoutes: []
+    cachedRoutes: [],
+    sitemapSections: { expand: [], labels: {} }
   }
 
   it('emits the closed-form number of routes for the fixture patterns', () => {

--- a/test/fixtures/basic/content/docs/components/badge.md
+++ b/test/fixtures/basic/content/docs/components/badge.md
@@ -1,0 +1,21 @@
+---
+title: Badge
+description: A page exercising the @nuxt/content adapter specifics.
+links:
+  - label: Reka UI
+    to: https://reka-ui.com/docs/components/badge
+  - label: GitHub
+    to: https://github.com/nuxt/ui
+---
+
+# Badge
+
+> A page exercising the @nuxt/content adapter specifics.
+
+## Usage
+
+A highlighted code block makes the highlighter append a per-document style element.
+
+```ts
+const label = 'Badge'
+```

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -2,6 +2,25 @@ export default defineNuxtConfig({
   modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms'],
   devtools: { enabled: false },
   compatibilityDate: '2026-01-01',
+  // Multi-theme highlighting makes the highlighter append a `<style>` node
+  // carrying the per-document CSS variables, which the raw markdown must not
+  // expose (see the `style` stripping in the `@nuxt/content` source).
+  content: {
+    build: {
+      markdown: {
+        highlight: {
+          langs: ['ts'],
+          theme: {
+            default: 'material-theme',
+            light: 'material-theme-lighter',
+            dark: 'material-theme-palenight'
+          }
+        }
+      }
+    }
+  },
+  compatibilityDate: '2026-01-01',
+
   agentDiscovery: {
     siteName: 'Basic'
   },

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -22,7 +22,14 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-01-01',
 
   agentDiscovery: {
-    siteName: 'Basic'
+    siteName: 'Basic',
+    sitemap: {
+      markdown: {
+        // `/docs/**` splits into a section per area; anything else stays whole.
+        expand: ['/docs'],
+        labels: { components: 'UI Components' }
+      }
+    }
   },
   llms: {
     domain: 'https://basic.example.com',

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,7 +1,6 @@
 export default defineNuxtConfig({
   modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms'],
   devtools: { enabled: false },
-  compatibilityDate: '2026-01-01',
   // Multi-theme highlighting makes the highlighter append a `<style>` node
   // carrying the per-document CSS variables, which the raw markdown must not
   // expose (see the `style` stripping in the `@nuxt/content` source).
@@ -23,11 +22,21 @@ export default defineNuxtConfig({
 
   agentDiscovery: {
     siteName: 'Basic',
+    // `/agent-resources.md` is served by its own handler, so it has to be
+    // excluded or the catch-all route pattern would rewrite it to its raw twin.
+    excludePrefixes: ['/_', '/api/', '/mcp', '/.well-known/', '/agent-resources.md'],
     sitemap: {
       markdown: {
         // `/docs/**` splits into a section per area; anything else stays whole.
         expand: ['/docs'],
         labels: { components: 'UI Components' }
+      }
+    },
+    discovery: {
+      mcpServerCard: {
+        endpoint: '/mcp',
+        name: 'Basic',
+        documentation: '/docs/getting-started'
       }
     }
   },

--- a/test/fixtures/basic/server/plugins/mcp-card.ts
+++ b/test/fixtures/basic/server/plugins/mcp-card.ts
@@ -1,0 +1,5 @@
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('agent-discovery:mcp-server-card', (_event, card) => {
+    card.tools = [{ name: 'search', description: 'Search the fixture.' }]
+  })
+})

--- a/test/fixtures/basic/server/routes/agent-resources.md.get.ts
+++ b/test/fixtures/basic/server/routes/agent-resources.md.get.ts
@@ -1,0 +1,6 @@
+import { renderAgentResources } from '#agent-discovery'
+
+export default defineEventHandler((event) => {
+  setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+  return renderAgentResources(event)
+})

--- a/test/fixtures/basic/server/routes/raw-urls.json.get.ts
+++ b/test/fixtures/basic/server/routes/raw-urls.json.get.ts
@@ -1,0 +1,9 @@
+import { rawUrl } from '#agent-discovery'
+
+export default defineEventHandler(event => ({
+  page: rawUrl(event, '/docs/getting-started'),
+  home: rawUrl(event, '/'),
+  query: rawUrl(event, '/docs/getting-started?x=1#y'),
+  asset: rawUrl(event, '/openapi.json'),
+  external: rawUrl(event, 'https://example.com/docs/x')
+}))

--- a/test/fixtures/basic/skills/basic-site/SKILL.md
+++ b/test/fixtures/basic/skills/basic-site/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: basic-site
+description: Fixture agent skill used to test the skills catalog and file serving.
+---
+
+# Basic site
+
+Guidance an agent would load before working with this fixture.

--- a/test/fixtures/basic/skills/basic-site/references/conventions.md
+++ b/test/fixtures/basic/skills/basic-site/references/conventions.md
@@ -1,0 +1,3 @@
+# Conventions
+
+A reference file, listed in the generated index.

--- a/test/fixtures/basic/skills/not-a-skill/README.md
+++ b/test/fixtures/basic/skills/not-a-skill/README.md
@@ -1,0 +1,1 @@
+ignored

--- a/test/fixtures/custom-source/nuxt.config.ts
+++ b/test/fixtures/custom-source/nuxt.config.ts
@@ -1,5 +1,7 @@
 export default defineNuxtConfig({
-  modules: ['../../../src/module', 'nuxt-llms'],
+  // `@nuxtjs/robots` first, so this fixture proves the integration works
+  // even when the robots module reads its own options before ours runs.
+  modules: ['@nuxtjs/robots', '../../../src/module', 'nuxt-llms'],
   devtools: { enabled: false },
   compatibilityDate: '2026-01-01',
   agentDiscovery: {

--- a/test/unit/minimark.test.ts
+++ b/test/unit/minimark.test.ts
@@ -1,0 +1,34 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { loadNuxt, tryResolveModule } from '@nuxt/kit'
+
+const basic = fileURLToPath(new URL('../fixtures/basic', import.meta.url))
+
+/**
+ * `minimark` is the tree format `@nuxt/content` stores and serializes with,
+ * not one this module owns: comark sources render through `comark/render` and
+ * custom sources bring their own. Stringifying with a copy resolved from this
+ * module's dependencies pins a version that can disagree with the content
+ * backend's, and a major bump changes the markdown of every page (attribute
+ * serialization, code-fence meta, ...). So the module aliases the stringifier
+ * to the one `@nuxt/content` itself resolves.
+ */
+describe('minimark resolution', () => {
+  it('aliases `minimark/stringify` to the copy `@nuxt/content` uses', async () => {
+    const nuxt = await loadNuxt({ cwd: basic, ready: true, overrides: { _prepare: true } })
+    try {
+      const alias = nuxt.options.nitro.alias?.['minimark/stringify']
+      expect(alias).toBeTruthy()
+
+      const contentEntry = await tryResolveModule('@nuxt/content', nuxt.options.modulesDir)
+      const fromContent = await tryResolveModule('minimark/stringify', [contentEntry!])
+      expect(alias).toBe(fromContent)
+
+      // ...and specifically not this module's own copy.
+      const ours = await tryResolveModule('minimark/stringify', [import.meta.url])
+      expect(alias).not.toBe(ours)
+    } finally {
+      await nuxt.close()
+    }
+  })
+})

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -29,6 +29,7 @@ function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationCo
     excludePrefixes: ['/_', '/api/', '/mcp', '/.well-known/'],
     links: [],
     cachedRoutes: [],
+    sitemapSections: { expand: [], labels: {} },
     ...overrides
   }
 }

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -17,6 +17,7 @@ function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationCo
     excludePrefixes: ['/_', '/api/', '/mcp', '/.well-known/'],
     links: [],
     cachedRoutes: [],
+    sitemapSections: { expand: [], labels: {} },
     ...overrides
   }
 }


### PR DESCRIPTION
Builds the module and publishes a preview release on every push and PR, so branches can be installed before a real release.

`pnpm prepack` is needed because pkg-pr-new packs `dist` as-is without running lifecycle scripts.