### PR TITLE
fix: pre-publish correctness pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ export default defineNuxtConfig({
 })
 ```
 
-It produces the same document the `@nuxt/content` adapter does, byte for byte, which is what makes swapping backend a one-file change. Same rendering format, the `# title` / `> description` lead added only when the body doesn't already open on an `h1`, the related links from `links` frontmatter appended the same way, site-relative links absolutized on the tree, and a highlighter's `<style>` node dropped rather than rendered (comark declares `removeLastStyle` and doesn't implement it). `test/e2e/shared.ts` holds all three adapters to the same expected bytes.
+It produces the same document the `@nuxt/content` adapter does for prose, which is what makes swapping backend close to a one-file change. Same rendering format, the `# title` / `> description` lead added only when the body doesn't already open on an `h1`, the related links from `links` frontmatter appended the same way, site-relative links absolutized on the tree, and a highlighter's `<style>` node dropped rather than rendered (comark declares `removeLastStyle` and doesn't implement it). `test/e2e/shared.ts` holds all three adapters to the same expected bytes.
+
+**Components are the exception.** comark and minimark serialize a component block with different blank lines around its children, so `::callout` renders as `<callout type="warning">\nCareful.\n</callout>` through comark and `<callout type="warning">\n\nCareful.\n\n\n\n</callout>` through `@nuxt/content`. The content is the same and both parse the same; only the whitespace differs, and it compounds when components nest. Diff a page carrying components before pointing a comark site at this, rather than taking the prose equivalence as covering it. `test/unit/comark.test.ts` pins the current difference so a change in either stringifier shows up here rather than during a migration.
 
 `agent-discovery:document` fires here too. The `page` it receives is comark's own `ContentFile`, so a transformer mutates `page.nodes` rather than `page.body.value`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Markdown content negotiation, CDN-level rewrites, and discovery documents for AI
 
 ## Features
 
-- `Accept` / User-Agent content negotiation with real q-value parsing (RFC 9110 precedence), so `text/plain` and `q=0` are handled correctly and `text/html` outranks markdown when a client prefers it
+- `Accept` / User-Agent content negotiation with real q-value parsing (RFC 9110 precedence), so `q=0` is a refusal and `text/html` outranks markdown when a client prefers it
 - Vercel Build Output routes so pages negotiate at the edge, before the CDN cache ever sees the request, with a route table that stays O(patterns), never O(pages): a rewrite where the page is prerendered, a 307 where a response cache would key on the path alone
 - A universal Nitro middleware giving the same behavior in dev and on every other host
 - Correct `Vary` and `Link` headers, including on responses served straight from the CDN rewrite table
@@ -24,7 +24,7 @@ Markdown content negotiation, CDN-level rewrites, and discovery documents for AI
 - `robots.txt` AI policy generated from the same user-agent list negotiation matches, so the two can't drift apart
 - A `useCanonical()` composable for canonical and markdown-alternate `<link>` tags, and a `rawUrl()` helper resolving a page URL to its markdown twin from the same route config
 - An `agent-discovery:extend` hook so other modules can add discovery links and user agents
-- Link relations validated against the IANA registry, so an invented `rel="llms"` fails the build
+- Link relations validated against the IANA registry, plus `sitemap`, which every crawler understands and nothing has registered, so an invented `rel="llms"` fails the build
 
 ## Quick Setup
 
@@ -48,7 +48,7 @@ What you get out of the box:
 
 - `/raw/**.md`, the raw markdown route, served from whichever content source is detected
 - `Accept: text/markdown` or an explicit `<path>.md` URL returns markdown for any negotiated route; a known agent User-Agent (ClaudeBot, GPTBot, PerplexityBot, ...) gets markdown without an `Accept` header
-- `Vary: Accept, User-Agent` on negotiated routes, their `.md` twins and `/raw/**`
+- `Vary: Accept, User-Agent` on the negotiated pages, and only those: a `.md` twin and everything under `/raw/**` answer markdown to every client, so nothing about them depends on the request
 - a `Link` header on `/` advertising the discovery resources
 - `/.well-known/api-catalog`
 - `/sitemap.md`
@@ -65,7 +65,7 @@ In this order:
 
 Exclusions never negotiate: `/_`, `/api/`, `/mcp`, `/.well-known/`, the raw prefix itself, and any path whose last segment is dotted (assets, `_payload.json`, images).
 
-Errors follow the same idea but browsers are protected: a `fetch()` call of any mode keeps the HTML or JSON error it was written against (`Sec-Fetch-Mode` other than `navigate`), and an explicit `Accept: text/html` or `application/json` is honored. Everything else, curl, an empty `Accept`, a navigation, gets the markdown error body.
+Errors follow the same idea but browsers are protected: a `fetch()` call of any mode keeps the HTML or JSON error it was written against (`Sec-Fetch-Mode` other than `navigate`), and an explicit `Accept: text/html` or `application/json` is honored unless the client is a known agent, which outranks it. Everything else, curl, an empty `Accept`, a navigation, gets the markdown error body.
 
 ## Configuration
 
@@ -73,7 +73,7 @@ Errors follow the same idea but browsers are protected: a `fetch()` call of any 
 export default defineNuxtConfig({
   agentDiscovery: {
     siteUrl: '',                 // '' resolves per-request / from `site.url` / `llms.domain`
-    siteName: '',
+    siteName: '',                // falls back to `site.name`
     rawPrefix: '/raw',
     source: 'auto',                    // 'auto' | 'content' | false | path to an AgentContentSource
     routes: ['/', '/**'],
@@ -82,7 +82,7 @@ export default defineNuxtConfig({
     discovery: {
       link: true,
       apiCatalog: true,
-      sitemapXml: true,
+      sitemapXml: true,               // only when `@nuxtjs/sitemap` is installed
       mcpServerCard: false,
       links: []
     },
@@ -95,7 +95,7 @@ export default defineNuxtConfig({
 ```
 
 - **`siteUrl`** Canonical site URL, resolved in this order when left empty: the `site.url` module option, then `llms.domain`, then, per request, the incoming host. Prerendered documents bake the URL in, so it's settled once at build time when it can be; request-time responses still fall back to the request origin.
-- **`siteName`** Used in `sitemap.md` and markdown error bodies.
+- **`siteName`** Used in `sitemap.md` and the generated `/raw/index.md`. Falls back to the `site.name` module option, the same way `siteUrl` falls back to `site.url`.
 - **`rawPrefix`** Where raw markdown representations live. Defaults to `/raw`.
 - **`source`** `'auto'` detects `@nuxt/content`. `'content'` forces it. `false` disables every content-backed feature (the raw route, `sitemap.md`, the `nuxt-llms` bridge) and leaves negotiation and discovery running against whatever already serves the raw markdown. Anything else is a path to a file exporting an `AgentContentSource` as its default export, which is how a comark site or a custom backend plugs in (see [Content sources](#content-sources)). `source: 'comark'` throws, pointing you at the factory instead, since comark sites construct their own content instance.
 - **`routes`** Page patterns markdown is negotiated for, as strings or `{ path, raw }` objects. `*` matches one path segment, `**` matches one or more, so a locale prefix or an entire nested tree is one pattern and the generated CDN route table stays O(patterns), never O(pages). `raw` overrides the raw destination and is only honored on exact (non-wildcard) patterns, e.g. `{ path: '/', raw: '/raw/index.md' }`; wildcard patterns always resolve to `rawPrefix + path + '.md'`.
@@ -103,12 +103,12 @@ export default defineNuxtConfig({
 - **`userAgents.extend`** Extra user agents appended to the defaults (18 agents, from `ai.robots.txt`: ClaudeBot, GPTBot, PerplexityBot, and others, see `src/defaults.ts`). **`userAgents.replace`** replaces the list entirely.
 - **`discovery.link`** Emit the discovery `Link` header on `/`.
 - **`discovery.apiCatalog`** Serve `/.well-known/api-catalog` (RFC 9727).
-- **`discovery.sitemapXml`** Add a `Link` entry pointing at `/sitemap.xml`. It also puts the `Sitemap:` line in the generated `robots.txt`. This module doesn't generate that file, bring your own sitemap module.
+- **`discovery.sitemapXml`** Advertise `/sitemap.xml` in the discovery links, which also puts the `Sitemap:` line in the generated `robots.txt`. On by default but only when `@nuxtjs/sitemap` is installed, since this module doesn't generate that file and pointing agents at a 404 is worse than saying nothing. A site serving its own registers it through `discovery.links`.
 - **`discovery.mcpServerCard`** Given an `McpServerCardOptions` object (`endpoint`, `name`, and optionally `title`, `description`, `documentation`, `repository`, `license`, `version`), serves `/.well-known/mcp/server-card.json`. `false` to disable.
 - **`discovery.links`** Site-specific discovery links: OpenAPI documents, service docs, anything else worth advertising. Rels are validated against the IANA registry, an invented one fails the build. Other modules can push into the same list through the `agent-discovery:extend` hook.
 - **`errors`** Chains a markdown error handler ahead of any existing Nitro `errorHandler`, answering with a markdown body carrying recovery links when the request prefers it.
-- **`sitemap.markdown`** Serve `/sitemap.md`, a markdown index of every page, from the content adapter. Pass an object to control the grouping: `expand` lists path prefixes whose children each get their own section (`['/docs']` turns one "Docs" section into "Components", "Composables", ... while `/blog/**` stays a single "Blog"), and `labels` overrides the heading derived from a segment. Top-level pages share one "Pages" section.
-- **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with `name` and `description` frontmatter becomes a skill; its files are listed from disk into a generated `/.well-known/skills/index.json`, so the index can never fall behind the files actually served. Names are validated against the Agent Skills spec. `false` to disable; the feature turns itself off when the directory does not exist. Skills are pushed into the discovery registry, so they reach the api-catalog and the error-body recovery links.
+- **`sitemap.markdown`** Serve `/sitemap.md`, a markdown index of every page, from the content adapter. Anything under `excludePrefixes` is left out, which is how a site keeps a legacy docs version out of the index and out of negotiation with one setting, and `agent-discovery:sitemap` is where a site adds the pages an adapter cannot know about. Pass an object to control the grouping: `expand` lists path prefixes whose children each get their own section (`['/docs']` turns one "Docs" section into "Components", "Composables", ... while `/blog/**` stays a single "Blog"), and `labels` overrides the heading derived from a segment. Top-level pages share one "Pages" section.
+- **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with a `description` in its frontmatter becomes a skill, taking its name from the directory unless the frontmatter sets one; its files are listed from disk into a generated `/.well-known/skills/index.json`, so the index can never fall behind the files actually served. Names are validated against the Agent Skills spec. `false` to disable; the feature turns itself off when the directory does not exist. Skills are pushed into the discovery registry, so they reach the api-catalog and the error-body recovery links.
 - **`robots.aiPolicy`** Feeds the shared user-agent list into `@nuxtjs/robots` when it's installed. Otherwise generates `/robots.txt`, skipped (with a warning) if a static `public/robots.txt` already exists.
 - **`robots.contentSignal`** The `Content-Signal` line added to the wildcard group. `false` to omit it.
 
@@ -120,12 +120,12 @@ export default defineNuxtConfig({
 | `/sitemap.md` | a content source resolves and `sitemap.markdown` is on |
 | `/.well-known/api-catalog` | `discovery.apiCatalog` |
 | `/.well-known/mcp/server-card.json` | `discovery.mcpServerCard` is an object |
-| `/.well-known/skills/index.json` and `/.well-known/skills/**` | the skills directory exists |
+| `/.well-known/skills/index.json` and `/.well-known/skills/**` | at least one valid skill is found |
 | `/robots.txt` | `robots.aiPolicy`, and neither `@nuxtjs/robots` nor a static `public/robots.txt` |
 
 `/llms.txt` and `/llms-full.txt` are not in there, and there's no option to add them. They belong to `nuxt-llms`, which every site already configures, so a second module claiming the route would be last-write-wins with no detection.
 
-With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered. Skill files are prerendered whatever the source. Nothing else under the raw prefix is: a wildcard pattern has no build-time page list, so those twins are rendered per request. On a source that is not the built-in one, that goes for every twin, including the ones `llms.txt` links.
+With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered. Skill files are prerendered whatever the source. With `nuxt-llms` installed, the bridge also hands Nitro's crawler every twin that `llms.txt` links, on any source, so those are prerendered too. A twin that nothing links and no exact pattern names is rendered per request.
 
 ### The raw route
 
@@ -188,8 +188,8 @@ It produces the same document the `@nuxt/content` adapter does, byte for byte, w
 import { defineAgentContentSource } from '#agent-discovery'
 
 export default defineAgentContentSource({
-  async routes() {
-    return ['/']
+  async list() {
+    return [{ route: '/', title: 'Hello' }]
   },
   async get(route) {
     if (route !== '/') return null
@@ -198,23 +198,12 @@ export default defineAgentContentSource({
 })
 ```
 
-`routes()` lists every markdown-representable route, `get()` resolves one to its markdown. Two optional methods:
+`list()` returns every markdown-representable page, `get()` resolves one to its markdown. Both take the request event as their last argument, which is how they reach the site URL and whatever request-scoped state the backend needs.
 
-- **`list(event, selector)`** returns routes with metadata in one call, used by `sitemap.md` and the `nuxt-llms` bridge to avoid a `get()` per page. Without it, `sitemap.md` and the `llms.txt` link list fall back to bare `routes()` and label each page by its path, while `llms-full.txt` falls back to `routes()` + a `get()` per page, since it needs the bodies anyway. With a `selector` (a `llms.sections` entry, handed over verbatim) return only the pages it names, or `null` when the selector isn't one you understand. An entry can carry a `section` label, which becomes the section title in `llms.txt` when the site declares no sections of its own.
-- **`firstLeaf(route, event)`** returns the first page under a section path, so a URL naming a directory rather than a page (`/raw/getting-started.md` with no index document) redirects to its first document instead of 404ing, the same as the HTML page does.
+- **`list(selector, event)`** is what `sitemap.md`, `listAgentPages()` and the `nuxt-llms` bridge read, so it is worth returning the metadata you already have: a `title` and `description` per entry, and a `section` label that becomes the section title in `llms.txt` when the site declares no sections of its own. With a `selector`, a `llms.sections` entry handed over verbatim, return only the pages it names, or `null` when the selector isn't one you understand.
+- **`firstLeaf(route, event)`** is optional. It returns the first page under a section path, so a URL naming a directory rather than a page (`/raw/getting-started.md` with no index document) redirects to its first document instead of 404ing, the same as the HTML page does.
 
-A markdown document is read detached from the site it came from, so site-relative links in it point nowhere. Both built-in adapters rewrite their document tree before rendering, with `absolutizeTreeLinks()`, which also catches the links in MDC component props. An adapter rendering straight to markdown should call `absolutizeMarkdownLinks()` instead, which leaves fenced blocks and inline code spans alone. Both are exported from `#agent-discovery`:
-
-```ts
-import { absolutizeMarkdownLinks, defineAgentContentSource, getAgentSiteUrl } from '#agent-discovery'
-
-export default defineAgentContentSource({
-  async get(route, event) {
-    const markdown = await render(route)
-    return { markdown: absolutizeMarkdownLinks(markdown, getAgentSiteUrl(event!)) }
-  }
-})
-```
+Site-relative links are absolutized for you. A markdown document is read detached from the site it came from, so a relative href in it points nowhere; the module rewrites whatever `get()` returns, leaving fenced blocks and inline code spans alone. The built-in adapters also rewrite their document tree before rendering, which is how they catch the links inside MDC component props, and running both is harmless because the pass only touches a destination that is still relative.
 
 ### llms.txt sections
 
@@ -236,12 +225,15 @@ A section whose selector no adapter recognises, and that has no description of i
 
 ```ts
 export default defineNuxtConfig({
-  routeRules: {
-    '/llms.txt': { prerender: false },
-    '/llms-full.txt': { prerender: false }
+  nitro: {
+    prerender: {
+      ignore: ['/llms.txt', '/llms-full.txt']
+    }
   }
 })
 ```
+
+A `routeRules` entry of `{ prerender: false }` on both routes does the same thing. Reach for `ignore` when the site is ISR end to end and has no prerendering to speak of, and for the route rule when you want to pair it with a cache.
 
 The module doesn't do this for you: it would turn both documents dynamic for every custom source, including the ones whose content is as static as `@nuxt/content`'s.
 
@@ -260,7 +252,7 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
-Tools in a group the card shouldn't advertise, `server/mcp/tools/admin/*.ts`, are left out. `discovery.mcpServerCard.excludeGroups` sets which groups those are, `['admin']` by default.
+Tools in a group the card shouldn't advertise, `server/mcp/tools/admin/*.ts`, are left out. `discovery.mcpServerCard.excludeGroups` adds to that list rather than replacing it, so naming your own private group keeps `admin` excluded.
 
 **`renderAgentResources()`** renders the discovery registry as a markdown block, for sites that hand-write an agent-facing homepage. It is the same list the `Link` header and the api-catalog are built from, so a resource can't be advertised in one place and missed in another. Pass `{ heading }` to change the default `## Resources for Agents` title:
 
@@ -326,6 +318,17 @@ useCanonical(() => `${route.path}.md`)
 </script>
 ```
 
+**`agent-discovery:sitemap`** adds to `/sitemap.md` before it renders. The content adapter only knows the pages it holds, so a hand-written route, a Vue-rendered showcase or a design document has no other way into the index an agent reads first. Sections are keyed by their heading, in order:
+
+```ts
+// server/plugins/agent-discovery.ts
+export default defineNitroPlugin((nitroApp) => {
+  nitroApp.hooks.hook('agent-discovery:sitemap', (event, sections) => {
+    sections.set('Design', [{ title: 'Design system', href: 'https://example.com/design.md' }])
+  })
+})
+```
+
 **`agent-discovery:document`** transforms a page before it is stringified, covered under [Content sources](#content-sources).
 
 ## Agent tooling
@@ -361,7 +364,7 @@ export default defineMcpTool({
 })
 ```
 
-- **`listAgentPages(event, { search, prefix })`** returns every page with its title, description, section, page URL and raw markdown URL. `search` keeps pages matching every whitespace-separated term across title, path and description. Without `list()` on the adapter it falls back to bare `routes()`, with no metadata.
+- **`listAgentPages(event, { search, prefix })`** returns every page with its title, description, section, page URL and raw markdown URL, skipping anything under `excludePrefixes`. `search` keeps pages matching every whitespace-separated term across title, path and description.
 - **`getAgentDocument(event, route, { sections })`** returns the exact bytes `/raw/<route>.md` serves, frontmatter and sitemap footer included, resolved in-process. `null` for a route with no markdown, `{ redirect }` for one that names a section rather than a page. Sites do this today by `$fetch`ing their own raw route from inside a serverless function.
 - **`extractSections(markdown, titles)`** narrows a document to the `##` sections named, keeping the frontmatter, title and description. Falls back to the whole document when none of them match, since handing back a title alone just makes the agent ask again.
 
@@ -379,11 +382,11 @@ Detected automatically, never a dependency. Detection happens at `modules:done`,
 
 On the `vercel` preset (skipped in dev), a Nitro `compiled` hook patches `.vercel/output/config.json` directly, the Build Output API v3, not `vercel.json`, prepending routes ahead of the ones Nitro emits from `routeRules`.
 
-The first route sets `Vary: Accept, User-Agent` across every configured pattern (and its `.md` twin, for exact patterns) with `continue: true`. That flag matters: Nitro emits its own header routes from `routeRules` *after* these rewrites and without `continue`, so without it `Vary` would never reach a request that gets rewritten straight to a prerendered `/raw/**.md` file off the CDN. A `Link` route on `/` carries the same `continue: true` for the same reason, the homepage's own `routeRules` entry never runs once a request is rewritten.
+The first route sets `Vary: Accept, User-Agent` across every configured pattern with `continue: true`. That flag matters: Nitro emits its own header routes from `routeRules` *after* these rewrites and without `continue`, so without it `Vary` would never reach a request that gets rewritten straight to a prerendered `/raw/**.md` file off the CDN. It skips anything with a dotted last segment, which keeps it off `/llms.txt`, `/robots.txt`, the `.md` twins and everything in `public/`: those answer the same bytes to every client, and a shared cache keyed per user-agent on them is close to no caching at all. A `Link` route on `/` carries the same `continue: true` for the same reason, the homepage's own `routeRules` entry never runs once a request is rewritten.
 
 Then, per route pattern, two negotiated routes: a `has` matcher on `Accept: text/markdown` and another on the agent User-Agent list. What they do depends on whether the pattern is cached:
 
-- **Prerendered pattern**: a rewrite, with `check: true` so Vercel looks the destination up on the filesystem first, which is where the prerendered raw files live, before falling through to the origin. The page URL is preserved, which is the point of doing this at the CDN rather than redirecting.
+- **Uncached pattern**: a rewrite, with `check: true` so Vercel looks the destination up on the filesystem first, which is where the prerendered raw files live, before falling through to the origin. The page URL is preserved, which is the point of doing this at the CDN rather than redirecting. Where the twin is not prerendered the request reaches the origin with its original path, so the Nitro middleware makes the call.
 - **Cached pattern** (see [ISR and cached routes](#isr-and-cached-routes)): a 307 to the raw twin, carrying `Vary` itself.
 
 The explicit `.md` twin stays a rewrite either way: that URL only ever serves markdown, so it has no second variant to worry about.
@@ -402,7 +405,7 @@ A `routeRules` entry with `isr`, `swr`, or `cache` can't vary its response on `A
 
 So for any configured pattern overlapping a cached route rule (logged at build time), the module:
 
-- disables request-time negotiation in the Nitro middleware, in production. Dev has no response cache, and a site that caches every page would otherwise never negotiate locally
+- redirects rather than answering in place in the Nitro middleware, in production. Dev has no response cache, and a site that caches every page would otherwise never negotiate locally
 - emits a 307 to the raw twin at the CDN instead of a rewrite, so each URL keeps a single variant and the client resolves the twin before any cache lookup
 
 A rule narrower than the pattern covering it, `routeRules['/docs/**']` under the default `/**`, gets its own redirect pair emitted ahead of that pattern's rewrite, so only the cached section is affected and the rest of the site keeps URL-preserving rewrites. Both strategies come out of the same detection, so a route rule added later moves the routes it covers on its own.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@nuxt/test-utils": "^4.1.0",
     "@nuxtjs/mcp-toolkit": "^0.19.0",
     "@nuxtjs/robots": "^6.2.0",
+    "@nuxtjs/sitemap": "^8.5.0",
     "@release-it/conventional-changelog": "^12.0.0",
     "@types/node": "^26.2.0",
     "better-sqlite3": "^13.0.3",
@@ -76,6 +77,8 @@
   "peerDependencies": {
     "@nuxt/content": "^3.0.0",
     "@nuxtjs/mcp-toolkit": ">=0.19.0",
+    "@nuxtjs/robots": "^6.0.0",
+    "@nuxtjs/sitemap": "^8.0.0",
     "comark": "^0.6.0",
     "nuxt-llms": ">=0.1.0"
   },
@@ -83,13 +86,19 @@
     "@nuxt/content": {
       "optional": true
     },
-    "nuxt-llms": {
+    "@nuxtjs/mcp-toolkit": {
+      "optional": true
+    },
+    "@nuxtjs/robots": {
+      "optional": true
+    },
+    "@nuxtjs/sitemap": {
       "optional": true
     },
     "comark": {
       "optional": true
     },
-    "@nuxtjs/mcp-toolkit": {
+    "nuxt-llms": {
       "optional": true
     }
   }

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -11,7 +11,6 @@ export default defineNuxtConfig({
       nativeSqlite: true
     }
   },
-  compatibilityDate: '2026-01-01',
   // `/docs/**` is cached, the rest of the site is not. That split is the point:
   // a cached pattern has to 307 to its raw twin, because a response cache keys
   // on the path alone and would otherwise serve one visitor's markdown to the
@@ -19,6 +18,7 @@ export default defineNuxtConfig({
   routeRules: {
     '/docs/**': { isr: 60 }
   },
+  compatibilityDate: '2026-01-01',
   nitro: {
     output: {
       // Vercel reads the build output from the repository root, not from the playground.

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -12,6 +12,13 @@ export default defineNuxtConfig({
     }
   },
   compatibilityDate: '2026-01-01',
+  // `/docs/**` is cached, the rest of the site is not. That split is the point:
+  // a cached pattern has to 307 to its raw twin, because a response cache keys
+  // on the path alone and would otherwise serve one visitor's markdown to the
+  // next, while everything outside it keeps a URL-preserving rewrite.
+  routeRules: {
+    '/docs/**': { isr: 60 }
+  },
   nitro: {
     output: {
       // Vercel reads the build output from the repository root, not from the playground.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@nuxtjs/robots':
         specifier: ^6.2.0
         version: 6.2.0(f015de5161a411bbcdeece620c4d793a)
+      '@nuxtjs/sitemap':
+        specifier: ^8.5.0
+        version: 8.5.0(f015de5161a411bbcdeece620c4d793a)
       '@release-it/conventional-changelog':
         specifier: ^12.0.0
         version: 12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.2)(release-it@21.0.2(@types/node@26.2.0)(magicast@0.5.4)(supports-color@10.2.2))
@@ -921,6 +924,9 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
 
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -1142,6 +1148,15 @@ packages:
 
   '@nuxtjs/robots@6.2.0':
     resolution: {integrity: sha512-+y8BRDWOkSMofe0ewOlVQm6+VFd4Qh/I8kh9z/++VwfPlDtrU6BDhoobJ18eVDaMkf8gJl12dwKZziK8yU4c/g==}
+    peerDependencies:
+      zod: '>=3'
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@nuxtjs/sitemap@8.5.0':
+    resolution: {integrity: sha512-DfhUZzP29Wzr9ro3L2mBpYUocmLBKvGDAGThvLdHWKGR1kBFnbY5VBhJaZG4Jeuba5gVKCpDzH9PhKNW11d46Q==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: '>=3'
     peerDependenciesMeta:
@@ -2279,6 +2294,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
@@ -3316,6 +3334,13 @@ packages:
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
+  fast-xml-builder@1.3.1:
+    resolution: {integrity: sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==}
+
+  fast-xml-parser@5.11.0:
+    resolution: {integrity: sha512-9IGxMqvqLOnqP+Egi1nqDHKv5k8aZ7r9n558enxcucmyVGEBNPAU+MOg/8jPIS7rO7sSq4gFm1/nHtiaubMruw==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3782,6 +3807,9 @@ packages:
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
+
+  is-unsafe@2.0.2:
+    resolution: {integrity: sha512-HgbIHPBH0KHHCcjLfGsCvhtPTVxjaAZlXjwdz7/GQC40SjSe4sfQsar8J5VFo8JOSbarkpV0OLG95bbaNd9aAQ==}
 
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
@@ -4636,6 +4664,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -5436,6 +5468,10 @@ packages:
     peerDependencies:
       vue: ^3.5.30
 
+  sitemapd@0.2.2:
+    resolution: {integrity: sha512-XAuW9x2cI3B757A/h2sFYfye5kBUHM8Gr6Muzwtve1oYRCv3BntoKMcgNu+GNF/LKIvUD1fQpBTVUCoHlzMihg==}
+    engines: {node: '>=18.0.0'}
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -5575,6 +5611,9 @@ packages:
 
   strip-literal@4.0.0:
     resolution: {integrity: sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==}
+
+  strnum@2.4.2:
+    resolution: {integrity: sha512-rDG3Ah4TV0k1hWvLSzkZtMmLN9+eS+h3knq4MP6A42Y3Yh5qGNnOUs1jJkoSr8FG5dsL28c7KgkIBzSEykqtuw==}
 
   structured-clone-es@2.0.1:
     resolution: {integrity: sha512-10ZL5r77LhknxlP1FBiCW+VdnuWOEFLdSS2SKtjyEV+L4qP1hUEIMIZW94LC3jKxRmT/Dj7KkD1mqh/IY6lhKQ==}
@@ -6342,6 +6381,10 @@ packages:
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
+
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
 
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
@@ -7154,6 +7197,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
+  '@nodable/entities@3.0.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7854,6 +7899,33 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
+    optionalDependencies:
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - vue
+
+  '@nuxtjs/sitemap@8.5.0(f015de5161a411bbcdeece620c4d793a)':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.2)(magicast@0.5.4)(oxc-parser@0.139.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.5)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
+      consola: 3.4.2
+      defu: 6.1.7
+      nuxt-site-config: 4.2.3(f015de5161a411bbcdeece620c4d793a)
+      nuxtseo-shared: 5.3.14(ce7ad50fb44b747fabc0f125fb5f589d)
+      ofetch: 1.5.1
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      radix3: 1.1.2
+      sitemapd: 0.2.2
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
     optionalDependencies:
       zod: 4.4.3
     transitivePeerDependencies:
@@ -8868,6 +8940,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  anynum@1.0.1: {}
 
   archiver-utils@5.0.2:
     dependencies:
@@ -10021,6 +10095,20 @@ snapshots:
     dependencies:
       fast-string-width: 3.0.2
 
+  fast-xml-builder@1.3.1:
+    dependencies:
+      path-expression-matcher: 1.6.2
+      xml-naming: 0.3.0
+
+  fast-xml-parser@5.11.0:
+    dependencies:
+      '@nodable/entities': 3.0.0
+      fast-xml-builder: 1.3.1
+      is-unsafe: 2.0.2
+      path-expression-matcher: 1.6.2
+      strnum: 2.4.2
+      xml-naming: 0.3.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -10572,6 +10660,8 @@ snapshots:
       which-typed-array: 1.1.22
 
   is-unicode-supported@2.1.0: {}
+
+  is-unsafe@2.0.2: {}
 
   is-wsl@3.1.1:
     dependencies:
@@ -11892,6 +11982,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.6.2: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -12813,6 +12905,10 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.41(typescript@5.9.3)
 
+  sitemapd@0.2.2:
+    dependencies:
+      fast-xml-parser: 5.11.0
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -12954,6 +13050,10 @@ snapshots:
   strip-literal@4.0.0:
     dependencies:
       js-tokens: 10.0.0
+
+  strnum@2.4.2:
+    dependencies:
+      anynum: 1.0.1
 
   structured-clone-es@2.0.1: {}
 
@@ -13731,6 +13831,8 @@ snapshots:
       powershell-utils: 0.1.0
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.3.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 

--- a/skills/migrate-to-nuxt-agent-discovery/SKILL.md
+++ b/skills/migrate-to-nuxt-agent-discovery/SKILL.md
@@ -7,7 +7,7 @@ description: Migrate a Nuxt site to the nuxt-agent-discovery module, replacing a
 
 Replace a site's hand-rolled agent-discovery layer with the module. The reference migration is [nuxt/ui#6883](https://github.com/nuxt/ui/pull/6883): a negotiation core, a CDN rewrite module, a request middleware, an error handler and six route handlers deleted, replaced by one config block and one Nitro plugin holding three hooks. Almost every file it touches is a deletion.
 
-Read the module's README first, and `.claude/DESIGN.md` in the module repo when a decision needs the reasoning behind it.
+Read the module's README first. It is the only document that ships with the package and the only one guaranteed to match the installed version.
 
 The shape of the work: **configuration replaces routing code, hooks replace site-specific code, everything else gets deleted.** A migration that keeps a file the module owns is not finished, and one that pushes site knowledge into the module is wrong in the other direction.
 
@@ -51,7 +51,7 @@ Record:
 pnpm add -D nuxt-agent-discovery
 ```
 
-Add `'nuxt-agent-discovery'` to `modules`. Order does not matter: the module detects `@nuxt/content`, `nuxt-llms`, `@nuxtjs/robots` and `@nuxtjs/sitemap` at `modules:done`.
+Add `'nuxt-agent-discovery'` to `modules`. Order does not matter for anything listed in `modules`, which the module reads directly. `@nuxtjs/robots`, `@nuxtjs/sitemap` and `@nuxtjs/mcp-toolkit` are detected later still, at `modules:done`, so a site getting them through `@nuxtjs/seo` is covered too. `@nuxt/content` and `nuxt-llms` are read during setup, so a content module pulled in as another module's dependency rather than listed is not seen: set `agentDiscovery.source` explicitly if the build warns that no content source resolved.
 
 ## Step 3: configure
 
@@ -162,7 +162,7 @@ curl -sS http://localhost:3000/.well-known/api-catalog | jq .
 curl -sS -A ClaudeBot http://localhost:3000/nope | head
 ```
 
-Then build, and read the log rather than skimming it. The module warns when a cached route rule overlaps a negotiated pattern, when a static `robots.txt` shadows the generated one, and throws on an invented link rel. Compare the prerendered route count against the old build.
+Then build, and read the log rather than skimming it. The module logs at info when a cached route rule covers a negotiated pattern, so grep for `response cache` rather than for warnings. It warns when no content source resolves, when a static `robots.txt` shadows the generated one, and when `extend` and `replace` are both set, and it throws on an invented link rel or a `siteUrl` carrying a path. Compare the prerendered route count against the old build.
 
 Then deploy a preview and run the `verify-nuxt-agent-discovery` skill against it. Local checks cannot exercise `Vary`, the `Link` header or the CDN rewrites, which is where the interesting failures live.
 

--- a/skills/verify-nuxt-agent-discovery/SKILL.md
+++ b/skills/verify-nuxt-agent-discovery/SKILL.md
@@ -58,7 +58,10 @@ Establish and write down:
 - **The raw prefix.** Read it off the links in `sitemap.md`, which point at raw twins. `/raw` is the default, and every command below uses `$RAW` rather than assuming it:
 
 ```sh
-RAW=$(curl -sS "$PREVIEW/sitemap.md" | grep -oE '\]\(https?://[^)]+' | sed 's|.*://[^/]*||' | grep -oE '^/[^/]+' | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
+# The longest common leading path of the twins, so a multi-segment prefix like
+# `/docs/raw` survives. Stripping only the first segment would target `/docs`.
+RAW=$(curl -sS "$PREVIEW/sitemap.md" | grep -oE '\]\(https?://[^)]+\.md' | sed 's|.*://[^/]*||' \
+  | awk -F/ 'NR==1{n=NF; for(i=1;i<NF;i++) p[i]=$i; next} {if(NF<n) n=NF; for(i=1;i<n;i++) if(p[i]!=$i){n=i; break}} END{s=""; for(i=2;i<n;i++) s=s "/" p[i]; print s}')
 RAW=${RAW:-/raw}
 echo "$RAW"
 ```
@@ -101,7 +104,7 @@ Run every row against `$HOME` and `$DOC`, plus one page from each class the swee
 | `show -A "$BOT" "$PREVIEW$DOC"` | same markdown, no `Accept` header needed |
 | `probe -A "$GPT" "$PREVIEW$DOC"` | same as ClaudeBot |
 | `show "$PREVIEW$DOC.md"` | markdown, 200, a rewrite even on a cached pattern |
-| `probe -H 'Accept: text/markdown;q=0.5, text/html;q=0.9' "$PREVIEW$DOC"` | HTML **when the twin is not prerendered**, markdown when it is. A CDN matcher cannot rank q-values, so on a prerendered twin the edge answers before the origin can. Documented in the README, not a bug. Pick a `$DOC` whose twin is rendered per request if you want a deterministic row |
+| `probe -H 'Accept: text/markdown;q=0.5, text/html;q=0.9' "$PREVIEW$DOC"` | HTML **on an uncached pattern whose twin is not prerendered**, which is the only deterministic case: pick that `$DOC`. A CDN matcher cannot rank q-values, so a prerendered twin answers markdown at the edge and a cached pattern answers 307, both before the origin can rank anything. Documented in the README, not a bug |
 | `probe -H 'Accept: text/markdown;q=0.9, text/html;q=0.5' "$PREVIEW$DOC"` | markdown |
 | `probe -H 'Accept: text/markdown;q=0' "$PREVIEW$DOC"` | HTML |
 | `probe -H 'Accept: */*' "$PREVIEW$DOC"` | HTML, a wildcard never counts as asking |
@@ -208,9 +211,12 @@ curl -sS "$PREVIEW/robots.txt"
 ```sh
 # Fail loudly when the index itself is missing: an empty pipeline below would
 # otherwise report a clean pass on a site that serves no index at all.
-curl -fsS "$PREVIEW/.well-known/skills/index.json" > /tmp/skills.json || echo 'NO SKILLS INDEX'
-jq -r '.skills[] | .name as $n | .files[] | "\($n)/\(.)"' /tmp/skills.json \
-  | while read -r p; do printf '%s %s\n' "$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW/.well-known/skills/$p")" "$p"; done
+if ! curl -fsS "$PREVIEW/.well-known/skills/index.json" > /tmp/skills.json; then
+  echo 'FAIL: no skills index'   # a finding whenever the site ships skills
+else
+  jq -r '.skills[] | .name as $n | .files[] | "\($n)/\(.)"' /tmp/skills.json \
+    | while read -r p; do printf '%s %s\n' "$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW/.well-known/skills/$p")" "$p"; done
+fi
 ```
 
 - `robots.txt` names the agents negotiation actually matches. Cross-check it: every user agent named there gets markdown on `$DOC`, and the list is not shorter than the 18 defaults unless the site replaced it.
@@ -231,8 +237,11 @@ grep -oE '\]\([^)]+\)' /tmp/llms.txt | grep -v '\.md)' | head       # same-origi
 - The link set matches the inventory. A section that lost its links, or a page that fell out, is a finding:
 
 ```sh
-grep -oE 'https?://[^)]+\.md' /tmp/llms.txt | sed "s|.*$RAW||;s|\.md$||" | sort -u > /tmp/llms-pages
-diff <(sed 's|/$||' /tmp/pages | sort -u) /tmp/llms-pages | head -40
+# The homepage is `/` in the sitemap and `/index` in a raw twin, so both sides
+# are folded to `/` before the diff. Without that a correct site reports one.
+home() { sed -e 's|^/index$|/|' -e 's|^$|/|' -e 's|\(.\)/$|\1|' | sort -u; }
+grep -oE 'https?://[^)]+\.md' /tmp/llms.txt | sed "s|.*$RAW||;s|\.md$||" | home > /tmp/llms-pages
+diff <(home < /tmp/pages) /tmp/llms-pages | head -40
 ```
 
 - A page's body inside `llms-full.txt` is byte-identical to the **body** of `/raw/<page>.md`, which is that document minus its frontmatter block and its `## Sitemap` footer. They come from one pipeline now, so any difference beyond that envelope is a bug. Check three pages from different sections.

--- a/skills/verify-nuxt-agent-discovery/SKILL.md
+++ b/skills/verify-nuxt-agent-discovery/SKILL.md
@@ -55,11 +55,17 @@ curl -sS "$PREVIEW/.well-known/api-catalog" | jq .
 Establish and write down:
 
 - **Host.** `x-vercel-id` means Vercel, where negotiation happens at the edge from the Build Output route table and everything in this skill applies. Anything else means only the Nitro middleware runs, and Nitro serves prerendered files ahead of user handlers, so **a prerendered page keeps returning HTML to an agent**. That is a documented limitation, not a regression: expect negotiation on never-prerendered pages and on explicit `.md` URLs, and say so in the report.
-- **The raw prefix.** Read it off the links in `sitemap.md`, which point at raw twins. `/raw` is the default.
+- **The raw prefix.** Read it off the links in `sitemap.md`, which point at raw twins. `/raw` is the default, and every command below uses `$RAW` rather than assuming it:
+
+```sh
+RAW=$(curl -sS "$PREVIEW/sitemap.md" | grep -oE '\]\(https?://[^)]+' | sed 's|.*://[^/]*||' | grep -oE '^/[^/]+' | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
+RAW=${RAW:-/raw}
+echo "$RAW"
+```
 - **The production URL**, baked into every prerendered document by `siteUrl`:
 
 ```sh
-PROD=$(curl -sS "$PREVIEW/raw/index.md" | grep -oE 'https?://[^/)]+' | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
+PROD=$(curl -sS "$PREVIEW$RAW/index.md" | grep -oE 'https?://[^/)]+' | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
 echo "$PROD"
 ```
 
@@ -95,14 +101,14 @@ Run every row against `$HOME` and `$DOC`, plus one page from each class the swee
 | `show -A "$BOT" "$PREVIEW$DOC"` | same markdown, no `Accept` header needed |
 | `probe -A "$GPT" "$PREVIEW$DOC"` | same as ClaudeBot |
 | `show "$PREVIEW$DOC.md"` | markdown, 200, a rewrite even on a cached pattern |
-| `probe -H 'Accept: text/markdown;q=0.5, text/html;q=0.9' "$PREVIEW$DOC"` | HTML, html outranks markdown |
+| `probe -H 'Accept: text/markdown;q=0.5, text/html;q=0.9' "$PREVIEW$DOC"` | HTML **when the twin is not prerendered**, markdown when it is. A CDN matcher cannot rank q-values, so on a prerendered twin the edge answers before the origin can. Documented in the README, not a bug. Pick a `$DOC` whose twin is rendered per request if you want a deterministic row |
 | `probe -H 'Accept: text/markdown;q=0.9, text/html;q=0.5' "$PREVIEW$DOC"` | markdown |
 | `probe -H 'Accept: text/markdown;q=0' "$PREVIEW$DOC"` | HTML |
 | `probe -H 'Accept: */*' "$PREVIEW$DOC"` | HTML, a wildcard never counts as asking |
 | `probe -H 'Accept: text/plain' "$PREVIEW$DOC"` | HTML, only `text/markdown` counts |
 | `probe -A "$BOT" "$PREVIEW$UNCOVERED"` | HTML, an unconfigured page must not start negotiating |
 | `probe -A "$BOT" "$PREVIEW$DOC?ref=x"` | markdown, and if it is a 307 the `location` keeps `?ref=x` |
-| `probe -A "$BOT" -X HEAD "$PREVIEW$DOC"` | same status and headers as the GET |
+| `probe -A "$BOT" -I "$PREVIEW$DOC"` | same status and headers as the GET. `-I`, not `-X HEAD`, which makes curl wait for a body that never comes |
 
 Two things that fail quietly, so check them explicitly:
 
@@ -112,7 +118,7 @@ Two things that fail quietly, so check them explicitly:
 ```sh
 curl -sS -H 'Accept: text/markdown' "$PREVIEW$DOC" > /tmp/a.md
 curl -sS "$PREVIEW$DOC.md" > /tmp/b.md
-curl -sS "$PREVIEW/raw${DOC}.md" > /tmp/c.md
+curl -sS "$PREVIEW$RAW${DOC}.md" > /tmp/c.md
 diff /tmp/a.md /tmp/b.md && diff /tmp/b.md /tmp/c.md
 ```
 
@@ -127,7 +133,7 @@ p="$1"
 agent=$(curl -sS -o /dev/null -w '%{http_code} %{content_type} %{redirect_url}' -A "$BOT" "$PREVIEW$p")
 html=$(curl -sS -o /dev/null -w '%{http_code} %{content_type}' -A "$BROWSER" -H "Accept: $HTML" "$PREVIEW$p")
 twin=$([ "$p" = "/" ] && echo skip || curl -sS -o /dev/null -w '%{http_code} %{content_type}' "$PREVIEW${p%/}.md")
-raw=$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW/raw$([ "$p" = "/" ] && echo /index || echo "${p%/}").md")
+raw=$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW$RAW$([ "$p" = "/" ] && echo /index || echo "${p%/}").md")
 echo "$p | agent: $agent | html: $html | twin: $twin | raw: $raw"
 EOF
 chmod +x /tmp/sweep.sh
@@ -156,22 +162,22 @@ Also sweep for empty or truncated documents, which return 200 and look fine:
 
 ```sh
 while read -r p; do
-  n=$(curl -sS "$PREVIEW/raw$([ "$p" = "/" ] && echo /index || echo "${p%/}").md" | wc -c)
+  n=$(curl -sS "$PREVIEW$RAW$([ "$p" = "/" ] && echo /index || echo "${p%/}").md" | wc -c)
   [ "$n" -lt 200 ] && echo "THIN $n $p"
 done < /tmp/pages
 ```
 
 ## Step 4: the raw route
 
-- `show "$PREVIEW/raw${DOC}.md"` returns 200, `text/markdown`, and a `Link` header with both `rel="canonical"` and `rel="alternate"; type="text/html"` pointing at the page URL.
-- `probe "$PREVIEW/raw${SECTION}.md"` returns 302 to the first document under that section, not a 404.
-- `show "$PREVIEW/raw/does-not-exist.md"` returns 404 with a markdown body.
-- `curl -sS "$PREVIEW/raw/index.md" | head -30` returns the homepage document, or the generated landing page: frontmatter, canonical and alternate links, and a resources block.
+- `show "$PREVIEW$RAW${DOC}.md"` returns 200, `text/markdown`, and a `Link` header with both `rel="canonical"` and `rel="alternate"; type="text/html"` pointing at the page URL.
+- `probe "$PREVIEW$RAW${SECTION}.md"` returns 302 to the first document under that section, not a 404.
+- `show "$PREVIEW$RAW/does-not-exist.md"` returns 404 with a markdown body.
+- `curl -sS "$PREVIEW$RAW/index.md" | head -30` returns the homepage document, or the generated landing page: frontmatter, canonical and alternate links, and a resources block.
 - Site-relative links are absolutised. Every `](/` outside a fenced block is a bug, across the whole inventory:
 
 ```sh
 while read -r p; do
-  curl -sS "$PREVIEW/raw$([ "$p" = "/" ] && echo /index || echo "${p%/}").md" \
+  curl -sS "$PREVIEW$RAW$([ "$p" = "/" ] && echo /index || echo "${p%/}").md" \
     | awk '/^ {0,3}(```|~~~)/{f=!f} !f' | grep -q '](/' && echo "RELATIVE $p"
 done < /tmp/pages
 ```
@@ -195,14 +201,16 @@ curl -sS "$PREVIEW/robots.txt"
 - The `Link` header on `/` carries only IANA-registered rels. Any `rel="llms"`, `rel="mcp"`, `rel="design"` or other invented relation means something outside the module is emitting headers, since the module rejects them at build time.
 - Every href in the `Link` header and the api-catalog resolves. Fetch each one and record the status.
 - `api-catalog` answers `application/linkset+json`, parses, and every `anchor` and `href` is absolute.
-- The server card carries `endpoint` and `name`, and lists live tools where the site hooks `agent-discovery:mcp-server-card`. The endpoint it names answers: POST an MCP `initialize` to it.
-- `sitemap.md` covers the same pages as `/tmp/pages` and every link points at a raw twin rather than the HTML page.
+- The server card carries `serverInfo.name` and an `endpoints` array (`endpoint` and `name` are the config keys, not the served fields), and lists live tools where the site runs `@nuxtjs/mcp-toolkit`. The endpoint it names answers: POST an MCP `initialize` to it. There is no `$schema`: the MCP spec has no server card yet.
+- `sitemap.md` links point at a raw twin for every page a `routes` pattern covers. A page outside those patterns correctly links to its HTML URL, and a path under `excludePrefixes` is left out entirely, so compare against the negotiated set rather than against `sitemap.xml`.
 - The skills index lists skills, and every file it names fetches 200:
 
 ```sh
-curl -sS "$PREVIEW/.well-known/skills/index.json" \
-  | jq -r '.. | .path? // empty' \
-  | while read -r p; do printf '%s %s\n' "$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW/$p")" "$p"; done
+# Fail loudly when the index itself is missing: an empty pipeline below would
+# otherwise report a clean pass on a site that serves no index at all.
+curl -fsS "$PREVIEW/.well-known/skills/index.json" > /tmp/skills.json || echo 'NO SKILLS INDEX'
+jq -r '.skills[] | .name as $n | .files[] | "\($n)/\(.)"' /tmp/skills.json \
+  | while read -r p; do printf '%s %s\n' "$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW/.well-known/skills/$p")" "$p"; done
 ```
 
 - `robots.txt` names the agents negotiation actually matches. Cross-check it: every user agent named there gets markdown on `$DOC`, and the list is not shorter than the 18 defaults unless the site replaced it.
@@ -223,11 +231,11 @@ grep -oE '\]\([^)]+\)' /tmp/llms.txt | grep -v '\.md)' | head       # same-origi
 - The link set matches the inventory. A section that lost its links, or a page that fell out, is a finding:
 
 ```sh
-grep -oE 'https?://[^)]+\.md' /tmp/llms.txt | sed "s|.*/raw||;s|\.md$||" | sort -u > /tmp/llms-pages
+grep -oE 'https?://[^)]+\.md' /tmp/llms.txt | sed "s|.*$RAW||;s|\.md$||" | sort -u > /tmp/llms-pages
 diff <(sed 's|/$||' /tmp/pages | sort -u) /tmp/llms-pages | head -40
 ```
 
-- A page's body inside `llms-full.txt` is byte-identical to `/raw/<page>.md`. They come from one pipeline now, so any difference is a bug. Check three pages from different sections.
+- A page's body inside `llms-full.txt` is byte-identical to the **body** of `/raw/<page>.md`, which is that document minus its frontmatter block and its `## Sitemap` footer. They come from one pipeline now, so any difference beyond that envelope is a bug. Check three pages from different sections.
 
 ## Step 7: error bodies
 
@@ -274,7 +282,7 @@ When production still runs a prior implementation, this is the strongest check a
 ```sh
 for p in $(awk 'NR % 18 == 1' /tmp/pages); do        # every 18th page, spread across the inventory
   curl -sS "$PROD/raw${p%/}.md"    | sed "s|$PROD||g" > /tmp/prod.md
-  curl -sS "$PREVIEW/raw${p%/}.md" | sed "s|$PREVIEW||g;s|$PROD||g" > /tmp/prev.md
+  curl -sS "$PREVIEW$RAW${p%/}.md" | sed "s|$PREVIEW||g;s|$PROD||g" > /tmp/prev.md
   echo "== $p"; diff /tmp/prod.md /tmp/prev.md || true
 done
 ```

--- a/skills/verify-nuxt-agent-discovery/SKILL.md
+++ b/skills/verify-nuxt-agent-discovery/SKILL.md
@@ -58,10 +58,10 @@ Establish and write down:
 - **The raw prefix.** Read it off the links in `sitemap.md`, which point at raw twins. `/raw` is the default, and every command below uses `$RAW` rather than assuming it:
 
 ```sh
-# The longest common leading path of the twins, so a multi-segment prefix like
-# `/docs/raw` survives. Stripping only the first segment would target `/docs`.
-RAW=$(curl -sS "$PREVIEW/sitemap.md" | grep -oE '\]\(https?://[^)]+\.md' | sed 's|.*://[^/]*||' \
-  | awk -F/ 'NR==1{n=NF; for(i=1;i<NF;i++) p[i]=$i; next} {if(NF<n) n=NF; for(i=1;i<n;i++) if(p[i]!=$i){n=i; break}} END{s=""; for(i=2;i<n;i++) s=s "/" p[i]; print s}')
+# Taken from the homepage twin, which is always `<prefix>/index.md`. Inferring
+# a common prefix instead collapses on a site whose pages all share a section:
+# `/raw/docs/a.md` and `/raw/docs/b.md` would give `/raw/docs`.
+RAW=$(curl -sS "$PREVIEW/sitemap.md" | grep -oE 'https?://[^)]+/index\.md' | head -1 | sed -e 's|.*://[^/]*||' -e 's|/index\.md$||')
 RAW=${RAW:-/raw}
 echo "$RAW"
 ```
@@ -239,7 +239,7 @@ grep -oE '\]\([^)]+\)' /tmp/llms.txt | grep -v '\.md)' | head       # same-origi
 ```sh
 # The homepage is `/` in the sitemap and `/index` in a raw twin, so both sides
 # are folded to `/` before the diff. Without that a correct site reports one.
-home() { sed -e 's|^/index$|/|' -e 's|^$|/|' -e 's|\(.\)/$|\1|' | sort -u; }
+home() { sed -e 's|\(.\)/$|\1|' -e 's|^/index$|/|' -e 's|^$|/|' | sort -u; }
 grep -oE 'https?://[^)]+\.md' /tmp/llms.txt | sed "s|.*$RAW||;s|\.md$||" | home > /tmp/llms-pages
 diff <(home < /tmp/pages) /tmp/llms-pages | head -40
 ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -241,7 +241,12 @@ export default defineNuxtModule<ModuleOptions>({
       const contentEntry = await tryResolveModule('@nuxt/content', nuxt.options.modulesDir)
       minimarkStringify = contentEntry ? await tryResolveModule('minimark/stringify', [contentEntry]) : undefined
       if (!minimarkStringify) {
-        logger.warn('Could not resolve `minimark/stringify` from `@nuxt/content`; falling back to this module\'s own copy. Raw markdown may differ from what `@nuxt/content` produces.')
+        // Points at the cause rather than the symptom: reached with
+        // `source: 'content'` on a site that has no `@nuxt/content` at all,
+        // where the next failure is an unresolvable `@nuxt/content/server`.
+        logger.warn(contentEntry
+          ? 'Could not resolve `minimark/stringify` from `@nuxt/content`, so raw markdown may differ from what it produces.'
+          : 'The content source is enabled but `@nuxt/content` could not be resolved. Install it, or set `agentDiscovery.source` to a file exporting an `AgentContentSource`.')
       }
     } else if (options.source === 'comark') {
       throw new Error('[nuxt-agent-discovery] comark sites construct their content instance themselves, so pass a source file instead: `source: \'~~/server/utils/agent-source\'`, exporting `createComarkSource(() => getContent())` from `#agent-discovery/comark`.')
@@ -281,8 +286,13 @@ export default defineNuxtModule<ModuleOptions>({
       // imports. Aliasing the real re-export in that state fails the Nitro
       // build on an unresolvable id, so the same three conditions are mirrored
       // here.
-      const mcpOptions = (nuxt.options as { mcp?: { enabled?: boolean } }).mcp
+      // `mcp: false` is how Nuxt disables a module by its config key, and it is
+      // not the same as `mcp: { enabled: false }`: optional chaining reads the
+      // first as `undefined !== false`, which passed this guard and left the
+      // card aliased to a toolkit that registered nothing.
+      const mcpOptions = (nuxt.options as { mcp?: false | { enabled?: boolean } }).mcp
       const mcpToolkit = hasNuxtModule('@nuxtjs/mcp-toolkit')
+        && mcpOptions !== false
         && mcpOptions?.enabled !== false
         && !nuxt.options.nitro?.static
         && (nuxt.options as { _generate?: boolean })._generate !== true
@@ -312,7 +322,19 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/.well-known/mcp/server-card.json', handler: resolve('./runtime/server/routes/mcp-server-card') })
     }
 
-    addServerHandler({ middleware: true, handler: resolve('./runtime/server/middleware/negotiate') })
+    // `source: false` is a site saying something else already serves the raw
+    // markdown, so negotiation still runs against it. `'auto'` resolving to
+    // nothing is a site that installed the module and has no adapter: rewriting
+    // every page to a prefix nothing serves would answer agents with a 404 on
+    // pages that render fine in HTML, which is worse than not installing it.
+    const negotiates = Boolean(sourcePath) || options.source === false
+    if (!negotiates) {
+      logger.warn('No content source resolved, so markdown negotiation is off. Install `@nuxt/content`, point `agentDiscovery.source` at a file exporting an `AgentContentSource`, or set `source: false` if another route already serves the raw markdown.')
+    }
+
+    if (negotiates) {
+      addServerHandler({ middleware: true, handler: resolve('./runtime/server/middleware/negotiate') })
+    }
 
     nuxt.hook('nitro:config', (nitroConfig) => {
       if (options.errors) {
@@ -482,9 +504,30 @@ export {}
       // Prerendered documents bake the site URL in, so resolve it from the
       // site config or the llms domain when not set explicitly. Request-time
       // responses still fall back to the incoming host.
+      const siteOptions = nuxt.options as { site?: { url?: string, name?: string }, llms?: { domain?: string } }
       if (!config.siteUrl) {
-        const siteOptions = nuxt.options as { site?: { url?: string }, llms?: { domain?: string } }
         config.siteUrl = (siteOptions.site?.url || siteOptions.llms?.domain || '').replace(/\/$/, '')
+      }
+      // Falls back the same way `siteUrl` does, so a site that already told
+      // `@nuxtjs/seo` its name does not repeat it here.
+      if (!config.siteName) {
+        config.siteName = siteOptions.site?.name || ''
+      }
+
+      // Every helper here treats `siteUrl` as an origin: `rawUrl()` compares
+      // against `new URL(siteUrl).origin`, then concatenates the raw path onto
+      // the configured value, so a path would end up in the middle of the URL.
+      // Failing at build is better than shipping documents whose every link is
+      // silently wrong.
+      if (config.siteUrl && new URL(config.siteUrl).pathname !== '/') {
+        throw new Error(`[nuxt-agent-discovery] \`siteUrl\` must be an origin, but it carries a path (${config.siteUrl}). Serving the site under a base path is not supported yet.`)
+      }
+
+      // Prerendered documents bake this in, and the prerenderer sends no host
+      // header, so an empty value here becomes `http://localhost` in every
+      // canonical URL and every absolutized link of the built output.
+      if (!config.siteUrl && nuxt.options.nitro.static) {
+        logger.warn('No `siteUrl`: set it, or `site.url`, or `llms.domain`. Prerendered documents resolve it from the request, which is `localhost` at build time.')
       }
 
       if (hasLlms && sourcePath) {
@@ -683,8 +726,10 @@ export {}
 
     /* ------------------------------- presets ------------------------------- */
 
-    nuxt.hook('nitro:init', (nitro) => {
-      setupVercelPreset(nitro, config)
-    })
+    if (negotiates) {
+      nuxt.hook('nitro:init', (nitro) => {
+        setupVercelPreset(nitro, config)
+      })
+    }
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -190,11 +190,24 @@ export default defineNuxtModule<ModuleOptions>({
     const runtimeConfig = nuxt.options.runtimeConfig as unknown as AgentDiscoveryRuntimeConfig & { public: AgentDiscoveryPublicRuntimeConfig }
 
     const rawPrefix = withoutTrailingSlash(withLeadingSlash(options.rawPrefix || '/raw'))
+    // Normalized, not validated: a pattern without a leading slash can never
+    // match a pathname, and silently emitted a prerender entry of
+    // `/rawabout.md`. The intent is unambiguous, so there is nothing to warn
+    // about.
     const routes: AgentRoute[] = (options.routes?.length ? options.routes : ['/', '/**'])
       .map(route => typeof route === 'string' ? { path: route } : route)
+      .map(route => ({ ...route, path: withLeadingSlash(route.path) }))
     // Copied, not aliased. `agent-discovery:extend` lets a site push onto this
     // list, and a `replace` array comes straight from the site's config, which
     // in a monorepo can be one const imported by two apps.
+    // `replace` wins, and saying both is the one case here where the intent is
+    // genuinely unclear, so it is the one worth a warning.
+    for (const [name, option] of [['userAgents', options.userAgents], ['excludePrefixes', options.excludePrefixes]] as const) {
+      if (option?.replace && option.extend?.length) {
+        logger.warn(`\`${name}\` has both \`replace\` and \`extend\`; \`replace\` wins and the extended entries are dropped.`)
+      }
+    }
+
     const userAgents = options.userAgents?.replace
       ? [...options.userAgents.replace]
       : [...AGENT_USER_AGENTS, ...(options.userAgents?.extend || [])]
@@ -373,6 +386,11 @@ declare module 'nitropack/types' {
     'agent-discovery:index': (event: H3Event, index: AgentIndex) => void | Promise<void>
     /** Enriches the served MCP server card with live tools, resources and prompts. */
     'agent-discovery:mcp-server-card': (event: H3Event, card: Record<string, unknown>) => void | Promise<void>
+    /**
+     * Adds to \`sitemap.md\` before it is rendered, for the pages a content
+     * adapter cannot know about. Keyed by section, in the order they appear.
+     */
+    'agent-discovery:sitemap': (event: H3Event, sections: Map<string, { title: string, href: string }[]>) => void | Promise<void>
   }
 }
 
@@ -583,7 +601,11 @@ export {}
       /* ------------------------------ registry ----------------------------- */
 
       const links: DiscoveryLink[] = []
-      if (options.discovery?.sitemapXml) {
+      // Advertised only when something serves it. This module does not generate
+      // `sitemap.xml`, so keying on the option alone meant a zero-config site
+      // pointed agents, the api-catalog and `robots.txt` at a 404. A site that
+      // serves its own can register it through `discovery.links`.
+      if (options.discovery?.sitemapXml !== false && hasNuxtModule('@nuxtjs/sitemap')) {
         links.push({ href: '/sitemap.xml', rel: 'sitemap', type: 'application/xml', title: 'Sitemap (XML)' })
       }
       if (sourcePath && options.sitemap?.markdown) {
@@ -636,7 +658,11 @@ export {}
           throw new Error(`[nuxt-agent-discovery] \`rel="${link.rel}"\` (${link.href}) is not an IANA-registered link relation. Use a registered rel or an absolute URI extension relation.`)
         }
       }
-      config.links.push(...links)
+      // Layer configs concatenate, so a layer and the app both declaring
+      // `/llms.txt` would double it in the `Link` header, the api-catalog and
+      // every error body. First one wins, which keeps the layer's ordering.
+      const seen = new Set<string>()
+      config.links.push(...links.filter(link => !seen.has(`${link.rel} ${link.href}`) && seen.add(`${link.rel} ${link.href}`)))
 
       // `/sitemap.md` is not a page twin: without this a catch-all route
       // pattern rewrites it to `${rawPrefix}/sitemap.md` at the edge and in the

--- a/src/module.ts
+++ b/src/module.ts
@@ -214,6 +214,7 @@ export default defineNuxtModule<ModuleOptions>({
       userAgents,
       excludePrefixes,
       links: [],
+      linkHeader: options.discovery?.link !== false,
       cachedRoutes: [],
       sitemapSections: {
         expand: (typeof options.sitemap?.markdown === 'object' && options.sitemap.markdown.expand) || [],
@@ -608,24 +609,34 @@ export {}
 
       /* ----------------------------- route rules ---------------------------- */
 
-      const headerRules: Record<string, { headers: Record<string, string> }> = {}
-      for (const route of routes) {
-        headerRules[route.path] = { headers: { Vary: MARKDOWN_VARY } }
-        if (!route.path.includes('*') && route.path !== '/') {
-          headerRules[`${route.path}.md`] = { headers: { Vary: MARKDOWN_VARY } }
-        }
+      // Only the `Link` header, and only on `/`. `Vary` used to be written here
+      // too, once per configured pattern, which under the default `/**` became
+      // a `routeRules` entry matching every path on the site: assets, the API,
+      // `/llms.txt`, `/robots.txt`. A route rule cannot express an exclusion,
+      // so the header now comes from the negotiation middleware, which already
+      // knows exactly which paths have two representations.
+      if (config.linkHeader && config.links.length) {
+        nuxt.options.routeRules = defu(nuxt.options.routeRules, {
+          '/': { headers: { Vary: MARKDOWN_VARY, Link: formatLinkHeader(config.links) } }
+        })
       }
-      headerRules[`${rawPrefix}/**`] = { headers: { Vary: MARKDOWN_VARY } }
-      if (options.discovery?.link !== false && config.links.length) {
-        headerRules['/'] = { headers: { Vary: MARKDOWN_VARY, Link: formatLinkHeader(config.links) } }
-      }
-      nuxt.options.routeRules = defu(nuxt.options.routeRules, headerRules)
 
       // A cached response cannot vary on Accept/User-Agent, so request-time
       // negotiation is disabled there. The CDN rewrites still cover those
       // pages because they run before the cache.
       for (const [key, rule] of Object.entries(nuxt.options.routeRules || {})) {
-        if (!rule || !(rule.isr || rule.swr || 'cache' in rule)) {
+        // Every shape Nitro turns into a response cache, read the way Nitro
+        // reads it. `isr: 0` and `swr: 0` are not one: the Vercel builder skips
+        // a falsy `isr` outright and `normalizeRouteRules` only configures a
+        // cache for a truthy `swr`, so no cached asset is ever written. A bare
+        // `'cache' in rule` counted `cache: false`, an opt-out, as a cache.
+        // `static` is the legacy Vercel spelling that `deprecateSWR` turns into
+        // `isr: !static`, so `static: false` is a real ISR route no other key
+        // here names; it is inert under `future.nativeSWR`, which errs towards
+        // a redirect and is the safe direction.
+        const cached = rule && (rule.isr || rule.swr || rule.cache
+          || ('static' in rule && !(rule as { static?: boolean | number }).static))
+        if (!cached) {
           continue
         }
         // Excluded prefixes never negotiate, so their caches are safe.

--- a/src/module.ts
+++ b/src/module.ts
@@ -538,6 +538,56 @@ export {}
       llmsOptions.llms = { ...llmsOptions.llms, contentRawMarkdown: false }
     }
 
+    /**
+     * Route-rule patterns with a response cache that a negotiated pattern
+     * reaches, which decide where the CDN redirects instead of rewriting.
+     *
+     * Run twice: once at `modules:done`, and again at `nitro:init` for the
+     * rules that do not exist yet at the first pass. A page calling
+     * `defineRouteRules({ isr })` under `experimental.inlineRouteRules` is
+     * applied through `nitro.updateConfig` after every module has set up, and
+     * missing it means emitting a URL-preserving rewrite onto a route that
+     * really is cached, which is the one error here that poisons a cache.
+     */
+    const collectCachedRoutes = () => {
+      for (const [key, rule] of Object.entries(nuxt.options.routeRules || {})) {
+        if (config.cachedRoutes.includes(key)) {
+          continue
+        }
+        // Every shape Nitro turns into a response cache, read the way Nitro
+        // reads it. `isr: 0` and `swr: 0` are not one: the Vercel builder skips
+        // a falsy `isr` outright and `normalizeRouteRules` only configures a
+        // cache for a truthy `swr`, so no cached asset is ever written. A bare
+        // `'cache' in rule` counted `cache: false`, an opt-out, as a cache.
+        // `static` is the legacy Vercel spelling that `deprecateSWR` turns into
+        // `isr: !static`, so `static: false` is a real ISR route no other key
+        // here names; it is inert under `future.nativeSWR`, which errs towards
+        // a redirect and is the safe direction.
+        const cached = rule && (rule.isr || rule.swr || rule.cache
+          || ('static' in rule && !(rule as { static?: boolean | number }).static))
+        if (!cached) {
+          continue
+        }
+        // Excluded prefixes never negotiate, so their caches are safe.
+        if (config.excludePrefixes.some(prefix => staticPrefix(key).startsWith(prefix)) || staticPrefix(key).startsWith(`${rawPrefix}/`)) {
+          continue
+        }
+        // The question is whether the path negotiates at all, which for an
+        // exact rule is `matchRoute`, not `patternsOverlap`: overlap puts
+        // every path under a `/` pattern, so a non-page rule like
+        // `/llms.txt` joined the list and the CDN gave it a 307 to a
+        // `/raw/llms.txt.md` that does not exist. A dotted last segment is an
+        // asset either way, the same rule `negotiatedRawPath` applies.
+        const negotiable = key.includes('*')
+          ? routes.some(route => patternsOverlap(key, route.path))
+          : Boolean(matchRoute(routes, key)) && !hasFileExtension(key)
+        if (negotiable) {
+          config.cachedRoutes.push(key)
+          logger.info(`Route rule \`${key}\` has a response cache: request-time markdown negotiation is disabled there, and the CDN routes redirect to the raw markdown instead of rewriting.`)
+        }
+      }
+    }
+
     nuxt.hook('modules:done', async () => {
       // Prerendered documents bake the site URL in, so resolve it from the
       // site config or the llms domain when not set explicitly. Request-time
@@ -645,9 +695,13 @@ export {}
       if (sourcePath && options.sitemap?.markdown) {
         links.push({ href: '/sitemap.md', rel: 'sitemap', type: 'text/markdown', title: 'Sitemap (Markdown): every page on the site' })
       }
-      if (options.discovery?.apiCatalog) {
-        links.push({ href: '/.well-known/api-catalog', rel: 'api-catalog', type: 'application/linkset+json', title: 'API catalog: every service document this site publishes' })
-      }
+      // Advertised only once something would be in it. The catalog groups the
+      // links carrying an `anchor` with a `service-desc`/`service-doc` rel, and
+      // a site with none of `nuxt-llms`, skills or an MCP card has no such
+      // link: the route answered `{"linkset":[]}` while the `Link` header on
+      // `/` pointed agents at it. Registered further down, once the rest of the
+      // registry is known.
+      const catalogLink: DiscoveryLink = { href: '/.well-known/api-catalog', rel: 'api-catalog', type: 'application/linkset+json', title: 'API catalog: every service document this site publishes' }
       if (options.discovery?.mcpServerCard) {
         const card = options.discovery.mcpServerCard
         const endpoint = card.endpoint.startsWith('/') ? `${config.siteUrl}${card.endpoint}` : card.endpoint
@@ -686,6 +740,11 @@ export {}
       links.push(...(options.discovery?.links || []))
 
       await nuxt.callHook('agent-discovery:extend', { links, userAgents })
+
+      // After the hook, so a link contributed by another module counts too.
+      if (options.discovery?.apiCatalog && links.some(link => link.anchor && (link.rel === 'service-desc' || link.rel === 'service-doc'))) {
+        links.unshift(catalogLink)
+      }
 
       for (const link of links) {
         if (!isValidRel(link.rel)) {
@@ -727,39 +786,7 @@ export {}
       // A cached response cannot vary on Accept/User-Agent, so request-time
       // negotiation is disabled there. The CDN rewrites still cover those
       // pages because they run before the cache.
-      for (const [key, rule] of Object.entries(nuxt.options.routeRules || {})) {
-        // Every shape Nitro turns into a response cache, read the way Nitro
-        // reads it. `isr: 0` and `swr: 0` are not one: the Vercel builder skips
-        // a falsy `isr` outright and `normalizeRouteRules` only configures a
-        // cache for a truthy `swr`, so no cached asset is ever written. A bare
-        // `'cache' in rule` counted `cache: false`, an opt-out, as a cache.
-        // `static` is the legacy Vercel spelling that `deprecateSWR` turns into
-        // `isr: !static`, so `static: false` is a real ISR route no other key
-        // here names; it is inert under `future.nativeSWR`, which errs towards
-        // a redirect and is the safe direction.
-        const cached = rule && (rule.isr || rule.swr || rule.cache
-          || ('static' in rule && !(rule as { static?: boolean | number }).static))
-        if (!cached) {
-          continue
-        }
-        // Excluded prefixes never negotiate, so their caches are safe.
-        if (config.excludePrefixes.some(prefix => staticPrefix(key).startsWith(prefix)) || staticPrefix(key).startsWith(`${rawPrefix}/`)) {
-          continue
-        }
-        // The question is whether the path negotiates at all, which for an
-        // exact rule is `matchRoute`, not `patternsOverlap`: overlap puts
-        // every path under a `/` pattern, so a non-page rule like
-        // `/llms.txt` joined the list and the CDN gave it a 307 to a
-        // `/raw/llms.txt.md` that does not exist. A dotted last segment is an
-        // asset either way, the same rule `negotiatedRawPath` applies.
-        const negotiable = key.includes('*')
-          ? routes.some(route => patternsOverlap(key, route.path))
-          : Boolean(matchRoute(routes, key)) && !hasFileExtension(key)
-        if (negotiable) {
-          config.cachedRoutes.push(key)
-          logger.info(`Route rule \`${key}\` has a response cache: request-time markdown negotiation is disabled there, and the CDN routes redirect to the raw markdown instead of rewriting.`)
-        }
-      }
+      collectCachedRoutes()
 
       /* ---------------------------- runtime config --------------------------- */
 
@@ -788,6 +815,11 @@ export {}
 
     if (negotiates) {
       nuxt.hook('nitro:init', (nitro) => {
+        // Once more before the preset reads the config: a page-level
+        // `defineRouteRules({ isr })` is merged in after every module has set
+        // up, so the first pass never saw it and the pattern would get a
+        // URL-preserving rewrite onto a route that really is cached.
+        collectCachedRoutes()
         setupVercelPreset(nitro, config)
       })
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -155,6 +155,25 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt: '>=3.0.0'
     }
   },
+  /**
+   * `@nuxt/content` is optional, so this never installs it: with
+   * `optional: true` Nuxt validates the version when the package is there and
+   * skips the entry entirely when it is not.
+   *
+   * Worth declaring because this module reaches into v3 internals rather than a
+   * public API, and every one of those failures is silent. It imports
+   * `@nuxt/content/server` and `#content/manifest`, resolves `minimark/stringify`
+   * out of the installed copy, and removes the llms feature's nitro plugin by
+   * matching the path it registers. A major bump moves any of those and the
+   * site keeps building, with `llms.txt` quietly carrying duplicate sections.
+   *
+   * Nothing else here gets a constraint: the other peers are reached through
+   * documented hooks, and capping a 0.x range would cost every adopter a
+   * release for a breakage that has not happened.
+   */
+  moduleDependencies: {
+    '@nuxt/content': { version: '^3.0.0', optional: true }
+  },
   defaults: {
     siteUrl: '',
     siteName: '',

--- a/src/module.ts
+++ b/src/module.ts
@@ -537,8 +537,22 @@ export {}
       // the configured value, so a path would end up in the middle of the URL.
       // Failing at build is better than shipping documents whose every link is
       // silently wrong.
-      if (config.siteUrl && new URL(config.siteUrl).pathname !== '/') {
-        throw new Error(`[nuxt-agent-discovery] \`siteUrl\` must be an origin, but it carries a path (${config.siteUrl}). Serving the site under a base path is not supported yet.`)
+      if (config.siteUrl) {
+        // Parsed defensively: `site.url` is commonly written without a scheme,
+        // and `new URL('example.com')` throws a bare `Invalid URL` that names
+        // neither the option nor this module.
+        let parsed: URL | undefined
+        try {
+          parsed = new URL(config.siteUrl)
+        } catch {
+          parsed = undefined
+        }
+        if (!parsed) {
+          throw new Error(`[nuxt-agent-discovery] \`siteUrl\` is not a valid URL (${config.siteUrl}). Give it a scheme, as in \`https://example.com\`.`)
+        }
+        if (parsed.pathname !== '/') {
+          throw new Error(`[nuxt-agent-discovery] \`siteUrl\` must be an origin, but it carries a path (${config.siteUrl}). Serving the site under a base path is not supported yet.`)
+        }
       }
 
       // Prerendered documents bake this in, and the prerenderer sends no host

--- a/src/module.ts
+++ b/src/module.ts
@@ -167,9 +167,10 @@ export default defineNuxtModule<ModuleOptions>({
    * matching the path it registers. A major bump moves any of those and the
    * site keeps building, with `llms.txt` quietly carrying duplicate sections.
    *
-   * Nothing else here gets a constraint: the other peers are reached through
-   * documented hooks, and capping a 0.x range would cost every adopter a
-   * release for a breakage that has not happened.
+   * Deliberately duplicates the `peerDependencies` range, which a package
+   * manager only warns about: keep the two in step when bumping. Nothing else
+   * gets an entry here, because every other integration fails loudly enough
+   * that the install-time warning is the right amount of noise.
    */
   moduleDependencies: {
     '@nuxt/content': { version: '^3.0.0', optional: true }

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -27,21 +27,24 @@ interface RouteMatcher {
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /**
- * `Accept` values that explicitly refuse markdown, as an anchored RE2 pattern:
- * a `text/markdown` range carrying `q=0`, with or without trailing zeroes, and
+ * `Accept` values that explicitly refuse markdown, as an anchored pattern: a
+ * `text/markdown` range carrying `q=0`, with or without trailing zeroes, and
  * whatever follows it.
  *
  * The negotiation core reads q-values per RFC 9110, so the Nitro middleware
  * serves HTML for `Accept: text/markdown;q=0, text/html`. A CDN matcher is a
- * plain regex over the raw header, and Vercel runs RE2, so there is no
- * lookahead to say "markdown, but not at q=0" in a `has` matcher. A `missing`
- * matcher says it directly: the rewrite applies only when this does not match,
- * which is confirmed against a real Vercel edge and not just the emitted config.
+ * plain regex over the raw header, with no way to express "markdown, but not at
+ * q=0" as a positive match. A `missing` matcher says it directly: the rewrite
+ * applies only when this does not match. Confirmed against a real Vercel edge,
+ * which anchors the value and matches it case-insensitively.
  *
  * `q=0.5` and friends must not match, hence the `(\.0+)?` rather than a loose
- * tail, and the boundary that follows keeps `q=0.05` (a real quality) out.
+ * tail, and the boundary that follows keeps `q=0.05` (a real quality) out. The
+ * whitespace before that boundary is load-bearing: RFC 9110 allows spaces
+ * around a list separator, and without it `text/markdown;q=0 , text/html` was
+ * served markdown by the edge after explicitly refusing it.
  */
-const REFUSES_MARKDOWN = String.raw`.*text/markdown\s*;\s*[qQ]=0(\.0+)?([;,].*)?`
+const REFUSES_MARKDOWN = String.raw`.*text/markdown\s*;\s*[qQ]=0(\.0+)?(\s*[;,].*)?`
 
 /** `has` matcher for the Vercel Build Output API, which anchors the value. */
 function agentUserAgentPattern(config: NegotiationConfig): string {
@@ -109,14 +112,34 @@ function negotiatedRoute(src: string, dest: string, has: RouteMatcher[], cached:
  * their 307 carries `Vary` itself, so the HTML variant is labelled as well.
  */
 export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
-  const acceptMarkdown = { type: 'header', key: 'accept', value: '(.*)text/markdown(.*)' }
+  // `text/markdown` at the head of a media range, not anywhere in the header.
+  // A bare substring also matched it inside a parameter value, so
+  // `Accept: text/html;profile="text/markdown"` was served markdown.
+  const acceptMarkdown = { type: 'header', key: 'accept', value: String.raw`(.*,)?\s*text/markdown\s*([;,].*)?` }
   // Only on the `Accept` routes. A known agent user agent gets markdown
   // whatever its `Accept` says, which is what the negotiation core does too.
   const refusesMarkdown = [{ type: 'header', key: 'accept', value: REFUSES_MARKDOWN }]
-  const agentUserAgent = { type: 'header', key: 'user-agent', value: agentUserAgentPattern(config) }
+  // An empty list has no matcher, not an empty alternation: `.*().*` matches
+  // every user agent there is, so `userAgents: { replace: [] }` served markdown
+  // to browsers at the edge while the runtime correctly matched nothing.
+  const agentUserAgent = config.userAgents.length
+    ? { type: 'header', key: 'user-agent', value: agentUserAgentPattern(config) }
+    : undefined
   const excluded = excludeLookahead(config)
 
   const routes: VercelRoute[] = []
+
+  /**
+   * One negotiated pattern: the `Accept` route, then the agent one. A site that
+   * emptied the user-agent list gets the first only, rather than an empty
+   * alternation that matches every client.
+   */
+  const pushNegotiated = (src: string, dest: string, cached: boolean) => {
+    routes.push(negotiatedRoute(src, dest, [acceptMarkdown], cached, refusesMarkdown))
+    if (agentUserAgent) {
+      routes.push(negotiatedRoute(src, dest, [agentUserAgent], cached))
+    }
+  }
 
   // Tell CDNs the response depends on `Accept` / `User-Agent`, then keep
   // routing. The dotted-segment lookahead is what keeps this off the documents
@@ -176,10 +199,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
       ? rawDestination(config, matched, rule)
       : `${config.rawPrefix}${patternDest(rule)}.md`
 
-    routes.push(
-      negotiatedRoute(src, dest, [acceptMarkdown], true, refusesMarkdown),
-      negotiatedRoute(src, dest, [agentUserAgent], true)
-    )
+    pushNegotiated(src, dest, true)
   }
 
   for (const route of config.routes) {
@@ -200,21 +220,17 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
       })
       // The dotted-last-segment lookahead keeps `.md` URLs on the rewrite above
       // and assets (`_payload.json`, images) out.
-      const negotiatedSrc = `^${NO_DOTTED_LAST_SEGMENT}${excluded}${body}$`
-      routes.push(
-        negotiatedRoute(negotiatedSrc, dest, [acceptMarkdown], cached, refusesMarkdown),
-        negotiatedRoute(negotiatedSrc, dest, [agentUserAgent], cached)
-      )
+      pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${body}$`, dest, cached)
     } else {
       const dest = rawDestination(config, route, route.path)
-      const src = `^${escapeRegExp(route.path)}$`
       if (route.path !== '/') {
         routes.push({ src: `^${escapeRegExp(route.path)}\\.md$`, dest })
       }
-      routes.push(
-        negotiatedRoute(src, dest, [acceptMarkdown], cached, refusesMarkdown),
-        negotiatedRoute(src, dest, [agentUserAgent], cached)
-      )
+      // The same two guards the wildcard branch carries. Without them an exact
+      // pattern negotiated at the edge where the runtime refuses it: a dotted
+      // one like `/faq.html` reads as an asset, and `/mcp` sits behind an
+      // excluded prefix.
+      pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${escapeRegExp(route.path)}/?$`, dest, cached)
     }
   }
 
@@ -229,7 +245,11 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
  * https://vercel.com/docs/build-output-api/configuration
  */
 export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig) {
-  if (nitro.options.dev || !nitro.options.preset.includes('vercel')) {
+  // `nuxt generate` on Vercel resolves the `vercel-static` preset, whose name
+  // contains "vercel" but which emits no function routes at all. Patching the
+  // table there leaves rewrites pointing at a filesystem that only holds what
+  // was prerendered, with nothing behind them to fall through to.
+  if (nitro.options.dev || nitro.options.static || !nitro.options.preset.includes('vercel')) {
     return
   }
   nitro.hooks.hook('compiled', async () => {

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'pathe'
 import { readFile, writeFile } from 'node:fs/promises'
 import type { Nitro } from 'nitropack'
-import { compilePattern, formatLinkHeader, matchRoute, patternsOverlap, rawDestination, staticPrefix, MARKDOWN_VARY } from '../runtime/shared/negotiation'
+import { compilePattern, formatLinkHeader, matchRoute, patternsOverlap, rawDestination, ruleCoversPattern, MARKDOWN_VARY } from '../runtime/shared/negotiation'
 import type { NegotiationConfig } from '../runtime/shared/types'
 
 export interface VercelRoute {
@@ -118,25 +118,22 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
 
   const routes: VercelRoute[] = []
 
-  // Tell CDNs the response depends on `Accept` / `User-Agent`, then keep routing.
-  const varySources = config.routes.flatMap((route) => {
-    const body = compilePattern(route.path).source.slice(1, -1)
-    const sources = [body]
-    // Exact patterns also cover their `.md` twin; wildcards already do.
-    if (!route.path.includes('*') && route.path !== '/') {
-      sources.push(`${escapeRegExp(route.path)}\\.md`)
-    }
-    return sources
-  })
+  // Tell CDNs the response depends on `Accept` / `User-Agent`, then keep
+  // routing. The dotted-segment lookahead is what keeps this off the documents
+  // that have a single representation: without it this route labelled
+  // `/llms.txt`, `/robots.txt`, `/sitemap.xml` and every file in `public/`,
+  // which fragments a shared cache per user-agent for nothing. `.md` twins are
+  // excluded by the same rule, and want to be: that URL only serves markdown.
+  const varySources = config.routes.map(route => compilePattern(route.path).source.slice(1, -1))
   routes.push({
-    src: `^${excluded}(?:${varySources.join('|')})$`,
+    src: `^${NO_DOTTED_LAST_SEGMENT}${excluded}(?:${varySources.join('|')})$`,
     headers: { Vary: MARKDOWN_VARY },
     continue: true
   })
 
   // The `/` routeRule carries the same `Link` header, but a homepage request
   // rewritten below to a prerendered raw markdown file never reaches it.
-  const linkHeader = formatLinkHeader(config.links)
+  const linkHeader = config.linkHeader ? formatLinkHeader(config.links) : ''
   if (linkHeader) {
     routes.push({
       src: '^/$',
@@ -145,22 +142,30 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     })
   }
 
+  // Whether a rule covers a whole pattern, so the pattern itself is demoted to
+  // a redirect. Comparing static-prefix lengths instead used to tie `/` with
+  // `/**`, so a single cached homepage demoted every page on the site.
+  const patternCached = (pattern: string) => config.cachedRoutes.some(rule => ruleCoversPattern(rule, pattern))
+
   // A cached rule narrower than the pattern covering it, `routeRules['/docs/**']`
   // under the default `/**`, gets its own 307 pair ahead of that pattern's
   // rewrite. Marking the whole pattern cached instead would demote every page on
   // the site to a redirect because one section happens to be cached.
   for (const rule of config.cachedRoutes) {
-    const covered = config.routes.filter(route => patternsOverlap(rule, route.path))
-    if (!covered.length || !covered.every(route => staticPrefix(rule).length > staticPrefix(route.path).length)) {
-      continue
-    }
-
     // An exact rule is only negotiable through the route it matches. Without
     // one there is no twin to send the client to, and inventing a
     // `rawPrefix + rule + '.md'` destination 307s to a URL that 404s.
     const wildcard = rule.includes('*')
     const matched = wildcard ? undefined : matchRoute(config.routes, rule)
-    if (!wildcard && !matched) {
+
+    // This loop handles what a rule caches *beyond* the patterns it fully
+    // covers; those are demoted wholesale below. Skipping a rule with nothing
+    // left over is what keeps a path from collecting two redirects.
+    if (wildcard) {
+      if (!config.routes.some(route => patternsOverlap(rule, route.path) && !patternCached(route.path))) {
+        continue
+      }
+    } else if (!matched || patternCached(matched.path)) {
       continue
     }
 
@@ -182,7 +187,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     // handled above, so this pattern keeps its rewrite for everything outside
     // it. The `.md` twins stay rewrites either way: that URL only ever serves
     // markdown, so there is no second variant to poison.
-    const cached = config.cachedRoutes.some(rule => patternsOverlap(rule, route.path) && staticPrefix(rule).length <= staticPrefix(route.path).length)
+    const cached = patternCached(route.path)
 
     if (route.path.includes('*')) {
       const body = compilePattern(route.path).source.slice(1, -1)

--- a/src/runtime/server/error.ts
+++ b/src/runtime/server/error.ts
@@ -54,7 +54,8 @@ const errorHandler: NitroErrorHandler = async (error, event, { defaultHandler })
   return send(event, errorMarkdown(config, {
     path: typeof data?.path === 'string' ? data.path : event.path,
     status,
-    // Already passed through h3's status message sanitizer.
+    // Not sanitized on the way here: `createError` only warns about an unsafe
+    // status message, and Nitro returns it verbatim. `errorMarkdown` strips it.
     statusMessage: res.statusText,
     siteUrl: config.siteUrl || getRequestURL(event).origin
   }))

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -1,7 +1,7 @@
 import { appendResponseHeader, createError, defineEventHandler, getRequestHeader, sendRedirect, setResponseHeader, setResponseStatus } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
-import { matchRoute, negotiatedRawPath, normalizePathname, MARKDOWN_VARY } from '../../shared/negotiation'
+import { isNegotiablePath, negotiatedRawPath, normalizePathname, ruleMatchesPath, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
  * Serves markdown through content negotiation on the Nitro server.
@@ -34,6 +34,16 @@ export default defineEventHandler(async (event) => {
   })
 
   if (!rawPath) {
+    // The HTML half of a page that has both representations. Its markdown half
+    // is labelled further down, and a shared cache that stored this one without
+    // `Vary` would replay the HTML to an agent asking for markdown.
+    //
+    // Set here rather than through a `routeRules` header: a route rule cannot
+    // express a negative pattern, so a catch-all pattern labelled every asset,
+    // every discovery document and the whole API surface as varying.
+    if (isNegotiablePath(config, event.path)) {
+      setResponseHeader(event, 'Vary', MARKDOWN_VARY)
+    }
     return
   }
 
@@ -49,8 +59,8 @@ export default defineEventHandler(async (event) => {
   // and passes the incoming query on to the destination, so both paths land on
   // the same URL for a page whose content is its query.
   const pathname = normalizePathname(event.path)
-  if (!import.meta.dev && !pathname.endsWith('.md') && config.cachedRoutes.length
-    && matchRoute(config.cachedRoutes.map(path => ({ path })), pathname)) {
+  if (!import.meta.dev && !pathname.endsWith('.md')
+    && config.cachedRoutes.some(rule => ruleMatchesPath(rule, pathname))) {
     const query = event.path.slice(event.path.indexOf('?') + 1)
     setResponseHeader(event, 'Vary', MARKDOWN_VARY)
     return sendRedirect(event, event.path.includes('?') ? `${rawPath}?${query}` : rawPath, 307)
@@ -85,7 +95,12 @@ export default defineEventHandler(async (event) => {
 
   setResponseStatus(event, response.status)
   setResponseHeader(event, 'Content-Type', response.headers.get('content-type') || 'text/markdown; charset=utf-8')
-  setResponseHeader(event, 'Vary', MARKDOWN_VARY)
+  // The markdown half of a page that also has an HTML one. An explicit `.md`
+  // URL reaches here too and is not labelled: it serves markdown to every
+  // client, so nothing about it depends on the request headers.
+  if (isNegotiablePath(config, event.path)) {
+    setResponseHeader(event, 'Vary', MARKDOWN_VARY)
+  }
 
   for (const name of ['cache-control', 'x-content-type-options', 'x-frame-options', 'referrer-policy']) {
     const value = response.headers.get(name)

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -76,7 +76,14 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const response = await useNitroApp().localFetch(rawPath, { headers })
+  // The query rides along: the CDN re-attaches it to a rewrite destination for
+  // free, and the redirect branch above does it by hand, so a source whose
+  // pages depend on the query has to see it here too.
+  const queryIndex = event.path.indexOf('?')
+  const response = await useNitroApp().localFetch(
+    queryIndex === -1 ? rawPath : `${rawPath}${event.path.slice(queryIndex)}`,
+    { headers }
+  )
 
   // The inner request has already handled and logged the original failure
   // against the raw path; rethrowing reports the status on the path the

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -6,6 +6,7 @@ import { defineNitroPlugin } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
 import type { AgentListEntry } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
+import { getSourcePage } from '../utils/document'
 import { hasFileExtension, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 interface LlmsSection {
@@ -85,10 +86,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       // something it can resolve.
       const unresolved: LlmsSection[] = []
       for (const section of options.sections) {
-        if (section.links?.length || !source.list) {
+        if (section.links?.length) {
           continue
         }
-        const entries = await source.list(event, section as unknown as Record<string, unknown>)
+        const entries = await source.list(section as unknown as Record<string, unknown>, event)
         if (entries?.length) {
           section.links = entries.map(entry => toLink(entry, domain))
         } else if (!section.description) {
@@ -107,9 +108,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       // not count as an otherwise empty document having content.
       const hasPageLinks = options.sections.some(section => section.links?.some(link => isPageLink(link.href, domain)))
       if (!hasPageLinks) {
-        const entries = source.list
-          ? (await source.list(event)) || []
-          : (await source.routes(event)).map(route => ({ route }) as AgentListEntry)
+        const entries = (await source.list(undefined, event)) || []
         for (const [title, group] of groupBySection(entries)) {
           options.sections.push({
             title,
@@ -180,25 +179,23 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       }
     }
 
-    if (source.list) {
-      for (const section of options.sections || []) {
-        const entries = await source.list(event, section as unknown as Record<string, unknown>)
-        for (const entry of entries || []) {
-          add(entry.route)
-        }
+    for (const section of options.sections || []) {
+      const entries = await source.list(section as unknown as Record<string, unknown>, event)
+      for (const entry of entries || []) {
+        add(entry.route)
       }
     }
     // A site declaring no resolvable section still wants its whole site.
     if (!routes.length) {
-      for (const route of await source.routes(event)) {
-        add(route)
+      for (const entry of (await source.list(undefined, event)) || []) {
+        add(entry.route)
       }
     }
 
     // The same `get()` the raw route calls, so a page reads identically whether
     // an agent fetches `/raw/**.md` or the single full document.
     for (const route of routes) {
-      const page = await source.get(route, event)
+      const page = await getSourcePage(route, event)
       if (page?.markdown) {
         contents.push(page.markdown)
       }

--- a/src/runtime/server/routes/mcp-server-card.ts
+++ b/src/runtime/server/routes/mcp-server-card.ts
@@ -43,8 +43,12 @@ export default defineEventHandler(async (event) => {
   const siteUrl = getAgentSiteUrl(event)
   const absolute = (href: string) => href.startsWith('/') ? `${siteUrl}${href}` : href
 
+  // No `$schema`: the URL this used to carry 404s, and so does the one the
+  // draft that would define it (SEP-2127) proposes, because that draft is
+  // unmerged. The released MCP spec has no server card, so the shape below is
+  // pre-standard by nature and advertising a schema it cannot be checked
+  // against is worse than advertising none.
   const serverCard: Record<string, unknown> = {
-    $schema: 'https://modelcontextprotocol.io/schema/server-card/v1',
     serverInfo: {
       name: card.name,
       ...(card.version ? { version: card.version } : {}),
@@ -74,7 +78,9 @@ export default defineEventHandler(async (event) => {
     }
     // Groups come from the subdirectory a definition sits in, which is how a
     // site separates its admin tools from the ones anybody may call.
-    const excluded = new Set(card.excludeGroups ?? ['admin'])
+    // Extends the default rather than replacing it: a site naming its own
+    // private group should not silently start publishing its admin tools.
+    const excluded = new Set(['admin', ...(card.excludeGroups ?? [])])
     const isPublic = (definition: McpDefinition) => !definition.group || !excluded.has(definition.group)
 
     serverCard.capabilities = {

--- a/src/runtime/server/routes/raw.ts
+++ b/src/runtime/server/routes/raw.ts
@@ -1,8 +1,8 @@
 import { createError, defineEventHandler, sendRedirect, setResponseHeader } from 'h3'
 import source from '#agent-discovery/source'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
-import { getAgentDocument, normalizeAgentRoute } from '../utils/document'
-import { normalizePathname } from '../../shared/negotiation'
+import { getAgentDocument } from '../utils/document'
+import { normalizeAgentRoute, normalizePathname } from '../../shared/negotiation'
 
 /**
  * Serves the raw markdown representation of a page from the content adapter.

--- a/src/runtime/server/routes/raw.ts
+++ b/src/runtime/server/routes/raw.ts
@@ -2,7 +2,7 @@ import { createError, defineEventHandler, sendRedirect, setResponseHeader } from
 import source from '#agent-discovery/source'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { getAgentDocument } from '../utils/document'
-import { normalizeAgentRoute, normalizePathname } from '../../shared/negotiation'
+import { normalizePathname } from '../../shared/negotiation'
 
 /**
  * Serves the raw markdown representation of a page from the content adapter.
@@ -25,7 +25,9 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Page Not Found', data: { path: event.path } })
   }
 
-  const path = normalizeAgentRoute(slug.slice(0, -3))
+  // Left unnormalized: `getAgentDocument` owns that, and decoding here as well
+  // would decode a doubly-encoded path twice, resolving it to a different page.
+  const path = slug.slice(0, -3)
   const document = await getAgentDocument(event, path)
 
   if (!document) {

--- a/src/runtime/server/routes/sitemap.md.ts
+++ b/src/runtime/server/routes/sitemap.md.ts
@@ -1,4 +1,5 @@
 import { defineEventHandler, setResponseHeader } from 'h3'
+import { useNitroApp } from 'nitropack/runtime'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { listAgentPages } from '../utils/pages'
 
@@ -44,6 +45,11 @@ export default defineEventHandler(async (event) => {
     }
     sections.get(key)!.push({ title: entry.title || entry.route, href })
   }
+
+  // The content adapter only knows the pages it holds. A site with hand-written
+  // routes, a Vue-rendered showcase or a design document has no other way to
+  // put them in the index an agent reads first.
+  await useNitroApp().hooks.callHook('agent-discovery:sitemap', event, sections)
 
   const siteName = config.siteName || new URL(siteUrl).hostname
   const lines: string[] = [

--- a/src/runtime/server/routes/skills-files.ts
+++ b/src/runtime/server/routes/skills-files.ts
@@ -32,7 +32,13 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'Not Found' })
   }
 
-  const path = decodeURIComponent(pathname.slice(index + prefix.length))
+  let path: string
+  try {
+    path = decodeURIComponent(pathname.slice(index + prefix.length))
+  } catch {
+    // A malformed escape (`%`, `%zz`) is a bad request, not a server error.
+    throw createError({ statusCode: 400, statusMessage: 'Bad Request' })
+  }
   if (!path || path.includes('..')) {
     throw createError({ statusCode: 400, statusMessage: 'Bad Request' })
   }

--- a/src/runtime/server/sources/comark.ts
+++ b/src/runtime/server/sources/comark.ts
@@ -26,13 +26,6 @@ interface ComarkLikeContent {
   navigation: () => Promise<ComarkNavigationItem[]>
 }
 
-function requireEvent(event?: H3Event): H3Event {
-  if (!event) {
-    throw new Error('[nuxt-agent-discovery] the comark source needs the request event')
-  }
-  return event
-}
-
 /** What a `llms.sections` entry may name for this adapter. */
 interface ComarkSelector {
   /** Navigation path whose subtree the section lists, e.g. `/getting-started`. */
@@ -78,20 +71,13 @@ function findNode(items: ComarkNavigationItem[], path: string): ComarkNavigation
  * export default createComarkSource(() => getProdContent())
  * ```
  */
-export function createComarkSource(getContent: (event?: H3Event) => Promise<ComarkLikeContent> | ComarkLikeContent): AgentContentSource {
+export function createComarkSource(getContent: (event: H3Event) => Promise<ComarkLikeContent> | ComarkLikeContent): AgentContentSource {
   return {
-    async routes(event?: H3Event) {
-      const content = await getContent(event)
-      const entries: AgentListEntry[] = []
-      collect(await content.navigation(), entries)
-      return [...new Set(entries.map(entry => entry.route))]
-    },
-
     /**
      * With no selector, every page grouped by its top-level navigation node.
      * With `{ navigation: '/path' }`, that subtree only.
      */
-    async list(event?: H3Event, selector?: AgentSectionSelector) {
+    async list(selector: AgentSectionSelector | undefined, event: H3Event) {
       const { navigation } = (selector || {}) as ComarkSelector
       if (selector && !navigation) {
         return null
@@ -118,7 +104,7 @@ export function createComarkSource(getContent: (event?: H3Event) => Promise<Coma
      * A directory node's first page, so `/raw/getting-started.md` redirects to
      * the section's first document the way the HTML page does.
      */
-    async firstLeaf(route: string, event?: H3Event) {
+    async firstLeaf(route: string, event: H3Event) {
       const content = await getContent(event)
       const node = findNode(await content.navigation(), route)
       if (!node) {
@@ -148,7 +134,7 @@ export function createComarkSource(getContent: (event?: H3Event) => Promise<Coma
      * backend changes the adapter and nothing else, and `test/e2e/expected.ts`
      * is what holds them to it.
      */
-    async get(route: string, event?: H3Event) {
+    async get(route: string, event: H3Event) {
       const content = await getContent(event)
       const path = route === '/index' ? '/' : route
       const item = await content.get(path)
@@ -165,7 +151,7 @@ export function createComarkSource(getContent: (event?: H3Event) => Promise<Coma
       // Lets sites transform the document (MDC components → plain markdown)
       // without replacing the whole source. Called before the nodes are read,
       // so a transformer can swap them wholesale.
-      await useNitroApp().hooks.callHook('agent-discovery:document', requireEvent(event), page)
+      await useNitroApp().hooks.callHook('agent-discovery:document', event, page)
 
       const nodes = page.nodes as ComarkNode[]
       const frontmatter = (page.data || {}) as { title?: string, description?: string, links?: unknown }
@@ -203,7 +189,7 @@ export function createComarkSource(getContent: (event?: H3Event) => Promise<Coma
         }
       }
 
-      absolutizeTreeLinks(nodes, getAgentSiteUrl(requireEvent(event)))
+      absolutizeTreeLinks(nodes, getAgentSiteUrl(event))
 
       // `render`, not `renderMarkdown`: the latter routes through
       // `renderFrontmatter`, which re-emits `data` as a YAML block the raw

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -103,6 +103,13 @@ const source: AgentContentSource = {
    */
   async firstLeaf(route: string, event?: H3Event) {
     const prefix = `${withLeadingSlash(route).replace(/\/$/, '')}/`
+    // `%` and `_` are `LIKE` wildcards and the prefix comes from the URL, so
+    // `/raw/%.md` would widen the query to every page in every collection and
+    // materialize them all before the check below throws them away. No real
+    // section path contains either.
+    if (prefix.includes('%') || prefix.includes('_')) {
+      return null
+    }
     for (const collection of pageCollections()) {
       const pages = await queryCollection(requireEvent(event), collection)
         .select('path', 'stem')

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -84,11 +84,12 @@ const source: AgentContentSource = {
    */
   async firstLeaf(route: string, event: H3Event) {
     const prefix = `${withLeadingSlash(route).replace(/\/$/, '')}/`
-    // `%` and `_` are `LIKE` wildcards and the prefix comes from the URL, so
-    // `/raw/%.md` would widen the query to every page in every collection and
-    // materialize them all before the check below throws them away. No real
-    // section path contains either.
-    if (prefix.includes('%') || prefix.includes('_')) {
+    // `%` is a `LIKE` wildcard and the prefix comes from the URL, so `/raw/%.md`
+    // would match every page in every collection and materialize them all
+    // before the check below throws them away. `_` is a wildcard too but only
+    // for a single character, which is a real path character and barely widens
+    // anything, so it stays.
+    if (prefix.includes('%')) {
       return null
     }
     for (const collection of pageCollections()) {

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -31,13 +31,6 @@ function titleCase(value: string): string {
     .replace(/\b\w/g, char => char.toUpperCase())
 }
 
-function requireEvent(event?: H3Event): H3Event {
-  if (!event) {
-    throw new Error('[nuxt-agent-discovery] the @nuxt/content source needs the request event')
-  }
-  return event
-}
-
 /**
  * Built-in `@nuxt/content` v3 adapter: `queryCollection()` over
  * `type: 'page'` collections, stringified with minimark. Mirrors the raw
@@ -45,25 +38,13 @@ function requireEvent(event?: H3Event): H3Event {
  * swapping to this module changes nothing for agents.
  */
 const source: AgentContentSource = {
-  async routes(event?: H3Event) {
-    const paths: string[] = []
-    for (const collection of pageCollections()) {
-      const pages = await queryCollection(requireEvent(event), collection)
-        .select('path')
-        .where('path', 'NOT LIKE', '%/.navigation')
-        .all() as { path: string }[]
-      paths.push(...pages.map(page => page.path))
-    }
-    return [...new Set(paths)]
-  },
-
   /**
    * Reads `contentCollection` and `contentFilters` off the section, the same
    * two keys `@nuxt/content`'s llms feature declared, so a site's existing
    * `llms.sections` config keeps working after this module takes the feature
    * over. A selector naming anything else is not ours.
    */
-  async list(event?: H3Event, selector?: AgentSectionSelector) {
+  async list(selector: AgentSectionSelector | undefined, event: H3Event) {
     const { contentCollection, contentFilters } = (selector || {}) as ContentSelector
     if (selector && !contentCollection) {
       return null
@@ -76,7 +57,7 @@ const source: AgentContentSource = {
 
     const entries: AgentListEntry[] = []
     for (const collection of names) {
-      const query = queryCollection(requireEvent(event), collection)
+      const query = queryCollection(event, collection)
         .select('path', 'title', 'description')
         .where('path', 'NOT LIKE', '%/.navigation')
       for (const filter of contentFilters || []) {
@@ -101,7 +82,7 @@ const source: AgentContentSource = {
    * already dropped, so this lands where the site's own navigation does rather
    * than on whatever sorts first alphabetically.
    */
-  async firstLeaf(route: string, event?: H3Event) {
+  async firstLeaf(route: string, event: H3Event) {
     const prefix = `${withLeadingSlash(route).replace(/\/$/, '')}/`
     // `%` and `_` are `LIKE` wildcards and the prefix comes from the URL, so
     // `/raw/%.md` would widen the query to every page in every collection and
@@ -111,7 +92,7 @@ const source: AgentContentSource = {
       return null
     }
     for (const collection of pageCollections()) {
-      const pages = await queryCollection(requireEvent(event), collection)
+      const pages = await queryCollection(event, collection)
         .select('path', 'stem')
         .where('path', 'LIKE', `${prefix}%`)
         .where('path', 'NOT LIKE', '%/.navigation')
@@ -129,7 +110,7 @@ const source: AgentContentSource = {
     return null
   },
 
-  async get(route: string, event?: H3Event) {
+  async get(route: string, event: H3Event) {
     let path = withLeadingSlash(route)
     if (path.endsWith('/index')) {
       path = path.slice(0, -6) || '/'
@@ -137,7 +118,7 @@ const source: AgentContentSource = {
 
     let page: PageCollectionItemBase | null = null
     for (const collection of pageCollections()) {
-      page = await queryCollection(requireEvent(event), collection).path(path).first() as PageCollectionItemBase | null
+      page = await queryCollection(event, collection).path(path).first() as PageCollectionItemBase | null
       if (page) {
         break
       }
@@ -152,7 +133,7 @@ const source: AgentContentSource = {
 
     // Lets sites transform the minimark tree (MDC components → plain
     // markdown) without replacing the whole source.
-    await useNitroApp().hooks.callHook('agent-discovery:document', requireEvent(event), page)
+    await useNitroApp().hooks.callHook('agent-discovery:document', event, page)
 
     const value = page.body.value as unknown as MinimarkNode[]
 
@@ -187,7 +168,7 @@ const source: AgentContentSource = {
       }
     }
 
-    absolutizeTreeLinks(value, getAgentSiteUrl(requireEvent(event)))
+    absolutizeTreeLinks(value, getAgentSiteUrl(event))
 
     return {
       markdown: stringify({ ...page.body, type: 'minimark' }, { format: 'markdown/html' }),

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -77,7 +77,7 @@ export { agentDiscoveryOpenApi } from './openapi'
 // and the CDN rewrites do. See the "Agent tooling" section of the README.
 export { listAgentPages } from './pages'
 export type { AgentPageListing, AgentPageListOptions } from './pages'
-export { getAgentDocument, normalizeAgentRoute } from './document'
+export { getAgentDocument } from './document'
 export type { AgentDocument, AgentDocumentOptions } from './document'
 export { extractSections } from '../../shared/sections'
 

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -81,11 +81,10 @@ export { getAgentDocument } from './document'
 export type { AgentDocument, AgentDocumentOptions } from './document'
 export { extractSections } from '../../shared/sections'
 
-// Every backend has to end up with absolute links, so both passes are public.
-// `absolutizeTreeLinks` for an adapter holding a document tree (it sees MDC
-// component props, which the markdown scan cannot), `absolutizeMarkdownLinks`
-// for one that renders straight to a string.
-export { absolutizeMarkdownLinks, absolutizeTreeLinks } from '../../shared/negotiation'
+// The absolutization passes are deliberately not exported: the module runs one
+// over whatever `get()` returns, so an adapter that forgets cannot emit
+// relative links, and one that does it anyway is unaffected because the pass is
+// idempotent.
 
 /** Identity helper for typed custom content sources. */
 export function defineAgentContentSource(source: AgentContentSource): AgentContentSource {

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -3,6 +3,7 @@ import { useNitroApp } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
 import { getAgentSiteUrl, renderAgentResources, useAgentDiscoveryConfig } from './agent-discovery'
 import { extractSections } from '../../shared/sections'
+import { normalizeAgentRoute } from '../../shared/negotiation'
 import type { AgentIndex } from '../../shared/types'
 
 /** A resolved markdown document, or where to go instead. */
@@ -61,17 +62,6 @@ async function generatedIndex(event: H3Event, siteUrl: string): Promise<AgentInd
       ''
     ].join('\n')
   }
-}
-
-/**
- * `/foo/index` and `/index` both name `/`, whichever way the URL spelled it.
- */
-export function normalizeAgentRoute(route: string): string {
-  let path = route
-  if (path.endsWith('/index')) {
-    path = path.slice(0, -6) || '/'
-  }
-  return path === '/index' || path === '' ? '/' : path
 }
 
 /**

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -3,8 +3,8 @@ import { useNitroApp } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
 import { getAgentSiteUrl, renderAgentResources, useAgentDiscoveryConfig } from './agent-discovery'
 import { extractSections } from '../../shared/sections'
-import { normalizeAgentRoute } from '../../shared/negotiation'
-import type { AgentIndex } from '../../shared/types'
+import { absolutizeMarkdownLinks, normalizeAgentRoute } from '../../shared/negotiation'
+import type { AgentIndex, AgentPage } from '../../shared/types'
 
 /** A resolved markdown document, or where to go instead. */
 export interface AgentDocument {
@@ -65,6 +65,26 @@ async function generatedIndex(event: H3Event, siteUrl: string): Promise<AgentInd
 }
 
 /**
+ * `source.get()` plus the link absolutization every adapter would otherwise
+ * have to remember.
+ *
+ * A markdown document is read detached from the site it came from, so a
+ * site-relative link in it points nowhere. The built-in adapters already
+ * rewrite their document tree, where they can also see the links in MDC
+ * component props; this pass is idempotent over that, because it only matches a
+ * destination starting with a single slash and those are already absolute.
+ * Doing it here rather than in each adapter is what keeps a custom source from
+ * silently emitting relative links.
+ */
+export async function getSourcePage(route: string, event: H3Event): Promise<AgentPage | null> {
+  const page = await source?.get(route, event)
+  if (!page) {
+    return null
+  }
+  return { ...page, markdown: absolutizeMarkdownLinks(page.markdown, getAgentSiteUrl(event)) }
+}
+
+/**
  * Resolves a page route to the exact document `/raw/<path>.md` serves.
  *
  * The HTTP route is a thin shell over this so that anything else reaching for
@@ -86,7 +106,7 @@ export async function getAgentDocument(event: H3Event, route: string, options: A
   const siteUrl = getAgentSiteUrl(event)
   const canonicalUrl = `${siteUrl}${path === '/' ? '' : path}` || siteUrl
 
-  const page = await source?.get(path, event)
+  const page = await getSourcePage(path, event)
   if (!page) {
     // A path that names a section rather than a page (`/getting-started` with
     // no index) resolves to the section's first document, the same as the

--- a/src/runtime/server/utils/pages.ts
+++ b/src/runtime/server/utils/pages.ts
@@ -45,9 +45,7 @@ export async function listAgentPages(event: H3Event, options: AgentPageListOptio
     return []
   }
 
-  const entries = source.list
-    ? (await source.list(event)) || []
-    : (await source.routes(event)).map(route => ({ route, title: undefined, description: undefined, section: undefined }))
+  const entries = (await source.list(undefined, event)) || []
 
   const config = useAgentDiscoveryConfig(event)
   const siteUrl = getAgentSiteUrl(event)

--- a/src/runtime/server/utils/pages.ts
+++ b/src/runtime/server/utils/pages.ts
@@ -1,6 +1,6 @@
 import type { H3Event } from 'h3'
 import source from '#agent-discovery/source'
-import { getAgentSiteUrl, rawUrl } from './agent-discovery'
+import { getAgentSiteUrl, rawUrl, useAgentDiscoveryConfig } from './agent-discovery'
 
 /** One page in a listing, with both URLs an agent might want. */
 export interface AgentPageListing {
@@ -49,10 +49,16 @@ export async function listAgentPages(event: H3Event, options: AgentPageListOptio
     ? (await source.list(event)) || []
     : (await source.routes(event)).map(route => ({ route, title: undefined, description: undefined, section: undefined }))
 
+  const config = useAgentDiscoveryConfig(event)
   const siteUrl = getAgentSiteUrl(event)
   const terms = options.search?.toLowerCase().split(/\s+/).filter(Boolean) || []
 
   return entries
+    // A path the module refuses to negotiate is not a page as far as the rest
+    // of the module is concerned, so listing it in `sitemap.md` or handing it
+    // to an MCP tool would advertise a markdown twin that does not exist. This
+    // is also how a site keeps a legacy docs version out of both.
+    .filter(entry => !config.excludePrefixes.some(prefix => entry.route.startsWith(prefix)))
     .filter(entry => !options.prefix || entry.route.startsWith(options.prefix))
     .filter((entry) => {
       if (!terms.length) {

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -121,6 +121,52 @@ export function patternsOverlap(a: string, b: string): boolean {
 }
 
 /**
+ * Whether a `routeRules` key covers a path, read the way Nitro reads it rather
+ * than the way this module's own patterns are read.
+ *
+ * Route rules are matched by radix3, where `**` stands for zero or more
+ * segments: `/docs/**` applies to `/docs` itself, and `/**` applies to `/`.
+ * `compilePattern` compiles `**` to `(.+)`, one or more, which is what a page
+ * pattern needs (the capture feeds `/raw/$1.md`) and not what a cache rule
+ * means. Reading a rule with the pattern matcher silently leaves the section
+ * root uncached, which is where a rewrite poisons a cache that really exists.
+ */
+export function ruleMatchesPath(rule: string, pathname: string): boolean {
+  if (rule.endsWith('**')) {
+    return isUnder(pathname, trimSlash(staticPrefix(rule)))
+  }
+  return patternRegExp(rule).test(pathname)
+}
+
+/**
+ * Whether a cached rule covers *every* path a negotiated pattern matches, the
+ * only condition under which the whole pattern may be demoted from a rewrite
+ * to a 307. Anything narrower gets its own pair of routes emitted ahead of the
+ * pattern instead.
+ *
+ * Errs towards `false`, the opposite bias to `patternsOverlap`: a pattern
+ * wrongly left uncovered still gets that rule's own 307, while a pattern
+ * wrongly covered turns every page under it into a redirect.
+ *
+ * A rule carrying a wildcard before its last segment, a locale prefix say,
+ * reports `true` for anything under its static prefix, because `staticPrefix`
+ * cuts at the first wildcard. That is the fail-safe direction and matches what
+ * the preset did before, so it is left alone deliberately.
+ */
+export function ruleCoversPattern(rule: string, pattern: string): boolean {
+  if (rule === pattern) {
+    return true
+  }
+  // A `**` rule owns its whole subtree, so it covers any pattern rooted in it.
+  if (rule.endsWith('**')) {
+    return isUnder(trimSlash(staticPrefix(pattern)), trimSlash(staticPrefix(rule)))
+  }
+  // Anything else matches a bounded set of paths, so it can only cover a
+  // pattern that is itself a single path the rule matches.
+  return !pattern.includes('*') && ruleMatchesPath(rule, pattern)
+}
+
+/**
  * The raw markdown destination for a matched page. `raw` is only honoured on
  * exact patterns; wildcard patterns always map to `rawPrefix + path + '.md'`.
  */
@@ -240,7 +286,9 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
   }
 
   // An explicit `.md` twin URL is a markdown request, whatever the headers
-  // say. A bare `/.md` is not a twin, matching the CDN rewrites.
+  // say. A bare `/.md` is not a twin, matching the CDN rewrites. Handled here
+  // rather than through `negotiableRoute`, whose dotted-segment rule would
+  // read the suffix as an asset.
   if (pathname.endsWith('.md')) {
     const base = pathname.slice(0, -3)
     if (base.length <= 1) {
@@ -254,17 +302,40 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
     return undefined
   }
 
-  const route = matchRoute(config.routes, pathname)
-  if (!route) {
+  const route = negotiableRoute(config, pathname)
+  return route ? rawDestination(config, route, pathname) : undefined
+}
+
+/**
+ * The route a path negotiates through, whatever the client asked for.
+ * `undefined` when the URL has a single representation: the raw prefix itself,
+ * an excluded prefix, a dotted asset (`_payload.json`, images), or a path no
+ * configured pattern covers.
+ */
+function negotiableRoute(config: NegotiationConfig, pathname: string): AgentRoute | undefined {
+  if (pathname === config.rawPrefix || pathname.startsWith(`${config.rawPrefix}/`)) {
     return undefined
   }
-
-  // Any other dotted path is an asset (`_payload.json`, images), not a page.
+  if (isExcluded(pathname, config)) {
+    return undefined
+  }
   if (hasFileExtension(pathname)) {
     return undefined
   }
+  return matchRoute(config.routes, pathname)
+}
 
-  return rawDestination(config, route, pathname)
+/**
+ * Whether a URL has both an HTML and a markdown representation, so its
+ * response genuinely depends on `Accept` and `User-Agent`.
+ *
+ * This is what `Vary` is set from. Deriving it here rather than from a route
+ * rule glob is the only way to exclude the API surface and the assets: a
+ * `routeRules` key cannot express a negative pattern, so a catch-all pattern
+ * would label every response on the site.
+ */
+export function isNegotiablePath(config: NegotiationConfig, path: string): boolean {
+  return Boolean(negotiableRoute(config, normalizePathname(path)))
 }
 
 /**

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -22,6 +22,31 @@ export function normalizePathname(path: string): string {
   return pathname || '/'
 }
 
+/**
+ * A raw route slug as the content backends spell it: decoded, without a
+ * trailing slash, and with `/index` folded into the directory it indexes.
+ *
+ * The URL arrives percent-encoded while every backend stores decoded paths, so
+ * without this `/docs/caf%C3%A9` has no markdown twin at all while its HTML
+ * page renders. A malformed escape is left as it came: it matches nothing
+ * either way, and throwing would turn a 404 into a 500.
+ */
+export function normalizeAgentRoute(route: string): string {
+  let path = route
+  try {
+    path = decodeURIComponent(path)
+  } catch {
+    // Not a valid escape sequence, so there is nothing to decode.
+  }
+  if (path.length > 1 && path.endsWith('/')) {
+    path = path.slice(0, -1)
+  }
+  if (path.endsWith('/index')) {
+    path = path.slice(0, -6) || '/'
+  }
+  return path === '/index' || path === '' ? '/' : path
+}
+
 /** Whether the last path segment is dotted: an asset, not a page. */
 export function hasFileExtension(pathname: string): boolean {
   const segment = pathname.slice(pathname.lastIndexOf('/') + 1)
@@ -40,6 +65,12 @@ const REGEX_SPECIALS = /[.+?^${}()|[\]\\]/
 /**
  * Compiles a route pattern to a regex source with one capture group per
  * wildcard: `*` matches one segment, `**` one or more.
+ *
+ * A trailing slash is matched but never captured. The runtime strips it in
+ * `normalizePathname` before matching, but the CDN tests this pattern against
+ * the raw request path, and a captured slash lands in the rewrite destination:
+ * `/docs/x/` becoming `/raw/docs/x/.md`, which 404s. The `**` capture is lazy
+ * so it yields the slash to that optional suffix rather than swallowing it.
  */
 export function compilePattern(pattern: string): { source: string, captures: number } {
   let source = ''
@@ -48,7 +79,7 @@ export function compilePattern(pattern: string): { source: string, captures: num
     const char = pattern[i]!
     if (char === '*') {
       if (pattern[i + 1] === '*') {
-        source += '(.+)'
+        source += '(.+?)'
         i++
       } else {
         source += '([^/]+)'
@@ -58,7 +89,7 @@ export function compilePattern(pattern: string): { source: string, captures: num
       source += REGEX_SPECIALS.test(char) ? `\\${char}` : char
     }
   }
-  return { source: `^${source}$`, captures }
+  return { source: `^${source}/?$`, captures }
 }
 
 const patternCache = new Map<string, RegExp>()
@@ -547,8 +578,11 @@ export function errorMarkdown(config: NegotiationConfig, options: { path: string
   const siteUrl = options.siteUrl.replace(/\/$/, '')
   // The pathname is attacker-chosen and lands in a code span of a document
   // written for agents, so drop anything that could close the span or smuggle
-  // markdown in.
-  const pathname = normalizePathname(options.path).replace(/[`\\]/g, '')
+  // markdown in. Newlines most of all: h3 has already decoded `%0A`, so without
+  // this a crafted path ends the paragraph and everything after it renders as
+  // first-class markdown, links included, in a document an agent will act on.
+  // Capped too, so a long path cannot bury the rest of the body.
+  const pathname = normalizePathname(options.path).replace(/[`\\\r\n]+/g, '').slice(0, 200)
   // Server errors never surface their message. Client errors use the status
   // message when there is one, stripped of anything that could break the
   // heading or the frontmatter line.

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -145,25 +145,23 @@ export type AgentSectionSelector = Record<string, unknown>
  * routes to whatever implements this.
  */
 export interface AgentContentSource {
-  /** Site-relative routes of every markdown-representable page. */
-  routes: (event?: H3Event) => Promise<string[]>
-  /** Resolve one route to its markdown representation, `null` when unknown. */
-  get: (route: string, event?: H3Event) => Promise<AgentPage | null>
   /**
-   * Optional listing with metadata, used by `sitemap.md` and the `nuxt-llms`
-   * bridge so they don't have to call `get()` once per page. Falls back to
-   * `routes()` + `get()` when absent.
+   * Every markdown-representable page, with whatever metadata the backend has.
+   * `sitemap.md`, the `nuxt-llms` bridge and `listAgentPages()` all read it.
    *
-   * With a `selector`, return only the pages it names, or `null` when the
-   * selector is not one this adapter understands.
+   * With a `selector`, a `llms.sections` entry handed over verbatim, return
+   * only the pages it names, or `null` when the selector is not one this
+   * adapter understands.
    */
-  list?: (event?: H3Event, selector?: AgentSectionSelector) => Promise<AgentListEntry[] | null>
+  list: (selector: AgentSectionSelector | undefined, event: H3Event) => Promise<AgentListEntry[] | null>
+  /** Resolve one route to its markdown representation, `null` when unknown. */
+  get: (route: string, event: H3Event) => Promise<AgentPage | null>
   /**
    * Optional: the first page under a section path, for a URL that names a
    * directory rather than a page (`/getting-started` with no `index`). The raw
    * route redirects to its markdown twin, mirroring what the HTML page does.
    */
-  firstLeaf?: (route: string, event?: H3Event) => Promise<string | null>
+  firstLeaf?: (route: string, event: H3Event) => Promise<string | null>
 }
 
 /** Normalized module state shared by build-time presets and the Nitro runtime. */

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -22,6 +22,11 @@ declare module 'nitropack/types' {
     'agent-discovery:index': (event: H3Event, index: AgentIndex) => void | Promise<void>
     /** Enriches the served MCP server card with live tools, resources and prompts. */
     'agent-discovery:mcp-server-card': (event: H3Event, card: Record<string, unknown>) => void | Promise<void>
+    /**
+     * Adds to `sitemap.md` before it is rendered. The map is keyed by section,
+     * in the order the sections appear.
+     */
+    'agent-discovery:sitemap': (event: H3Event, sections: Map<string, { title: string, href: string }[]>) => void | Promise<void>
   }
 }
 

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -172,6 +172,12 @@ export interface NegotiationConfig {
   /** Path prefixes that never negotiate and keep their JSON/HTML errors. */
   excludePrefixes: string[]
   links: DiscoveryLink[]
+  /**
+   * Whether the discovery `Link` header is emitted on `/`. Carried here rather
+   * than read off the module options, because the deploy presets emit that
+   * header themselves and only ever see this config.
+   */
+  linkHeader: boolean
   /** How `sitemap.md` groups pages into sections. */
   sitemapSections: SitemapSections
   /**

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -71,6 +71,13 @@ async function listFiles(dir: string, base = ''): Promise<string[]> {
   const files: string[] = []
   for (const entry of await readdir(dir, { withFileTypes: true })) {
     const path = base ? `${base}/${entry.name}` : entry.name
+    // A symlink reports neither directory nor regular file here, so listing it
+    // would publish whatever it points at: the catalog is the allowlist the
+    // runtime route checks against, so a link to `../../.env` would be served.
+    // Skipped rather than resolved, because a skill has no reason to hold one.
+    if (entry.isSymbolicLink()) {
+      continue
+    }
     if (entry.isDirectory()) {
       files.push(...await listFiles(join(dir, entry.name), path))
     } else {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs'
-import { readdir, readFile } from 'node:fs/promises'
+import { lstat, readdir, readFile } from 'node:fs/promises'
 import { join } from 'pathe'
 import { parse as parseYaml } from 'yaml'
 import type { ConsolaInstance } from 'consola'
@@ -101,7 +101,11 @@ export async function scanSkills(dir: string, logger: ConsolaInstance): Promise<
 
     const skillDir = join(dir, entry.name)
     const skillMd = join(skillDir, 'SKILL.md')
-    if (!existsSync(skillMd)) {
+    // `lstat`, not `existsSync`, which follows the link: `SKILL.md` is added to
+    // the catalog unconditionally below, so a symlinked one would publish
+    // whatever it points at. The reference files are filtered the same way.
+    const stats = await lstat(skillMd).catch(() => null)
+    if (!stats?.isFile()) {
       continue
     }
 

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -431,3 +431,18 @@ describe('nuxt-llms bridge', () => {
     expect(full).toContain(body.trim())
   })
 })
+
+// `@nuxtjs/sitemap` owns `sitemap.xml`. The raw twins are alternate
+// representations of pages it already lists, not pages of their own, so the
+// module drops them through that module's own `sitemap:input` hook.
+describe('@nuxtjs/sitemap handoff', () => {
+  it('lists the pages and none of their raw twins', async () => {
+    const xml = await fetch('/sitemap.xml').then(response => response.text())
+
+    expect(xml).toContain('<loc>')
+    expect(xml).toContain('/docs/getting-started')
+    // The filter is what keeps these out: they are prerendered, so the sitemap
+    // sources see them like any other route.
+    expect(xml).not.toContain('/raw/')
+  })
+})

--- a/test/e2e/expected.ts
+++ b/test/e2e/expected.ts
@@ -1,6 +1,10 @@
 /**
  * The documents every content backend has to produce, byte for byte.
  *
+ * Prose only. The two stringifiers disagree on the blank lines inside a
+ * component block, so nothing here carries one: `test/unit/comark.test.ts`
+ * pins that difference instead of pretending it away.
+ *
  * `basic` serves these from `@nuxt/content` through the built-in adapter,
  * `custom-source` from a hand-written in-memory adapter, and `comark` from
  * `comark-content` through `createComarkSource()`. Same `llms.domain`, same

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { fetch, setup } from '@nuxt/test-utils/e2e'
-import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from '../../src/defaults'
 import { vercelMarkdownRoutes } from '../../src/presets/vercel'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
 import { CLAUDE_BOT, MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY } from './expected'
@@ -99,31 +98,36 @@ describe('sitemap.md destinations', () => {
  * replaces.
  */
 describe('O(1) route table', () => {
-  const config: NegotiationConfig = {
-    siteUrl: SITE_URL,
-    siteName: 'i18n',
-    rawPrefix: '/raw',
-    routes: [{ path: '/', raw: '/raw/index.md' }, { path: '/*/docs/**' }],
-    userAgents: AGENT_USER_AGENTS,
-    excludePrefixes: EXCLUDE_PREFIXES,
-    links: [{ href: '/llms.txt', rel: 'describedby', type: 'text/plain', title: 'llms.txt' }],
-    linkHeader: true,
-    cachedRoutes: [],
-    sitemapSections: { expand: [], labels: {} }
-  }
+  // The config the module resolved, read off the running fixture. Asserting
+  // against a literal here would restate `nuxt.config` and pass even if the
+  // module expanded the locale wildcard into one pattern per locale, which is
+  // the one thing this fixture exists to catch.
+  // Fetched on first use rather than in `beforeAll`, which runs before
+  // `setup()` has published its context.
+  let cached: NegotiationConfig | undefined
+  const resolved = async () => (cached ??= await fetch('/agent-config.json').then(response => response.json()) as NegotiationConfig)
 
-  it('emits the closed-form number of routes for the fixture patterns', () => {
+  it('keeps the locale a wildcard instead of enumerating the locales', async () => {
+    const config = await resolved()
+
+    expect(config.routes.map(route => route.path)).toEqual(['/', '/*/docs/**'])
+    // The fixture ships `en` and `fr`; neither may appear as a pattern.
+    expect(config.routes.some(route => /\/(?:en|fr)\//.test(route.path))).toBe(false)
+  })
+
+  it('emits the closed-form number of routes for the resolved patterns', async () => {
+    const config = await resolved()
     const routes = vercelMarkdownRoutes(config)
     const exact = config.routes.filter(route => !route.path.includes('*')).length
     const glob = config.routes.filter(route => route.path.includes('*')).length
 
-    // 2 header routes (`Vary`, `Link`) + 2 per exact path + 3 per glob.
+    // 2 header routes (`Vary`, `Link`) + 2 per exact path + 3 per glob, and
+    // nothing that scales with the 5 content files or the 2 locales.
     expect(routes).toHaveLength(2 + exact * 2 + glob * 3)
-    expect(routes).toHaveLength(7)
   })
 
-  it('captures the locale segment rather than enumerating locales', () => {
-    const routes = vercelMarkdownRoutes(config)
+  it('captures the locale segment rather than enumerating locales', async () => {
+    const routes = vercelMarkdownRoutes(await resolved())
     const localeRewrites = routes.filter(route => route.dest?.includes('$'))
 
     // One `.md` twin rewrite plus the two negotiated ones, all three sharing
@@ -137,8 +141,8 @@ describe('O(1) route table', () => {
     expect(routes.filter(route => route.dest === '/raw/index.md')).toHaveLength(2)
   })
 
-  it('never names a locale or a page', () => {
-    const serialized = JSON.stringify(vercelMarkdownRoutes(config))
+  it('never names a locale or a page', async () => {
+    const serialized = JSON.stringify(vercelMarkdownRoutes(await resolved()))
 
     for (const fragment of ['/en', '/fr', 'getting-started', 'button', 'about']) {
       expect(serialized).not.toContain(fragment)
@@ -148,12 +152,12 @@ describe('O(1) route table', () => {
   it('stays smaller than a per-page table for the pages the fixture serves', async () => {
     const sitemap = await fetch('/sitemap.md').then(response => response.text())
     const pages = sitemap.split('\n').filter(line => line.startsWith('- [')).length
+    const routes = vercelMarkdownRoutes(await resolved())
 
     expect(pages).toBeGreaterThanOrEqual(5)
     // A per-link table (two routes per page) would already be larger here and
-    // would keep growing; this one is fixed at 7.
-    expect(vercelMarkdownRoutes(config)).toHaveLength(7)
-    expect(vercelMarkdownRoutes(config).length).toBeLessThan(pages * 2)
+    // would keep growing; this one does not move with the page count.
+    expect(routes.length).toBeLessThan(pages * 2)
   })
 })
 

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -107,6 +107,7 @@ describe('O(1) route table', () => {
     userAgents: AGENT_USER_AGENTS,
     excludePrefixes: EXCLUDE_PREFIXES,
     links: [{ href: '/llms.txt', rel: 'describedby', type: 'text/plain', title: 'llms.txt' }],
+    linkHeader: true,
     cachedRoutes: [],
     sitemapSections: { expand: [], labels: {} }
   }

--- a/test/e2e/shared.ts
+++ b/test/e2e/shared.ts
@@ -56,7 +56,10 @@ export function describeSharedDocuments(): void {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
-      expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
+      // No `Vary`: this URL answers markdown to every client, so nothing about
+      // the response depends on `Accept` or `User-Agent`. Only the page it is
+      // the twin of carries the header.
+      expect(response.headers.get('vary')).toBeNull()
       expect(response.headers.get('link')).toBe(GETTING_STARTED_LINK)
       expect(await response.text()).toBe(GETTING_STARTED_MARKDOWN)
     })
@@ -66,7 +69,7 @@ export function describeSharedDocuments(): void {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
-      expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
+      expect(response.headers.get('vary')).toBeNull()
       expect(await response.text()).toBe(GETTING_STARTED_MARKDOWN)
     })
 

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -7,8 +7,10 @@ import { MARKDOWN_VARY } from './expected'
 interface VercelRoute {
   src?: string
   dest?: string
+  status?: number
   headers?: Record<string, string>
   has?: { type: string, key: string, value: string }[]
+  missing?: { type: string, key: string, value: string }[]
   check?: boolean
   continue?: boolean
   handle?: string
@@ -27,7 +29,18 @@ function isModuleRoute(route: VercelRoute): boolean {
   if (route.dest?.startsWith('/raw/')) {
     return true
   }
+  // A cached pattern redirects instead of rewriting, so it carries a
+  // `Location` and no `dest`. Missing it here stopped the walk below early and
+  // silently measured a shorter table than the module emitted.
+  if (route.status === 307 && route.headers?.Location?.startsWith('/raw/')) {
+    return true
+  }
   return route.continue === true && Boolean(route.headers?.Vary || route.headers?.Link)
+}
+
+/** Where a negotiated route sends the client, rewrite or redirect. */
+function destinationOf(route: VercelRoute): string {
+  return route.dest || route.headers?.Location || ''
 }
 
 let routes: VercelRoute[] = []
@@ -76,24 +89,42 @@ describe('vercel build output', () => {
     expect(linkRoute!.headers?.Link).toContain('</>; rel="alternate"; type="text/markdown"')
   })
 
-  it('rewrites on the `Accept` header', () => {
+  it('negotiates on the `Accept` header', () => {
     const acceptRoutes = routes.filter(route => route.has?.some(has => has.type === 'header' && has.key === 'accept'))
 
     expect(acceptRoutes.length).toBeGreaterThanOrEqual(2)
     for (const route of acceptRoutes) {
-      expect(route.dest).toMatch(/^\/raw\//)
-      expect(route.check).toBe(true)
-      expect(route.has!.find(has => has.key === 'accept')!.value).toContain('text/markdown')
+      // A rewrite on an uncached pattern, a redirect on a cached one. Either
+      // way it resolves to the raw prefix, and a rewrite looks the destination
+      // up on the filesystem first.
+      expect(destinationOf(route)).toMatch(/^\/raw\//)
+      expect(route.dest ? route.check : route.status).toBeTruthy()
+
+      // The matcher has to agree with `acceptsMarkdown`, which means matching a
+      // media range rather than the string anywhere in the header.
+      const value = route.has!.find(has => has.key === 'accept')!.value
+      const accepts = (header: string) => new RegExp(`^(?:${value})$`).test(header)
+      expect(accepts('text/markdown')).toBe(true)
+      expect(accepts('text/html, text/markdown')).toBe(true)
+      expect(accepts('text/html;profile="text/markdown"')).toBe(false)
+
+      // A client that explicitly refused markdown is excluded, whitespace
+      // before the delimiter included: RFC 9110 allows it and a real edge
+      // served markdown without this.
+      const refuses = (header: string) => new RegExp(`^(?:${route.missing![0]!.value})$`).test(header)
+      expect(refuses('text/markdown;q=0')).toBe(true)
+      expect(refuses('text/markdown;q=0 , text/html')).toBe(true)
+      expect(refuses('text/markdown;q=0.5')).toBe(false)
     }
   })
 
-  it('rewrites on a known agent `User-Agent`', () => {
+  it('negotiates on a known agent `User-Agent`', () => {
     const agentRoutes = routes.filter(route => route.has?.some(has => has.type === 'header' && has.key === 'user-agent'))
 
     expect(agentRoutes.length).toBeGreaterThanOrEqual(2)
     for (const route of agentRoutes) {
-      expect(route.dest).toMatch(/^\/raw\//)
-      expect(route.check).toBe(true)
+      expect(destinationOf(route)).toMatch(/^\/raw\//)
+      expect(route.dest ? route.check : route.status).toBeTruthy()
 
       const pattern = route.has!.find(has => has.key === 'user-agent')!.value
       expect(pattern).toContain('ClaudeBot')
@@ -110,15 +141,45 @@ describe('vercel build output', () => {
     expect(twin!.src).toContain('\\.md$')
   })
 
+  // The property is that the table is a function of the configured patterns and
+  // the cached rules, not of how many pages the site has. The fixture has five
+  // content pages; the closed form below never mentions them.
   it('keeps the table O(patterns)', () => {
     let count = 0
     while (routes[count] && isModuleRoute(routes[count]!)) {
       count++
     }
 
-    // `routes: ['/', '/**']` → 2 header routes + 2 exact + 3 glob.
-    expect(count).toBe(7)
-    expect(count).toBeLessThanOrEqual(12)
+    const patterns = 2 // `routes: ['/', '/**']`
+    const exact = 1 // `/`
+    const cachedRules = 1 // `/docs/components/**`
+    const headerRoutes = 2 // `Vary` and `Link`
+    // Per pattern: an `Accept` route and a User-Agent route, plus a `.md` alias
+    // for a wildcard. Per cached rule narrower than the pattern over it: its own
+    // redirect pair.
+    expect(count).toBe(headerRoutes + patterns * 2 + (patterns - exact) + cachedRules * 2)
+  })
+
+  // The cache-correctness path, asserted against real emitted output rather
+  // than the pure function, because the module has to read the site's route
+  // rules to know the section is cached at all.
+  it('redirects the cached section and rewrites everything else', () => {
+    const cached = routes.filter(route => route.status === 307)
+    expect(cached).toHaveLength(2)
+
+    for (const route of cached) {
+      expect(route.headers?.Location).toBe('/raw/docs/components/$1.md')
+      expect(route.headers?.Vary).toBe(MARKDOWN_VARY)
+      expect(route.dest).toBeUndefined()
+      expect(new RegExp(route.src!).test('/docs/components/button')).toBe(true)
+      expect(new RegExp(route.src!).test('/docs/getting-started')).toBe(false)
+    }
+    expect(cached.map(route => route.has?.[0]?.key)).toEqual(['accept', 'user-agent'])
+
+    // The catch-all is untouched by the narrower rule.
+    const catchAll = routes.filter(route => route.dest === '/raw/$1.md' && route.has)
+    expect(catchAll).toHaveLength(2)
+    expect(catchAll.every(route => route.check && !route.status)).toBe(true)
   })
 
   it('prerenders the homepage raw markdown into the static output', () => {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,5 +1,5 @@
 export default defineNuxtConfig({
-  modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms', '@nuxtjs/mcp-toolkit'],
+  modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms', '@nuxtjs/mcp-toolkit', '@nuxtjs/sitemap'],
   devtools: { enabled: false },
   // Multi-theme highlighting makes the highlighter append a `<style>` node
   // carrying the per-document CSS variables, which the raw markdown must not
@@ -70,5 +70,10 @@ export default defineNuxtConfig({
       title: 'Handwritten',
       links: [{ title: 'Getting Started', href: '/docs/getting-started' }]
     }]
+  },
+  sitemap: {
+    // Hands the filter a raw twin to drop, which a default sitemap never
+    // contains, so the assertion cannot pass vacuously.
+    sources: ['/api/__sitemap__/urls']
   }
 })

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -18,6 +18,13 @@ export default defineNuxtConfig({
       }
     }
   },
+  // One cached section under an uncached catch-all, which is the split the
+  // Build Output table has to get right: `/docs/components/**` redirects to its
+  // raw twin because a path-keyed cache cannot hold two variants, while every
+  // other page keeps a URL-preserving rewrite.
+  routeRules: {
+    '/docs/components/**': { isr: 60 }
+  },
   compatibilityDate: '2026-01-01',
 
   agentDiscovery: {

--- a/test/fixtures/basic/server/api/__sitemap__/urls.get.ts
+++ b/test/fixtures/basic/server/api/__sitemap__/urls.get.ts
@@ -1,0 +1,12 @@
+/**
+ * A sitemap source that deliberately includes a raw markdown twin.
+ *
+ * Without one the sitemap holds only `/`, and the module's `sitemap:input`
+ * filter would have nothing to remove: the assertion that no twin is listed
+ * would pass whether or not the filter ran.
+ */
+export default defineEventHandler(() => [
+  { loc: '/docs/getting-started' },
+  { loc: '/raw/docs/getting-started.md' },
+  { loc: 'https://basic.example.com/raw/index.md' }
+])

--- a/test/fixtures/custom-source/server/agent-source.ts
+++ b/test/fixtures/custom-source/server/agent-source.ts
@@ -1,4 +1,4 @@
-import { absolutizeMarkdownLinks, defineAgentContentSource, getAgentSiteUrl } from '#agent-discovery'
+import { defineAgentContentSource } from '#agent-discovery'
 
 /**
  * In-memory stand-in for a non-`@nuxt/content` backend (comark, a CMS, a
@@ -79,21 +79,14 @@ const label = 'Badge'
 }
 
 export default defineAgentContentSource({
-  async routes() {
-    return Object.keys(pages)
-  },
-
   async list() {
     return Object.entries(pages).map(([route, page]) => ({ route, title: page.title, description: page.description }))
   },
 
-  async get(route: string, event) {
-    const page = pages[route]
-    if (!page) {
-      return null
-    }
-    // What every adapter rendering straight to markdown has to do, so the
-    // document matches the `@nuxt/content` one byte for byte.
-    return { ...page, markdown: event ? absolutizeMarkdownLinks(page.markdown, getAgentSiteUrl(event)) : page.markdown }
+  // No link absolutization here: the module runs it over whatever `get()`
+  // returns, so this document matches the `@nuxt/content` one byte for byte
+  // without the adapter having to remember.
+  async get(route: string) {
+    return pages[route] || null
   }
 })

--- a/test/fixtures/i18n/server/routes/agent-config.json.get.ts
+++ b/test/fixtures/i18n/server/routes/agent-config.json.get.ts
@@ -1,0 +1,13 @@
+import { useAgentDiscoveryConfig } from '#agent-discovery'
+
+/**
+ * The config the module actually resolved, so a test can assert against it
+ * rather than against a literal that restates the fixture's `nuxt.config`.
+ *
+ * The route table is generated from `routes` alone, so the property worth
+ * checking is that the module kept the locale as a wildcard. A duplicated
+ * literal cannot show that: it would pass just the same if the module expanded
+ * the locale wildcard into one pattern per locale, which is the failure this
+ * fixture exists to catch.
+ */
+export default defineEventHandler(event => useAgentDiscoveryConfig(event))

--- a/test/fixtures/landing/server/agent-source.ts
+++ b/test/fixtures/landing/server/agent-source.ts
@@ -22,10 +22,6 @@ const pages: Record<string, { title: string, description: string, markdown: stri
 }
 
 export default defineAgentContentSource({
-  async routes() {
-    return Object.keys(pages)
-  },
-
   async list() {
     return Object.entries(pages).map(([route, page]) => ({
       route,

--- a/test/unit/comark.test.ts
+++ b/test/unit/comark.test.ts
@@ -155,3 +155,40 @@ describe('comark listing', () => {
     expect(await source.get(leaf!, event)).toBeTruthy()
   })
 })
+
+/**
+ * Where the two backends stop agreeing.
+ *
+ * The rest of this file, and `test/e2e/shared.ts`, assert that comark and
+ * `@nuxt/content` serve the same bytes. That holds for prose and stops holding
+ * at component blocks: the two stringifiers put different blank lines around a
+ * component's children. Both parse back to the same document and no adopter is
+ * affected yet, since the sites running this module use `@nuxt/content` or a
+ * custom source, so the divergence is pinned here rather than papered over.
+ *
+ * Pinned, not asserted as correct. If either stringifier changes its spacing
+ * this fails, which is the point: it should surface here and not halfway
+ * through migrating a comark site full of MDC.
+ */
+describe('comark vs minimark: the known divergence', () => {
+  const nodes = [['callout', { type: 'warning' }, ['p', {}, 'Careful.']]] as never[]
+
+  it('agrees on prose', async () => {
+    const { render } = await import('comark/render')
+    const { stringify } = await import('minimark/stringify')
+    const prose = [['p', {}, 'Just prose.']] as never[]
+
+    expect(await render({ nodes: prose }, { format: 'markdown/html' }))
+      .toBe(stringify({ type: 'minimark', value: prose }, { format: 'markdown/html' }))
+  })
+
+  it('differs on the blank lines inside a component block', async () => {
+    const { render } = await import('comark/render')
+    const { stringify } = await import('minimark/stringify')
+
+    expect(await render({ nodes }, { format: 'markdown/html' }))
+      .toBe('<callout type="warning">\nCareful.\n</callout>\n')
+    expect(stringify({ type: 'minimark', value: nodes }, { format: 'markdown/html' }))
+      .toBe('<callout type="warning">\n\nCareful.\n\n\n\n</callout>\n')
+  })
+})

--- a/test/unit/comark.test.ts
+++ b/test/unit/comark.test.ts
@@ -117,7 +117,7 @@ describe('comark source', () => {
 
 describe('comark listing', () => {
   it('lists every page in the navigation', async () => {
-    const routes = await source.routes(event)
+    const routes = ((await source.list(undefined, event)) || []).map(entry => entry.route)
 
     expect(routes).toContain('/')
     expect(routes).toContain('/about')
@@ -126,7 +126,7 @@ describe('comark listing', () => {
   })
 
   it('carries the title and the navigation group into the listing', async () => {
-    const entries = await source.list?.(event)
+    const entries = await source.list(undefined, event)
     const button = entries?.find(entry => entry.route === '/docs/components/button')
 
     expect(button?.title).toBe('Button')
@@ -134,7 +134,7 @@ describe('comark listing', () => {
   })
 
   it('scopes a listing to the subtree a `navigation` selector names', async () => {
-    const entries = await source.list?.(event, { navigation: '/docs' })
+    const entries = await source.list({ navigation: '/docs' }, event)
 
     expect(entries?.length).toBeGreaterThan(0)
     expect(entries?.every(entry => entry.route.startsWith('/docs'))).toBe(true)
@@ -144,7 +144,7 @@ describe('comark listing', () => {
     // A site swapping backend keeps its `llms.sections` config, so the
     // `@nuxt/content` keys arrive here. Claiming them would list the wrong
     // pages; the bridge drops the section instead.
-    expect(await source.list?.(event, { contentCollection: 'docs' })).toBe(null)
+    expect(await source.list({ contentCollection: 'docs' }, event)).toBe(null)
   })
 
   it('resolves a section path to its first document', async () => {

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -159,6 +159,36 @@ describe('module setup: cached routes', () => {
     '/tools/**': { isr: 3600 }
   }
 
+  // Which route-rule shapes Nitro actually turns into a response cache. Pinned
+  // because it is otherwise folklore about `deprecateSWR` and
+  // `normalizeRouteRules`, and because guessing wrong in either direction is a
+  // bug: a missed cache gets a rewrite that poisons it, a false positive costs
+  // a redirect where a rewrite would have done.
+  it('reads a route rule the way Nitro reads it', async () => {
+    const cached = async (rule: Record<string, unknown>) => {
+      const config = await setupModule({ routes: ['/docs/**'] }, { '/docs/**': rule })
+      return config.cachedRoutes.includes('/docs/**')
+    }
+
+    expect(await cached({ isr: 3600 })).toBe(true)
+    expect(await cached({ isr: true })).toBe(true)
+    expect(await cached({ swr: 60 })).toBe(true)
+    expect(await cached({ cache: { maxAge: 60 } })).toBe(true)
+    // `deprecateSWR` turns `static` into `isr: !static`, so this really is ISR.
+    expect(await cached({ static: false })).toBe(true)
+
+    expect(await cached({ isr: false })).toBe(false)
+    expect(await cached({ swr: false })).toBe(false)
+    expect(await cached({ static: true })).toBe(false)
+    expect(await cached({ prerender: true })).toBe(false)
+    // An opt-out, which `'cache' in rule` used to read as a cache.
+    expect(await cached({ cache: false })).toBe(false)
+    // The Vercel builder skips a falsy `isr` outright, and `normalizeRouteRules`
+    // only configures a cache for a truthy `swr`, so neither is one.
+    expect(await cached({ isr: 0 })).toBe(false)
+    expect(await cached({ swr: 0 })).toBe(false)
+  })
+
   it('only lists a rule the routes actually negotiate', async () => {
     const config = await setupModule({ routes }, routeRules)
 

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -189,6 +189,24 @@ describe('module setup: cached routes', () => {
     expect(await cached({ swr: 0 })).toBe(false)
   })
 
+  // `experimental.inlineRouteRules` merges a page's `defineRouteRules({ isr })`
+  // in after every module has set up, so the pass at `modules:done` never sees
+  // it. Missing it emits a URL-preserving rewrite onto a route that really is
+  // cached, which is the one error in this area that poisons a cache.
+  it('picks up a route rule that lands after `modules:done`', async () => {
+    const nuxt = await runModule({ routes: ['/', '/**'] }, { '/tools': { isr: 3600 } })
+    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+
+    expect(config.cachedRoutes).toEqual(['/tools'])
+
+    // What `nitro.updateConfig` does with an inline page rule, then the hook
+    // the preset reads the config from.
+    nuxt.options.routeRules['/docs/late'] = { isr: 60 }
+    await nuxt.hooks.callHook('nitro:init' as never, { options: { dev: false, preset: 'node-server' } } as never)
+
+    expect(config.cachedRoutes).toEqual(['/tools', '/docs/late'])
+  })
+
   it('only lists a rule the routes actually negotiate', async () => {
     const config = await setupModule({ routes }, routeRules)
 
@@ -357,5 +375,25 @@ describe('module setup: content source', () => {
 
     expect(nuxt.options.nitro.alias?.['#agent-discovery/comark']).toMatch(/sources[\\/]comark$/)
     expect(nuxt.options.nitro.alias?.['#agent-discovery/source']).toMatch(/agent-source$/)
+  })
+})
+
+describe('module setup: api-catalog', () => {
+  // The catalog groups links carrying an `anchor` with a `service-desc` or
+  // `service-doc` rel. A site with no `nuxt-llms`, no skills and no MCP card
+  // has none, so the route answered `{"linkset":[]}` while the `Link` header
+  // on `/` still pointed agents at it.
+  it('is not advertised when nothing would be in it', async () => {
+    const config = await setupModule()
+
+    expect(config.links.some(link => link.href === '/.well-known/api-catalog')).toBe(false)
+  })
+
+  it('is advertised once a site contributes an anchored service link', async () => {
+    const config = await setupModule({
+      discovery: { links: [{ href: '/openapi.json', rel: 'service-desc', anchor: '/', title: 'OpenAPI' }] }
+    })
+
+    expect(config.links.some(link => link.href === '/.well-known/api-catalog')).toBe(true)
   })
 })

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -8,13 +8,17 @@ import {
   errorMarkdown,
   formatLinkHeader,
   hasFileExtension,
+  isNegotiablePath,
   matchRoute,
   negotiatedRawPath,
+  normalizeAgentRoute,
   normalizePathname,
   parseAccept,
   patternsOverlap,
   prefersMarkdownError,
   rawDestination,
+  ruleCoversPattern,
+  ruleMatchesPath,
   staticPrefix
 } from '../../src/runtime/shared/negotiation'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
@@ -332,6 +336,85 @@ describe('prefersMarkdownError', () => {
   })
 })
 
+// What `Vary` is derived from: a URL with two representations, independent of
+// what the client asked for. A route rule cannot express these exclusions,
+// which is why the header does not come from one.
+describe('isNegotiablePath', () => {
+  it('covers the pages that have both representations', () => {
+    expect(isNegotiablePath(config, '/')).toBe(true)
+    expect(isNegotiablePath(config, '/docs/guide')).toBe(true)
+    expect(isNegotiablePath(config, '/docs/guide/')).toBe(true)
+  })
+
+  it('leaves the single-representation URLs alone', () => {
+    expect(isNegotiablePath(config, '/llms.txt')).toBe(false)
+    expect(isNegotiablePath(config, '/robots.txt')).toBe(false)
+    expect(isNegotiablePath(config, '/docs/guide.md')).toBe(false)
+    expect(isNegotiablePath(config, '/raw/docs/guide.md')).toBe(false)
+    expect(isNegotiablePath(config, '/api/x')).toBe(false)
+    expect(isNegotiablePath(config, '/_nuxt/entry.js')).toBe(false)
+    expect(isNegotiablePath(config, '/blog/post')).toBe(false)
+  })
+})
+
+describe('normalizeAgentRoute', () => {
+  it('decodes, so a non-ASCII page has a markdown twin at all', () => {
+    expect(normalizeAgentRoute('/docs/caf%C3%A9')).toBe('/docs/café')
+    expect(normalizeAgentRoute('/docs/a%20b')).toBe('/docs/a b')
+  })
+
+  it('leaves a malformed escape alone rather than throwing', () => {
+    expect(normalizeAgentRoute('/docs/%zz')).toBe('/docs/%zz')
+    expect(normalizeAgentRoute('/docs/%')).toBe('/docs/%')
+  })
+
+  it('drops a trailing slash and folds `/index`', () => {
+    expect(normalizeAgentRoute('/docs/getting-started/')).toBe('/docs/getting-started')
+    expect(normalizeAgentRoute('/docs/index')).toBe('/docs')
+    expect(normalizeAgentRoute('/docs/index/')).toBe('/docs')
+    expect(normalizeAgentRoute('/index')).toBe('/')
+    expect(normalizeAgentRoute('/')).toBe('/')
+  })
+})
+
+// Route rules speak radix3, where `**` is zero or more segments, while the
+// module's own patterns compile it to one or more. Reading a rule with the
+// wrong one is what left a cached section root rewriting.
+describe('ruleMatchesPath', () => {
+  it('treats `**` as zero or more segments', () => {
+    expect(ruleMatchesPath('/docs/**', '/docs')).toBe(true)
+    expect(ruleMatchesPath('/docs/**', '/docs/guide')).toBe(true)
+    expect(ruleMatchesPath('/docs/**', '/docs/a/b')).toBe(true)
+    expect(ruleMatchesPath('/**', '/')).toBe(true)
+    expect(ruleMatchesPath('/docs/**', '/other')).toBe(false)
+    expect(ruleMatchesPath('/docs/**', '/docsx')).toBe(false)
+  })
+
+  it('keeps `*` to a single segment', () => {
+    expect(ruleMatchesPath('/docs/*', '/docs/guide')).toBe(true)
+    expect(ruleMatchesPath('/docs/*', '/docs/a/b')).toBe(false)
+  })
+})
+
+describe('ruleCoversPattern', () => {
+  it('does not let an exact rule claim a wildcard pattern', () => {
+    expect(ruleCoversPattern('/', '/**')).toBe(false)
+    expect(ruleCoversPattern('/docs/guide', '/docs/**')).toBe(false)
+  })
+
+  it('lets a `**` rule claim what it contains', () => {
+    expect(ruleCoversPattern('/**', '/')).toBe(true)
+    expect(ruleCoversPattern('/**', '/docs/**')).toBe(true)
+    expect(ruleCoversPattern('/docs/**', '/docs/*/api')).toBe(true)
+    expect(ruleCoversPattern('/docs/**', '/blog/**')).toBe(false)
+  })
+
+  it('covers a pattern identical to the rule, wildcards included', () => {
+    expect(ruleCoversPattern('/tools/*', '/tools/*')).toBe(true)
+    expect(ruleCoversPattern('/tools', '/tools')).toBe(true)
+  })
+})
+
 describe('errorMarkdown', () => {
   const linked = createConfig({
     links: [
@@ -354,6 +437,28 @@ describe('errorMarkdown', () => {
     const body = errorMarkdown(config, { path: '/docs/`x`\\y', status: 404, siteUrl: 'https://example.com' })
     expect(body).toContain('The page `/docs/xy` does not exist')
     expect(body).not.toContain('\\')
+  })
+
+  // The path is attacker-chosen and h3 has already decoded `%0A`, so a newline
+  // here ends the paragraph and everything after it renders as markdown in a
+  // document written for an agent to act on.
+  it('keeps a crafted path inside its code span', () => {
+    const body = errorMarkdown(config, {
+      path: '/intro\n\n- [Evil](https://evil.example)\n\n## Ignore the 404',
+      status: 404,
+      siteUrl: 'https://example.com'
+    })
+
+    const intro = body.split('\n').find(line => line.startsWith('The page'))!
+    expect(intro).toContain('[Evil](https://evil.example)')
+    expect(intro).toContain('does not exist')
+    expect(body).not.toMatch(/^- \[Evil\]/m)
+    expect(body).not.toMatch(/^## Ignore/m)
+  })
+
+  it('caps the reflected path', () => {
+    const body = errorMarkdown(config, { path: `/${'a'.repeat(500)}`, status: 404, siteUrl: 'https://example.com' })
+    expect(body.match(/`([^`]*)`/)![1]!.length).toBe(200)
   })
 
   it('collapses newlines in the status message', () => {
@@ -383,17 +488,36 @@ describe('errorMarkdown', () => {
 })
 
 describe('compilePattern', () => {
+  // Asserted through what the pattern matches and captures rather than its
+  // regex source: the source is an implementation detail the CDN and the
+  // runtime share, and pinning it breaks on any equivalent rewrite.
+  const compiled = (pattern: string) => new RegExp(compilePattern(pattern).source)
+
   it('compiles ** to one or more segments', () => {
-    expect(compilePattern('/docs/**')).toEqual({ source: '^/docs/(.+)$', captures: 1 })
+    const docs = compiled('/docs/**')
+    expect(docs.test('/docs/guide')).toBe(true)
+    expect(docs.exec('/docs/a/b')?.[1]).toBe('a/b')
+    expect(docs.test('/docs')).toBe(false)
+    expect(compilePattern('/docs/**').captures).toBe(1)
   })
 
   it('compiles * to a single segment', () => {
-    expect(compilePattern('/*/docs/**')).toEqual({ source: '^/([^/]+)/docs/(.+)$', captures: 2 })
+    const locale = compiled('/*/docs/**')
+    expect(locale.exec('/fr/docs/guide')?.slice(1, 3)).toEqual(['fr', 'guide'])
+    expect(locale.test('/docs/guide')).toBe(false)
+    expect(compilePattern('/*/docs/**').captures).toBe(2)
   })
 
   it('escapes regex specials', () => {
-    expect(compilePattern('/docs/3.x/**').source).toBe('^/docs/3\\.x/(.+)$')
-    expect(new RegExp(compilePattern('/docs/3.x/**').source).test('/docs/3ax/guide')).toBe(false)
+    expect(compiled('/docs/3.x/**').test('/docs/3.x/guide')).toBe(true)
+    expect(compiled('/docs/3.x/**').test('/docs/3ax/guide')).toBe(false)
+  })
+
+  // The CDN tests this against the raw request path, where the runtime has not
+  // normalized anything yet. A captured slash lands in the rewrite destination.
+  it('matches a trailing slash without capturing it', () => {
+    expect(compiled('/docs/**').exec('/docs/guide/')?.[1]).toBe('guide')
+    expect(compiled('/changelog').test('/changelog/')).toBe(true)
   })
 })
 

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -31,6 +31,7 @@ function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationCo
     userAgents: ['ClaudeBot', 'GPTBot', 'curl/8.4'],
     excludePrefixes: ['/_', '/api/', '/mcp', '/.well-known/'],
     links: [],
+    linkHeader: true,
     cachedRoutes: [],
     sitemapSections: { expand: [], labels: {} },
     ...overrides

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -368,6 +368,13 @@ describe('normalizeAgentRoute', () => {
     expect(normalizeAgentRoute('/docs/%')).toBe('/docs/%')
   })
 
+  // Decoding is not idempotent, so only one layer may own it. Applying it twice
+  // turns an encoded `%2F` into a path separator and resolves a different page.
+  it('decodes exactly once', () => {
+    expect(normalizeAgentRoute('/docs/a%252Fb')).toBe('/docs/a%2Fb')
+    expect(normalizeAgentRoute(normalizeAgentRoute('/docs/a%252Fb'))).toBe('/docs/a/b')
+  })
+
   it('drops a trailing slash and folds `/index`', () => {
     expect(normalizeAgentRoute('/docs/getting-started/')).toBe('/docs/getting-started')
     expect(normalizeAgentRoute('/docs/index')).toBe('/docs')

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -16,6 +16,7 @@ function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationCo
     userAgents: ['ClaudeBot', 'GPTBot', 'curl/8.4'],
     excludePrefixes: ['/_', '/api/', '/mcp', '/.well-known/'],
     links: [],
+    linkHeader: true,
     cachedRoutes: [],
     sitemapSections: { expand: [], labels: {} },
     ...overrides
@@ -62,10 +63,19 @@ describe('vercelMarkdownRoutes: Vary', () => {
     expect(matches(vary!, '/blog/x')).toBe(false)
   })
 
-  it('covers the .md twin of an exact pattern', () => {
+  // `Vary` belongs on a URL with two representations and nowhere else. A `.md`
+  // twin only ever serves markdown, and a shared cache keyed per user-agent on
+  // the documents agents fetch most is close to no caching at all.
+  it('leaves the single-representation documents alone', () => {
     const [exact] = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/changelog' }] }))
     expect(matches(exact!, '/changelog')).toBe(true)
-    expect(matches(exact!, '/changelog.md')).toBe(true)
+    expect(matches(exact!, '/changelog.md')).toBe(false)
+
+    expect(matches(vary!, '/llms.txt')).toBe(false)
+    expect(matches(vary!, '/robots.txt')).toBe(false)
+    expect(matches(vary!, '/sitemap.xml')).toBe(false)
+    expect(matches(vary!, '/logo.png')).toBe(false)
+    expect(matches(vary!, '/docs/foo.md')).toBe(false)
   })
 })
 
@@ -217,6 +227,53 @@ describe('vercelMarkdownRoutes: cached routes', () => {
   it('still labels cached pages with `Vary` through the leading continue route', () => {
     expect(routes[0]?.continue).toBe(true)
     expect(matches(routes[0]!, '/docs/foo')).toBe(true)
+  })
+
+  // A rule only demotes a pattern it covers *entirely*. Comparing static-prefix
+  // lengths instead tied `/` with `/**`, so one cached page took the whole site
+  // down to redirects with it.
+  it('does not let a cached `/` demote every other pattern', () => {
+    const site = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/', raw: '/raw/index.md' }, { path: '/**' }],
+      cachedRoutes: ['/']
+    }))
+
+    const home = site.filter(route => route.headers?.Location === '/raw/index.md')
+    expect(home).toHaveLength(2)
+    expect(home.every(route => route.status === 307)).toBe(true)
+
+    const rest = site.filter(route => route.dest === '/raw/$1.md' && route.has)
+    expect(rest).toHaveLength(2)
+    expect(rest.every(route => route.check && !route.status)).toBe(true)
+  })
+
+  // radix3 reads `**` as zero or more segments, so `/docs/**` caches `/docs`
+  // itself. Reading the rule with `compilePattern`, one or more, left the
+  // section root rewriting onto a cache that really exists.
+  it('treats a section root as cached by its own `**` rule', () => {
+    const site = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/docs' }],
+      cachedRoutes: ['/docs/**']
+    }))
+
+    const docs = site.filter(route => route.headers?.Location === '/raw/docs.md')
+    expect(docs).toHaveLength(2)
+    expect(docs.every(route => route.status === 307)).toBe(true)
+    expect(site.some(route => route.dest === '/raw/docs.md' && route.has)).toBe(false)
+  })
+
+  it('emits one redirect per path, never two', () => {
+    const site = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/docs/**' }],
+      cachedRoutes: ['/docs/**', '/docs/api/**']
+    }))
+
+    for (const path of ['/', '/docs/guide', '/docs/api/x']) {
+      const hit = site.filter(route => route.status === 307 && matches(route, path))
+      expect(hit.length).toBeLessThanOrEqual(2)
+      const targets = new Set(hit.map(route => path.replace(new RegExp(route.src), route.headers!.Location!)))
+      expect(targets.size).toBeLessThanOrEqual(1)
+    }
   })
 
   it('matches a route rule by static prefix, whatever the wildcards are', () => {

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -129,8 +129,21 @@ describe('vercelMarkdownRoutes: negotiated rewrites', () => {
     expect(negotiated).toHaveLength(2)
     expect(negotiated[0]?.src).toBe(negotiated[1]?.src)
     expect(negotiated.every(route => route.check)).toBe(true)
-    expect(negotiated[0]?.has).toEqual([{ type: 'header', key: 'accept', value: '(.*)text/markdown(.*)' }])
+    expect(negotiated[0]?.has?.[0]).toMatchObject({ type: 'header', key: 'accept' })
     expect(negotiated[1]?.has?.[0]?.key).toBe('user-agent')
+  })
+
+  // The matcher has to agree with `acceptsMarkdown`, so it is asserted through
+  // headers rather than through its source. `text/markdown` has to head a media
+  // range: as a bare substring it also matched inside a parameter value.
+  it('matches `Accept` the way the negotiation core does', () => {
+    const accept = (header: string) => new RegExp(`^(?:${negotiated[0]!.has![0]!.value})$`).test(header)
+
+    expect(accept('text/markdown')).toBe(true)
+    expect(accept('text/markdown;q=0.9')).toBe(true)
+    expect(accept('text/html, text/markdown')).toBe(true)
+    expect(accept('text/html;profile="text/markdown"')).toBe(false)
+    expect(accept('text/html')).toBe(false)
   })
 
   it('matches pages, not .md URLs, assets or excluded prefixes', () => {
@@ -157,7 +170,7 @@ describe('vercelMarkdownRoutes: negotiated rewrites', () => {
 
   it('rewrites the exact root through its explicit raw destination', () => {
     const root = rewrites(routes).filter(route => route.dest === '/raw/index.md')
-    expect(root.every(route => route.src === '^/$')).toBe(true)
+    expect(root.every(route => matches(route, '/'))).toBe(true)
     expect(root.every(route => route.check)).toBe(true)
     expect(matches(root[0]!, '/docs/foo')).toBe(false)
   })


### PR DESCRIPTION
Findings from a full read of the module, verified by executing the source rather than reading it, and by probing the deployed playground.

## Cache correctness

Route rules are matched by radix3, where `**` means zero or more segments, so `/docs/**` covers `/docs` itself. The module read them with `compilePattern`, where it means one or more. Three ways to rewrite a URL that really is cached fell out of that:

- a section root under its own `**` rule was never marked cached
- an exact rule tied with a wildcard pattern on static-prefix length, so `routeRules: { '/': { isr } }` demoted every pattern on the site to a redirect
- `cache: false` counted as a cache, while `static: false`, which `deprecateSWR` turns into real ISR, did not

`ruleMatchesPath` and `ruleCoversPattern` now hold that distinction in one place, and the middleware and the preset both read it.

## Vary

Under the default `/**` this was a route rule matching every path on the site, and a route rule cannot express an exclusion, so it labelled assets, `/llms.txt`, `/robots.txt` and the whole API surface. Measured on the deployment before the fix: every discovery document carried `Vary: Accept, User-Agent` while having exactly one representation.

It now comes from the negotiation middleware, which knows which paths have two representations, plus a CDN route that carries the dotted-segment lookahead it was missing.

## Silent failures

- `source: 'auto'` with no adapter registered negotiation anyway, so every agent got a markdown 404 on a page that renders fine in HTML
- `mcp: false` passed the toolkit guard, because `false?.enabled !== false`
- `nuxt generate` on Vercel resolves `vercel-static`, whose name matched the preset check while the build emits no function routes behind the rewrites
- `userAgents: { replace: [] }` compiled to `.*().*`, which matches every browser
- `/sitemap.xml` was advertised in the `Link` header, the api-catalog and `robots.txt` whether or not anything served it

## Paths and edge parity

- nothing decoded the path, so a non-ASCII page had no markdown twin at all
- a trailing slash reached the CDN as `/raw/docs/x/.md`
- `Accept: text/markdown;q=0 , text/html` was served markdown at the edge. RFC 9110 allows the space, the refusal matcher did not. Reproduced on the live deployment
- `text/html;profile="text/markdown"` matched the old substring test
- exact patterns skipped the asset and excluded-prefix lookaheads the wildcard branch carries

## Security

- newlines survived the error-body sanitizer, so a crafted path broke out of its code span and injected followable links into a document written for agents
- `scanSkills` listed symlinks, publishing whatever they point at
- a malformed escape under `/.well-known/skills/` 500'd instead of 400ing
- a `%` in a section path widened the `firstLeaf` LIKE query to the whole collection

## API

Measured against the two real integrations rather than the README. `routes()` and `list()` were the same query twice, so `list()` is now the only listing method, which also removes three fallback branches and a hazard where teaching `list()` a selector silently narrowed `llms-full.txt`. The event was typed optional while both built-ins threw without it, which is why each carried a `requireEvent` helper and the README example needed `event!`.

Link absolutization moves into the module: it was exported for adapters to call, called nowhere inside the module, and in real consumer code produced `event ? absolutize(...) : page.markdown`, a silent path emitting relative links. `excludeGroups` now extends the `admin` default instead of replacing it. The MCP card drops a `$schema` that 404s.

`sitemap.md` honours `excludePrefixes` and gains an `agent-discovery:sitemap` hook, which is what nuxt.com needs for its version exclusion and its hand-written links.

## Docs

The verify skill reported false results twice over: its q-value row expected HTML, which is right only when the page's twin is not prerendered, and its skills check grepped for a `.path` key that has never existed, so a site serving no index at all passed clean.

## Verified

`pnpm test` (317), `pnpm lint`, `pnpm typecheck`, `pnpm dev:build`. The whichcodingtools config, the only fully-ISR adopter, still emits all redirects and no rewrites. The `basic` fixture now builds with the Vercel preset *and* a cached route rule, which no fixture combined before and is the gap the cache bugs lived in.

Three Vercel behaviours were settled against the deployment rather than assumed: `has.value` is anchored, a `check: true` filesystem miss hands the function the original path, and the documented q-value divergence is real but only on a prerendered twin.

The last open question is settled against `whichcoding.tools`, which runs this module and is ISR end to end, so every negotiated route there is already a 307: Vercel **does** re-attach the query to a hand-written `Location` (`/tools?sort=name&x=1` → `location: /raw/tools.md?sort=name&x=1`). The preset's comment was right and nothing needed changing there. The middleware now forwards the query on its in-place response too, so the two agree.

That site also reproduces the whitespace bug in production: `Accept: text/markdown;q=0 , text/html` gets a 307 to the markdown twin after explicitly refusing markdown. Worth a version bump there once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added 60-second caching for documentation routes.
  - Added sitemap extensibility and improved discovery metadata.
  - Added support for Nuxt Content v3 content sources.
  - Improved Markdown negotiation, route matching, and Vercel routing.
  - Updated MCP server cards with safer default exclusions.

- **Bug Fixes**
  - Malformed skill URLs now return a 400 response.
  - Improved handling of cached routes, trailing slashes, Markdown URLs, and assets.
  - Prevented symbolic links from appearing in skill listings.
  - Enhanced error-message sanitization.

- **Documentation**
  - Updated configuration, migration, content-source, sitemap, and caching guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
