### PR TITLE
fix: set Vary on the markdown representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Markdown content negotiation, CDN-level rewrites, and discovery documents for AI
 - `Accept` / User-Agent content negotiation with real q-value parsing (RFC 9110 precedence), so `q=0` is a refusal and `text/html` outranks markdown when a client prefers it
 - Vercel Build Output routes so pages negotiate at the edge, before the CDN cache ever sees the request, with a route table that stays O(patterns), never O(pages): a rewrite where the page is prerendered, a 307 where a response cache would key on the path alone
 - A universal Nitro middleware giving the same behavior in dev and on every other host
-- Correct `Vary` and `Link` headers, including on responses served straight from the CDN rewrite table
+- Correct `Vary` and `Link` headers, on both halves of a negotiated page and on responses served straight from the CDN rewrite table
 - A raw markdown route driven by a pluggable content adapter: `@nuxt/content` built in, `comark` through a factory, or your own
 - A `nuxt-llms` bridge: `/llms.txt` and `/llms-full.txt` stay owned by `nuxt-llms`, this module never registers them, but their sections, links and full document all come from the content adapter, so a page reads the same whichever backend serves it and whichever URL an agent fetches it from
 - Markdown error bodies with recovery links for agents hitting a 404 or other error
@@ -48,7 +48,7 @@ What you get out of the box:
 
 - `/raw/**.md`, the raw markdown route, served from whichever content source is detected
 - `Accept: text/markdown` or an explicit `<path>.md` URL returns markdown for any negotiated route; a known agent User-Agent (ClaudeBot, GPTBot, PerplexityBot, ...) gets markdown without an `Accept` header
-- `Vary: Accept, User-Agent` on the negotiated pages, and only those: a `.md` twin and everything under `/raw/**` answer markdown to every client, so nothing about them depends on the request
+- `Vary: Accept, User-Agent` on both halves of a negotiated page: the HTML one, and the markdown one it rewrites or redirects to. A `.md` twin, `/raw/**` and `/sitemap.md` answer markdown to every client, but they are where a negotiated page sends one, so they carry the header too. Assets, the API surface and the other discovery documents never do
 - a `Link` header on `/` advertising the discovery resources
 - `/.well-known/api-catalog`
 - `/sitemap.md`
@@ -66,6 +66,24 @@ In this order:
 Exclusions never negotiate: `/_`, `/api/`, `/mcp`, `/.well-known/`, the raw prefix itself, and any path whose last segment is dotted (assets, `_payload.json`, images).
 
 Errors follow the same idea but browsers are protected: a `fetch()` call of any mode keeps the HTML or JSON error it was written against (`Sec-Fetch-Mode` other than `navigate`), and an explicit `Accept: text/html` or `application/json` is honored unless the client is a known agent, which outranks it. Everything else, curl, an empty `Accept`, a navigation, gets the markdown error body.
+
+An `Accept` that allows neither representation gets the HTML page anyway, unless the site turns on [strict content negotiation](#strict-content-negotiation).
+
+### Strict content negotiation
+
+A negotiated page has exactly two representations, HTML and markdown, so an `Accept` allowing neither is a 406 per RFC 9110. `notAcceptable: true` makes the module answer one, at the origin and at the Vercel edge both.
+
+It's off by default because the strictly correct answer breaks clients that send a narrow `Accept` without meaning it, and a page that used to render turning into an error is a bad trade for a site that isn't chasing the RFC. Turn it on knowing that:
+
+- browsers (`*/*;q=0.8`) and `fetch()` (`*/*`) rate both representations through the wildcard and are never refused
+- a navigation (`Sec-Fetch-Mode: navigate`) and a known agent User-Agent are never refused either, the same protections the markdown error bodies have
+- `Accept: text/markdown;q=0` on its own is a 406, on the same reading that makes `Accept: application/xml` one: a quality of zero is a refusal, and refusing both leaves nothing to send
+- an `Accept` carrying no media range at all is ignored rather than refused, so a proxy mangling the header can't take a page down
+- the body lists the two representations, in whichever format the client's error rules resolve to: markdown for an agent or curl, JSON for a browser `fetch()`
+
+Only the pages negotiate, so only the pages can refuse them all. A `.md` twin, `/raw/**`, the assets and the discovery documents have one representation each and are served whatever the header says.
+
+At the edge the guards are Build Output matchers rather than the q-value ranking, so a representation offered and then refused at `q=0` still reads as offered there and the page is served where the origin would answer 406. That's the same known divergence the `text/markdown;q=0` rewrite matcher has, in the same fail-safe direction.
 
 ## Configuration
 
@@ -87,6 +105,7 @@ export default defineNuxtConfig({
       links: []
     },
     errors: true,
+    notAcceptable: false,
     sitemap: { markdown: true },
     robots: { aiPolicy: true, contentSignal: 'search=yes, ai-train=yes, ai-input=yes' },
     skills: { dir: 'skills' }
@@ -107,6 +126,7 @@ export default defineNuxtConfig({
 - **`discovery.mcpServerCard`** Given an `McpServerCardOptions` object (`endpoint`, `name`, and optionally `title`, `description`, `documentation`, `repository`, `license`, `version`), serves `/.well-known/mcp/server-card.json`. `false` to disable.
 - **`discovery.links`** Site-specific discovery links: OpenAPI documents, service docs, anything else worth advertising. Rels are validated against the IANA registry, an invented one fails the build. Other modules can push into the same list through the `agent-discovery:extend` hook.
 - **`errors`** Chains a markdown error handler ahead of any existing Nitro `errorHandler`, answering with a markdown body carrying recovery links when the request prefers it.
+- **`notAcceptable`** Answer a negotiated page with 406 when the request's `Accept` allows neither of its two representations, which is what RFC 9110 asks for. Off by default, and worth reading [Strict content negotiation](#strict-content-negotiation) before turning it on.
 - **`sitemap.markdown`** Serve `/sitemap.md`, a markdown index of every page, from the content adapter. Anything under `excludePrefixes` is left out, which is how a site keeps a legacy docs version out of the index and out of negotiation with one setting, and `agent-discovery:sitemap` is where a site adds the pages an adapter cannot know about. Pass an object to control the grouping: `expand` lists path prefixes whose children each get their own section (`['/docs']` turns one "Docs" section into "Components", "Composables", ... while `/blog/**` stays a single "Blog"), and `labels` overrides the heading derived from a segment. Top-level pages share one "Pages" section.
 - **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with a `description` in its frontmatter becomes a skill, taking its name from the directory unless the frontmatter sets one; its files are listed from disk into a generated `/.well-known/skills/index.json`, so the index can never fall behind the files actually served. Names are validated against the Agent Skills spec. `false` to disable; the feature turns itself off when the directory does not exist. Skills are pushed into the discovery registry, so they reach the api-catalog and the error-body recovery links.
 - **`robots.aiPolicy`** Feeds the shared user-agent list into `@nuxtjs/robots` when it's installed. Otherwise generates `/robots.txt`, skipped (with a warning) if a static `public/robots.txt` already exists.
@@ -129,7 +149,7 @@ With the built-in `@nuxt/content` source, the raw twin of every exact route patt
 
 ### The raw route
 
-`/raw/**.md` answers `text/markdown; charset=utf-8`, with a `Link` header carrying the page's `rel="canonical"` and its `rel="alternate"; type="text/html"`. The body opens on frontmatter:
+`/raw/**.md` answers `text/markdown; charset=utf-8`, with `Vary: Accept, User-Agent` and a `Link` header carrying the page's `rel="canonical"` and its `rel="alternate"; type="text/html"`. The body opens on frontmatter:
 
 ```md
 ---
@@ -142,6 +162,8 @@ canonical_url: "https://example.com/docs/getting-started"
 `canonical_url` is always there. `title` and `description` are left out when the page has none, rather than emitted empty, since an empty key reads as a value the page set to nothing on purpose.
 
 Then the page markdown, with every same-origin link absolutized. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
+
+`Vary` is on every response here, the 302 below included, even though this URL answers markdown to every client. It's where a negotiated page sends one: on a cached pattern the CDN answers `Accept: text/markdown` with a 307, so this is the response the client keeps and the one a shared cache stores. Without the header on it, whatever follows the hop lands on a URL with two representations behind it and nothing saying so. `/sitemap.md` carries it for the same reason.
 
 A path naming a section rather than a page, `/raw/docs.md` where there is no `docs` index document, redirects 302 to the section's first document when the adapter implements `firstLeaf()`. Anything else missing answers a real 404, so an agent can tell an unknown URL from an empty one. The body is the markdown error, reporting the page path the client asked for rather than the raw one.
 
@@ -384,7 +406,11 @@ Detected automatically, never a dependency. Detection happens at `modules:done`,
 
 On the `vercel` preset (skipped in dev), a Nitro `compiled` hook patches `.vercel/output/config.json` directly, the Build Output API v3, not `vercel.json`, prepending routes ahead of the ones Nitro emits from `routeRules`.
 
-The first route sets `Vary: Accept, User-Agent` across every configured pattern with `continue: true`. That flag matters: Nitro emits its own header routes from `routeRules` *after* these rewrites and without `continue`, so without it `Vary` would never reach a request that gets rewritten straight to a prerendered `/raw/**.md` file off the CDN. It skips anything with a dotted last segment, which keeps it off `/llms.txt`, `/robots.txt`, the `.md` twins and everything in `public/`: those answer the same bytes to every client, and a shared cache keyed per user-agent on them is close to no caching at all. A `Link` route on `/` carries the same `continue: true` for the same reason, the homepage's own `routeRules` entry never runs once a request is rewritten.
+The first route sets `Vary: Accept, User-Agent` across every configured pattern with `continue: true`. That flag matters: Nitro emits its own header routes from `routeRules` *after* these rewrites and without `continue`, so without it `Vary` would never reach a request that gets rewritten straight to a prerendered `/raw/**.md` file off the CDN. It skips anything with a dotted last segment, which keeps it off `/llms.txt`, `/robots.txt`, `/sitemap.xml` and everything in `public/`: those answer the same bytes to every client, and a shared cache keyed per user-agent on them is close to no caching at all.
+
+The second labels the markdown representations that route deliberately leaves out: everything under the raw prefix, the `.md` twins and `/sitemap.md`. Their handlers set the header themselves, but a prerendered file is answered off the filesystem and never reaches one, which is the whole reason this is a CDN route. A `Link` route on `/` carries the same `continue: true` for the same reason, the homepage's own `routeRules` entry never runs once a request is rewritten.
+
+With [`notAcceptable`](#strict-content-negotiation) on, a 406 route follows them, carrying the middleware's guards as `has`/`missing` matchers.
 
 Then, per route pattern, two negotiated routes: a `has` matcher on `Accept: text/markdown` and another on the agent User-Agent list. What they do depends on whether the pattern is cached:
 
@@ -400,6 +426,8 @@ The table stays O(route patterns): one set of routes per configured pattern, not
 ### Other hosts
 
 The Nitro middleware runs everywhere, dev included, covering `.md` twin URLs, `Accept: text/markdown`, and known agent User-Agents, and answers unknown pages with a markdown 404. Caveat: Nitro serves prerendered files ahead of user handlers, so on a built server an already-prerendered page is served straight off disk and bypasses the middleware entirely, staying HTML. Only never-prerendered pages and explicit `.md` URLs reach it. For prerendered pages sitting behind a generic CDN, negotiate at the edge with the Vercel preset instead, or render those routes on demand (SSR or serverless) rather than prerendering them.
+
+The same caveat applies to the headers the route handlers set. With the `@nuxt/content` source, `/sitemap.md` and the raw twin of every exact pattern are prerendered, so off Vercel they're served off disk without `Vary`. The Vercel preset labels them at the edge; anywhere else, add the header for the raw prefix and `/sitemap.md` in that host's own configuration.
 
 ### ISR and cached routes
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ What you get out of the box:
 In this order:
 
 1. An explicit `.md` twin URL is always a markdown request, whatever the headers say.
-2. `Accept: text/markdown` with a q-value that `text/html` doesn't outrank (wildcards like `*/*` never count as asking).
-3. A known agent User-Agent, matched by substring against the shared list.
+2. `Accept: text/markdown` with a q-value that `text/html` doesn't outrank. A wildcard on its own never counts as asking, so `*/*` and `text/*` keep HTML.
+3. `Accept` refusing `text/html` outright while a wildcard permits markdown, as in `text/html;q=0, */*`. The client ruled out the only other representation there is, so HTML would hand it the one thing it said it couldn't read. Narrow by construction: a browser and a `fetch()` both rate HTML through their own wildcard, so neither ever lands here.
+4. A known agent User-Agent, matched by substring against the shared list.
 
 Exclusions never negotiate: `/_`, `/api/`, `/mcp`, `/.well-known/`, the raw prefix itself, and any path whose last segment is dotted (assets, `_payload.json`, images).
 
@@ -420,6 +421,8 @@ Then, per route pattern, two negotiated routes: a `has` matcher on `Accept: text
 The explicit `.md` twin stays a rewrite either way: that URL only ever serves markdown, so it has no second variant to worry about.
 
 The `Accept` route also carries a `missing` matcher for `text/markdown;q=0`, so a client that explicitly refuses markdown gets HTML from the edge like it does from the origin. Full q-value precedence is not expressible in a matcher: Vercel runs RE2, which has no lookahead, so `Accept: text/markdown;q=0.1, text/html;q=0.9` is a known divergence. The Nitro middleware ranks those per RFC 9110 and returns HTML, while the edge rewrite still sends markdown. Only the outright refusal (`q=0`) is covered.
+
+`Accept: text/html;q=0, */*` is the same kind of divergence the other way. The matcher looks for a literal `text/markdown` range and there isn't one, so the edge serves HTML while the origin serves markdown. Expressing it would take a second route pair per pattern to test the refusal and the wildcard separately, which is a real cost to the table for a header almost nothing sends.
 
 The table stays O(route patterns): one set of routes per configured pattern, not one per page, however many pages the site has.
 

--- a/skills/verify-nuxt-agent-discovery/SKILL.md
+++ b/skills/verify-nuxt-agent-discovery/SKILL.md
@@ -103,19 +103,22 @@ Run every row against `$HOME` and `$DOC`, plus one page from each class the swee
 | `show -H 'Accept: text/markdown' "$PREVIEW$DOC"` | markdown body, `content-type: text/markdown`, 200 at the same URL (307 to the raw twin on a cached pattern, HTML on a non-Vercel host when the page is prerendered) |
 | `show -A "$BOT" "$PREVIEW$DOC"` | same markdown, no `Accept` header needed |
 | `probe -A "$GPT" "$PREVIEW$DOC"` | same as ClaudeBot |
-| `show "$PREVIEW$DOC.md"` | markdown, 200, a rewrite even on a cached pattern |
+| `show "$PREVIEW$DOC.md"` | markdown, 200, a rewrite even on a cached pattern, `vary` contains `Accept` and `User-Agent` |
+| `probe "$PREVIEW$RAW${DOC}.md"` | markdown, 200, same `vary`. This is where a 307 lands, so it is the response a shared cache stores |
+| `probe "$PREVIEW/sitemap.md"` | markdown, 200, same `vary` |
 | `probe -H 'Accept: text/markdown;q=0.5, text/html;q=0.9' "$PREVIEW$DOC"` | HTML **on an uncached pattern whose twin is not prerendered**, which is the only deterministic case: pick that `$DOC`. A CDN matcher cannot rank q-values, so a prerendered twin answers markdown at the edge and a cached pattern answers 307, both before the origin can rank anything. Documented in the README, not a bug |
 | `probe -H 'Accept: text/markdown;q=0.9, text/html;q=0.5' "$PREVIEW$DOC"` | markdown |
 | `probe -H 'Accept: text/markdown;q=0' "$PREVIEW$DOC"` | HTML |
 | `probe -H 'Accept: */*' "$PREVIEW$DOC"` | HTML, a wildcard never counts as asking |
 | `probe -H 'Accept: text/plain' "$PREVIEW$DOC"` | HTML, only `text/markdown` counts |
+| `probe -H 'Accept: application/xml' "$PREVIEW$DOC"` | HTML, unless the site set `notAcceptable: true`, which makes it a 406. Check the site's config before calling either one a failure |
 | `probe -A "$BOT" "$PREVIEW$UNCOVERED"` | HTML, an unconfigured page must not start negotiating |
 | `probe -A "$BOT" "$PREVIEW$DOC?ref=x"` | markdown, and if it is a 307 the `location` keeps `?ref=x` |
 | `probe -A "$BOT" -I "$PREVIEW$DOC"` | same status and headers as the GET. `-I`, not `-X HEAD`, which makes curl wait for a body that never comes |
 
 Two things that fail quietly, so check them explicitly:
 
-- **`Vary: Accept, User-Agent` is present on the markdown responses too**, including the ones served straight off the CDN rewrite. This is the `continue: true` fix most hand-rolled implementations get wrong. A markdown response with no `Vary` poisons the shared cache for browsers.
+- **`Vary: Accept, User-Agent` is present on the markdown responses too**, including the ones served straight off the CDN rewrite and the prerendered `/sitemap.md` and `/raw/index.md`. This is the `continue: true` fix most hand-rolled implementations get wrong. A markdown response with no `Vary` poisons the shared cache for browsers, and a checker following a 307 to the raw twin sees a URL with two representations behind it and no header saying so.
 - **The three markdown representations are byte-identical.**
 
 ```sh
@@ -332,7 +335,7 @@ jq '.routes | length' .vercel/output/config.json
 jq '.routes[0:6]' .vercel/output/config.json
 ```
 
-- The first route sets `Vary: Accept, User-Agent` with `continue: true`, ahead of anything Nitro emits from `routeRules`. The `Link` route on `/` does too.
+- The first route sets `Vary: Accept, User-Agent` on the pages with `continue: true`, ahead of anything Nitro emits from `routeRules`. The second sets it on the markdown representations: the raw prefix, the `.md` twins and `/sitemap.md`. The `Link` route on `/` carries `continue: true` too.
 - Two negotiated routes per configured pattern, one matching `Accept`, one matching the agent user agents. Prerendered patterns rewrite with `check: true`, cached patterns 307.
 - Total route count tracks the pattern count, not the page count.
 
@@ -353,7 +356,7 @@ Every finding lands in one of two repos, and the fix is different in each. Attri
 
 | Symptom | Likely owner | Confirm by |
 |---|---|---|
-| No `Vary` on a markdown response, or none on `/` | module, `src/presets/vercel.ts` | check the site does not override headers for that path in `routeRules` |
+| No `Vary` on a markdown response, or none on `/` | module, `src/presets/vercel.ts` | check the site does not override headers for that path in `routeRules`. Off Vercel a prerendered `/sitemap.md` or `/raw/index.md` is served off disk and carries none, which is the documented caveat, not a bug |
 | `text/plain` or `q=0` decided wrong, wildcard treated as asking | module, `src/runtime/shared/negotiation.ts` | a unit test in the module's `test/`, it is pure logic |
 | A whole section serves HTML to agents | site, `routes` patterns | does the pattern actually cover it? if it plainly does, the module's `compilePattern`/`matchRoute` |
 | `.md` twin 404s while `/raw/**.md` answers | module, `rawDestination` or the preset rewrite | unless an `excludePrefixes` entry on the site swallows that path |

--- a/src/module.ts
+++ b/src/module.ts
@@ -97,6 +97,16 @@ export interface ModuleOptions {
   }
   /** Answer errors with a markdown body when the client asked for markdown. */
   errors?: boolean
+  /**
+   * Answer a negotiated page with 406 when the request's `Accept` allows
+   * neither of its two representations, which is what RFC 9110 asks for.
+   *
+   * Off by default. Browsers and `fetch()` send a wildcard and are never
+   * affected, and neither is a navigation or a known agent, but a client
+   * sending a narrow `Accept` it did not mean starts getting an error where it
+   * used to get a page. See the "Strict content negotiation" README section.
+   */
+  notAcceptable?: boolean
   sitemap?: {
     /**
      * Serve `/sitemap.md`, a markdown index of every page. Pass an object to
@@ -193,6 +203,7 @@ export default defineNuxtModule<ModuleOptions>({
       links: []
     },
     errors: true,
+    notAcceptable: false,
     sitemap: { markdown: true },
     robots: { aiPolicy: true, contentSignal: 'search=yes, ai-train=yes, ai-input=yes' },
     skills: { dir: 'skills' }
@@ -248,6 +259,7 @@ export default defineNuxtModule<ModuleOptions>({
       excludePrefixes,
       links: [],
       linkHeader: options.discovery?.link !== false,
+      notAcceptable: options.notAcceptable === true,
       cachedRoutes: [],
       sitemapSections: {
         expand: (typeof options.sitemap?.markdown === 'object' && options.sitemap.markdown.expand) || [],

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -46,22 +46,36 @@ const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\
  */
 const REFUSES_MARKDOWN = String.raw`.*text/markdown\s*;\s*[qQ]=0(\.0+)?(\s*[;,].*)?`
 
+/** A media range half: a non-empty RFC 9110 token, which `*` is one of. */
+const TOKEN = String.raw`[a-z0-9!#$%&'*+.^_|~-]+`
+
 /**
- * `Accept` values leaving a negotiated page something to serve: an `text/html`
+ * `Accept` values leaving a negotiated page something to serve: a `text/html`
  * or `text/markdown` range, or a wildcard covering one of them.
  *
  * The `missing` matcher for the 406 route, so the page is refused only when
- * this does not match. A substring test, not the q-value ranking the runtime
- * does, for the same reason `REFUSES_MARKDOWN` exists: a matcher is a plain
- * regex over the raw header. So a representation offered and then refused with
- * `q=0` still reads as offered here, and the edge serves the page where the
- * origin would answer 406. That is the fail-safe direction, and the one this
- * route wants above all others.
+ * this does not match. Anchored at media-range boundaries the same way
+ * `acceptMarkdown` is, and for the same reason: a bare substring also matches
+ * inside a parameter value, so `Accept: application/json;profile="text/html"`
+ * read as offering HTML when the only range in it is JSON.
+ *
+ * Still not the q-value ranking the runtime does, because a matcher is a plain
+ * regex over the raw header. A representation offered and then refused with
+ * `q=0` reads as offered here, so the edge serves the page where the origin
+ * answers 406. That is the fail-safe direction, and the one this route wants
+ * above all others.
  */
-const ACCEPTS_A_REPRESENTATION = String.raw`.*(text/(html|markdown|\*)|\*/\*).*`
+const ACCEPTS_A_REPRESENTATION = String.raw`(.*,)?\s*(text/(html|markdown|\*)|\*/\*)\s*([;,].*)?`
 
-/** An `Accept` carrying at least one media range, however unacceptable. */
-const ANY_MEDIA_RANGE = String.raw`.*/.*`
+/**
+ * An `Accept` carrying at least one media range, however unacceptable.
+ *
+ * Both halves have to be there: `text/`, `/html` and `text/html/extra` are
+ * mangled rather than unacceptable, and the runtime ignores those rather than
+ * refusing over them. A looser test here would 406 at the edge what the origin
+ * serves, which is the one divergence this route cannot have.
+ */
+const ANY_MEDIA_RANGE = String.raw`(.*,)?\s*${TOKEN}/${TOKEN}\s*([;,].*)?`
 
 /** `has` matcher for the Vercel Build Output API, which anchors the value. */
 function agentUserAgentPattern(config: NegotiationConfig): string {

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -59,13 +59,19 @@ const TOKEN = String.raw`[a-z0-9!#$%&'*+.^_|~-]+`
  * inside a parameter value, so `Accept: application/json;profile="text/html"`
  * read as offering HTML when the only range in it is JSON.
  *
+ * The list separator has to be a real one too. `(.*,)?` treated the comma in
+ * `profile="x,text/html;q=0"` as the end of a range, which put the quoted
+ * fragment at the head of the next one and read it as an offer. Only quotes
+ * closed before the comma count, so a separator inside a quoted value cannot
+ * split the header.
+ *
  * Still not the q-value ranking the runtime does, because a matcher is a plain
  * regex over the raw header. A representation offered and then refused with
  * `q=0` reads as offered here, so the edge serves the page where the origin
  * answers 406. That is the fail-safe direction, and the one this route wants
  * above all others.
  */
-const ACCEPTS_A_REPRESENTATION = String.raw`(.*,)?\s*(text/(html|markdown|\*)|\*/\*)\s*([;,].*)?`
+const ACCEPTS_A_REPRESENTATION = String.raw`(([^"]|"[^"]*")*,)?\s*(text/(html|markdown|\*)|\*/\*)\s*([;,].*)?`
 
 /**
  * An `Accept` carrying at least one media range, however unacceptable.

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -46,6 +46,23 @@ const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\
  */
 const REFUSES_MARKDOWN = String.raw`.*text/markdown\s*;\s*[qQ]=0(\.0+)?(\s*[;,].*)?`
 
+/**
+ * `Accept` values leaving a negotiated page something to serve: an `text/html`
+ * or `text/markdown` range, or a wildcard covering one of them.
+ *
+ * The `missing` matcher for the 406 route, so the page is refused only when
+ * this does not match. A substring test, not the q-value ranking the runtime
+ * does, for the same reason `REFUSES_MARKDOWN` exists: a matcher is a plain
+ * regex over the raw header. So a representation offered and then refused with
+ * `q=0` still reads as offered here, and the edge serves the page where the
+ * origin would answer 406. That is the fail-safe direction, and the one this
+ * route wants above all others.
+ */
+const ACCEPTS_A_REPRESENTATION = String.raw`.*(text/(html|markdown|\*)|\*/\*).*`
+
+/** An `Accept` carrying at least one media range, however unacceptable. */
+const ANY_MEDIA_RANGE = String.raw`.*/.*`
+
 /** `has` matcher for the Vercel Build Output API, which anchors the value. */
 function agentUserAgentPattern(config: NegotiationConfig): string {
   return `.*(${config.userAgents.map(escapeRegExp).join('|')}).*`
@@ -105,11 +122,13 @@ function negotiatedRoute(src: string, dest: string, has: RouteMatcher[], cached:
  * serve markdown through content negotiation at the edge, where prerendered
  * pages never reach Nitro. The table stays O(route patterns), never O(pages).
  *
- * The `Vary` route must come first and carry `continue: true`: Nitro emits its
- * own `routeRules` header routes *after* these rewrites and without
+ * The two `Vary` routes must come first and carry `continue: true`: Nitro emits
+ * its own `routeRules` header routes *after* these rewrites and without
  * `continue`, so they never run for a request that gets rewritten to a
- * prerendered raw markdown file. It covers cached patterns too, even though
- * their 307 carries `Vary` itself, so the HTML variant is labelled as well.
+ * prerendered raw markdown file. The first labels the pages, cached patterns
+ * included even though their 307 carries `Vary` itself, so the HTML variant is
+ * labelled as well; the second labels the markdown representations those pages
+ * send a client to.
  */
 export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   // `text/markdown` at the head of a media range, not anywhere in the header.
@@ -145,14 +164,74 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   // routing. The dotted-segment lookahead is what keeps this off the documents
   // that have a single representation: without it this route labelled
   // `/llms.txt`, `/robots.txt`, `/sitemap.xml` and every file in `public/`,
-  // which fragments a shared cache per user-agent for nothing. `.md` twins are
-  // excluded by the same rule, and want to be: that URL only serves markdown.
+  // which fragments a shared cache per user-agent for nothing. It takes the
+  // `.md` twins out too, which the route below puts back deliberately.
   const varySources = config.routes.map(route => compilePattern(route.path).source.slice(1, -1))
   routes.push({
     src: `^${NO_DOTTED_LAST_SEGMENT}${excluded}(?:${varySources.join('|')})$`,
     headers: { Vary: MARKDOWN_VARY },
     continue: true
   })
+
+  // The markdown representations themselves: everything under the raw prefix,
+  // the `.md` twins, and `/sitemap.md`. Their own handlers set the header, but
+  // a prerendered file never reaches a handler, and a request one of the
+  // rewrites below matches never reaches what Nitro emits from `routeRules`
+  // either.
+  //
+  // A negotiated page rewrites or 307s to one of these, so the response a
+  // client keeps, and the one a shared cache stores, is the twin's. Labelling
+  // only the page leaves the URL the hop actually lands on saying nothing about
+  // the two representations behind it, which is what a checker following the
+  // redirect sees. The cost is a shared cache keyed per user-agent on these
+  // documents, which is why they were left alone until it turned out the
+  // negotiated pair has to be consistent end to end.
+  const twinSources = config.routes.flatMap((route) => {
+    if (route.path.includes('*')) {
+      return [`${excluded}${compilePattern(route.path).source.slice(1, -1)}\\.md`]
+    }
+    // `/` has no `.md` twin URL, matching the rewrite loop below.
+    return route.path === '/' ? [] : [`${escapeRegExp(route.path)}\\.md`]
+  })
+  // Keyed on the registered link rather than on this module serving the route,
+  // the same way the exclusion is: a site with `sitemap.markdown` off that
+  // serves its own through `discovery.links` needs the label just as much.
+  const markdownSources = [
+    `${escapeRegExp(config.rawPrefix)}/.*`,
+    ...twinSources,
+    ...(config.links.some(link => link.href === '/sitemap.md') ? [String.raw`/sitemap\.md`] : [])
+  ]
+  routes.push({
+    src: `^(?:${markdownSources.join('|')})$`,
+    headers: { Vary: MARKDOWN_VARY },
+    continue: true
+  })
+
+  // Opt-in: a negotiated page has exactly two representations, so an `Accept`
+  // allowing neither is a 406 per RFC 9110 rather than a page the client just
+  // said it cannot read. Emitted here as well as in the middleware because a
+  // prerendered page is answered off the filesystem and never reaches it, so
+  // without this the option would be on for the pages Nitro renders and
+  // quietly off for the rest of the site.
+  //
+  // The guards are the middleware's, as matchers: an `Accept` has to be there
+  // and carry a media range at all, must not offer a representation, and a
+  // navigation or a known agent is never refused. The body is empty, where the
+  // origin renders the markdown one, which is the price of answering before
+  // anything runs.
+  if (config.notAcceptable) {
+    routes.push({
+      src: `^${NO_DOTTED_LAST_SEGMENT}${excluded}(?:${varySources.join('|')})$`,
+      status: 406,
+      headers: { Vary: MARKDOWN_VARY },
+      has: [{ type: 'header', key: 'accept', value: ANY_MEDIA_RANGE }],
+      missing: [
+        { type: 'header', key: 'accept', value: ACCEPTS_A_REPRESENTATION },
+        { type: 'header', key: 'sec-fetch-mode', value: 'navigate' },
+        ...(agentUserAgent ? [agentUserAgent] : [])
+      ]
+    })
+  }
 
   // The `/` routeRule carries the same `Link` header, but a homepage request
   // rewritten below to a prerendered raw markdown file never reaches it.

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -1,7 +1,7 @@
 import { appendResponseHeader, createError, defineEventHandler, getRequestHeader, sendRedirect, setResponseHeader, setResponseStatus } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
-import { isNegotiablePath, negotiatedRawPath, normalizePathname, ruleMatchesPath, MARKDOWN_VARY } from '../../shared/negotiation'
+import { isNegotiablePath, negotiatedRawPath, normalizePathname, notAcceptable, ruleMatchesPath, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
  * Serves markdown through content negotiation on the Nitro server.
@@ -28,10 +28,10 @@ export default defineEventHandler(async (event) => {
 
   const config = useAgentDiscoveryConfig(event)
 
-  const rawPath = negotiatedRawPath(config, event.path, {
-    accept: getRequestHeader(event, 'accept'),
-    userAgent: getRequestHeader(event, 'user-agent')
-  })
+  const accept = getRequestHeader(event, 'accept')
+  const userAgent = getRequestHeader(event, 'user-agent')
+
+  const rawPath = negotiatedRawPath(config, event.path, { accept, userAgent })
 
   if (!rawPath) {
     // The HTML half of a page that has both representations. Its markdown half
@@ -44,6 +44,22 @@ export default defineEventHandler(async (event) => {
     if (isNegotiablePath(config, event.path)) {
       setResponseHeader(event, 'Vary', MARKDOWN_VARY)
     }
+
+    // Those two representations are all there is, so an `Accept` allowing
+    // neither has nothing to be served. Opt-in through `notAcceptable`, and
+    // guarded there against everything that sends a narrow `Accept` without
+    // meaning it. The error handler renders the body, listing what the page
+    // does have.
+    if (notAcceptable(config, {
+      method: event.method,
+      path: event.path,
+      accept,
+      userAgent,
+      secFetchMode: getRequestHeader(event, 'sec-fetch-mode')
+    })) {
+      throw createError({ statusCode: 406, statusMessage: 'Not Acceptable' })
+    }
+
     return
   }
 
@@ -102,12 +118,13 @@ export default defineEventHandler(async (event) => {
 
   setResponseStatus(event, response.status)
   setResponseHeader(event, 'Content-Type', response.headers.get('content-type') || 'text/markdown; charset=utf-8')
-  // The markdown half of a page that also has an HTML one. An explicit `.md`
-  // URL reaches here too and is not labelled: it serves markdown to every
-  // client, so nothing about it depends on the request headers.
-  if (isNegotiablePath(config, event.path)) {
-    setResponseHeader(event, 'Vary', MARKDOWN_VARY)
-  }
+  // The markdown half of a page that also has an HTML one, and the explicit
+  // `.md` twin that reaches here too. That URL serves markdown to every client,
+  // so nothing about it depends on the request, but it is where a negotiated
+  // page sends one, and the raw route it proxies labels its own responses the
+  // same way. Leaving it off here made the twin the one URL in the chain whose
+  // answer differed by preset.
+  setResponseHeader(event, 'Vary', MARKDOWN_VARY)
 
   for (const name of ['cache-control', 'x-content-type-options', 'x-frame-options', 'referrer-policy']) {
     const value = response.headers.get(name)

--- a/src/runtime/server/routes/raw.ts
+++ b/src/runtime/server/routes/raw.ts
@@ -2,7 +2,7 @@ import { createError, defineEventHandler, sendRedirect, setResponseHeader } from
 import source from '#agent-discovery/source'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { getAgentDocument } from '../utils/document'
-import { normalizePathname } from '../../shared/negotiation'
+import { normalizePathname, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
  * Serves the raw markdown representation of a page from the content adapter.
@@ -15,6 +15,14 @@ import { normalizePathname } from '../../shared/negotiation'
  * from an empty one. The error handler renders it as markdown for the raw
  * prefix, reporting the documentation path the client asked for through
  * `data.path`.
+ *
+ * `Vary` is on every response here, redirects included. This URL serves
+ * markdown to every client, so nothing about it depends on the request, but it
+ * is where a negotiated page sends one: the CDN answers `Accept: text/markdown`
+ * on a cached page with a 307, so the response the client keeps, and the one a
+ * shared cache stores, is this one. Without the header on it, whatever follows
+ * the hop lands on a URL with two representations behind it and nothing saying
+ * so.
  */
 export default defineEventHandler(async (event) => {
   const config = useAgentDiscoveryConfig(event)
@@ -33,6 +41,9 @@ export default defineEventHandler(async (event) => {
   if (!document) {
     throw createError({ statusCode: 404, statusMessage: 'Page Not Found', data: { path } })
   }
+
+  setResponseHeader(event, 'Vary', MARKDOWN_VARY)
+
   if ('redirect' in document) {
     return sendRedirect(event, `${config.rawPrefix}${document.redirect}.md`, 302)
   }

--- a/src/runtime/server/routes/sitemap.md.ts
+++ b/src/runtime/server/routes/sitemap.md.ts
@@ -2,6 +2,7 @@ import { defineEventHandler, setResponseHeader } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { listAgentPages } from '../utils/pages'
+import { MARKDOWN_VARY } from '../../shared/negotiation'
 
 const escapeLabel = (label: string) => label
   .replace(/\\/g, '\\\\')
@@ -17,6 +18,9 @@ const escapeLabel = (label: string) => label
  * the middleware and the `llms.txt` bridge resolve. Hand-rolling the twin here
  * put `/` on the HTML page while `llms.txt` pointed it at `/raw/index.md`, in
  * two documents an agent reads together, and ignored `raw` overrides.
+ *
+ * Carries `Vary` like the raw route does, so every markdown document the module
+ * serves answers the same way about what its response depends on.
  */
 export default defineEventHandler(async (event) => {
   const config = useAgentDiscoveryConfig(event)
@@ -69,5 +73,7 @@ export default defineEventHandler(async (event) => {
   }
 
   setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+  setResponseHeader(event, 'Vary', MARKDOWN_VARY)
+
   return lines.join('\n')
 })

--- a/src/runtime/server/utils/openapi.ts
+++ b/src/runtime/server/utils/openapi.ts
@@ -129,7 +129,7 @@ function text(description: string): Json {
   return { description, content: { 'text/plain': { schema: { type: 'string' } } } }
 }
 
-function negotiatedPage(route: AgentRoute, operationId: string): Json {
+function negotiatedPage(config: NegotiationConfig, route: AgentRoute, operationId: string): Json {
   const { path, params } = toTemplate(route.path)
   const label = route.path === '/' ? 'Homepage' : `Page under \`${route.path}\``
   return {
@@ -149,7 +149,11 @@ function negotiatedPage(route: AgentRoute, operationId: string): Json {
               'text/markdown': { schema: { type: 'string' } }
             }
           },
-          404: { $ref: '#/components/responses/NotFoundMarkdown' }
+          404: { $ref: '#/components/responses/NotFoundMarkdown' },
+          // Only the pages can refuse every representation, and only where the
+          // site turned that on. Left out otherwise rather than documented as
+          // a status nothing returns.
+          ...(config.notAcceptable ? { 406: { $ref: '#/components/responses/NotAcceptable' } } : {})
         }
       }
     }
@@ -195,7 +199,7 @@ export function agentDiscoveryOpenApi(event: H3Event): { tags: Json[], paths: Js
     const operation = routeOperation(route.path)
     Object.assign(
       paths,
-      negotiatedPage(route, `get${claim(taken, operation)}`),
+      negotiatedPage(config, route, `get${claim(taken, operation)}`),
       rawPage(config, route, `get${claim(taken, `${operation}Markdown`)}`)
     )
   }
@@ -361,7 +365,22 @@ export function agentDiscoveryOpenApi(event: H3Event): { tags: Json[], paths: Js
         NotFoundMarkdown: {
           description: 'The page does not exist. The body is a short Markdown document linking to the entry points an agent can recover from.',
           content: { 'text/markdown': { schema: { type: 'string' } } }
-        }
+        },
+        // The body follows the same rules every other error does, so a browser
+        // `fetch()` keeps the JSON it was written against while an agent or a
+        // command-line client gets the Markdown one.
+        ...(config.notAcceptable
+          ? {
+              NotAcceptable: {
+                description: 'The `Accept` header allows neither representation of the page. The body names the two that exist.',
+                headers: { Vary: { $ref: '#/components/headers/Vary' } },
+                content: {
+                  'text/markdown': { schema: { type: 'string' } },
+                  'application/json': { schema: { type: 'object' } }
+                }
+              }
+            }
+          : {})
       },
       schemas
     }

--- a/src/runtime/server/utils/openapi.ts
+++ b/src/runtime/server/utils/openapi.ts
@@ -112,8 +112,17 @@ function pathParameters(params: string[], pattern: string): Json[] {
   }))
 }
 
+/**
+ * A markdown response. Carries `Vary` like the negotiated page does: these URLs
+ * serve markdown to every client, but they are where a negotiated page sends
+ * one, so the header is on them too and the document has to say so.
+ */
 function markdown(description: string): Json {
-  return { description, content: { 'text/markdown': { schema: { type: 'string' } } } }
+  return {
+    description,
+    headers: { Vary: { $ref: '#/components/headers/Vary' } },
+    content: { 'text/markdown': { schema: { type: 'string' } } }
+  }
 }
 
 function text(description: string): Json {
@@ -344,7 +353,7 @@ export function agentDiscoveryOpenApi(event: H3Event): { tags: Json[], paths: Js
     components: {
       headers: {
         Vary: {
-          description: 'Always includes `Accept` and `User-Agent`, since the representation depends on both.',
+          description: 'Always includes `Accept` and `User-Agent`. The page depends on both, and its Markdown representation carries the header too, since that is where a negotiated request is sent.',
           schema: { type: 'string' }
         }
       },

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -376,6 +376,16 @@ export function isNegotiablePath(config: NegotiationConfig, path: string): boole
 export const REPRESENTATIONS = ['text/html', 'text/markdown']
 
 /**
+ * A media range as RFC 9110 spells one: a full wildcard, `type/*`, or
+ * `type/subtype`, each half a non-empty token.
+ *
+ * `text/`, `/html` and `text/html/extra` are not media ranges, they are a
+ * mangled header, and the difference matters: an unacceptable range is a 406
+ * while a mangled one is ignored.
+ */
+const MEDIA_RANGE = /^[a-z0-9!#$%&'*+.^_|~-]+\/[a-z0-9!#$%&'*+.^_|~-]+$/
+
+/**
  * Whether a negotiated page has to answer 406: the request carries an `Accept`
  * that rules out both of its representations, which is what RFC 9110 asks for
  * when a server cannot honour the header.
@@ -391,7 +401,9 @@ export const REPRESENTATIONS = ['text/html', 'text/markdown']
  * - a known agent gets markdown whatever its `Accept` says, so it can never be
  *   refused over a header it was not being read on anyway
  * - a header with no media range in it at all is malformed, and RFC 9110 says
- *   to ignore one of those rather than fail the request over it
+ *   to ignore one of those rather than fail the request over it. `garbage` is
+ *   one, and so is a half-mangled `text/` or `/html`, which is the shape a
+ *   proxy rewriting the header leaves behind
  *
  * `Accept: text/markdown;q=0` reaches the last check and is a 406, on the same
  * reading that makes `Accept: application/xml` one: a quality of zero is a
@@ -431,8 +443,12 @@ export function notAcceptable(config: NegotiationConfig, options: {
     return false
   }
 
+  // One intelligible range is enough to judge the request on. RFC 9110 says to
+  // ignore what cannot be parsed, so `application/xml, text/` is still a
+  // refusal of both representations while `text/` on its own is not a request
+  // this can read at all.
   const entries = parseAccept(options.accept)
-  if (!entries.some(entry => entry.type.includes('/'))) {
+  if (!entries.some(entry => MEDIA_RANGE.test(entry.type))) {
     return false
   }
 

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -276,16 +276,26 @@ export function acceptQuality(entries: AcceptEntry[], target: string): number {
 
 /**
  * Whether the client explicitly asked for markdown: a literal `text/markdown`
- * entry with a non-zero q-value that html does not outrank. Wildcards never
- * count as asking, so wildcard-only clients keep HTML on pages.
+ * entry with a non-zero q-value that html does not outrank. A wildcard on its
+ * own never counts as asking, so wildcard-only clients keep HTML on pages.
+ *
+ * Unless it refused html outright. A client sending `text/html;q=0` alongside
+ * a full wildcard has ruled out the only other representation there is, so
+ * html hands it the one thing it said it could not read, and the page is not
+ * unacceptable either: markdown rates through that wildcard, so there is
+ * nothing for `notAcceptable` to refuse. Markdown is the only answer left.
+ *
+ * Narrow on purpose: a browser and a `fetch()` both rate html through their
+ * own wildcard, so neither ever reaches this.
  */
 export function acceptsMarkdown(accept?: string | null): boolean {
   const entries = parseAccept(accept)
+  const html = acceptQuality(entries, 'text/html')
   const markdown = explicitQuality(entries, 'text/markdown')
-  if (!markdown) {
-    return false
+  if (markdown) {
+    return markdown >= html
   }
-  return markdown >= acceptQuality(entries, 'text/html')
+  return html === 0 && acceptQuality(entries, 'text/markdown') > 0
 }
 
 /** Case-sensitive on purpose, so it agrees with the CDN `has` matchers. */

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -370,6 +370,76 @@ export function isNegotiablePath(config: NegotiationConfig, path: string): boole
 }
 
 /**
+ * The media types a negotiated page has a representation for, in the order the
+ * 406 body lists them.
+ */
+export const REPRESENTATIONS = ['text/html', 'text/markdown']
+
+/**
+ * Whether a negotiated page has to answer 406: the request carries an `Accept`
+ * that rules out both of its representations, which is what RFC 9110 asks for
+ * when a server cannot honour the header.
+ *
+ * Off unless a site turns it on, and narrow when it is on, because every false
+ * positive here is a page that used to render turning into an error. So:
+ *
+ * - no `Accept` at all means the client takes anything, and the full wildcard
+ *   a `fetch()` sends, or the one at `q=0.8` every browser sends, rates both
+ *   representations through `acceptQuality`, so neither reaches the last check
+ * - a `Sec-Fetch-Mode` of `navigate` is a real navigation, and keeps its page
+ *   whatever it asked for, the same protection `prefersMarkdownError` gives
+ * - a known agent gets markdown whatever its `Accept` says, so it can never be
+ *   refused over a header it was not being read on anyway
+ * - a header with no media range in it at all is malformed, and RFC 9110 says
+ *   to ignore one of those rather than fail the request over it
+ *
+ * `Accept: text/markdown;q=0` reaches the last check and is a 406, on the same
+ * reading that makes `Accept: application/xml` one: a quality of zero is a
+ * refusal, and refusing both representations leaves nothing to send.
+ */
+export function notAcceptable(config: NegotiationConfig, options: {
+  method?: string
+  path: string
+  accept?: string | null
+  userAgent?: string | null
+  secFetchMode?: string | null
+}): boolean {
+  if (!config.notAcceptable) {
+    return false
+  }
+
+  const method = (options.method || 'GET').toUpperCase()
+  if (method !== 'GET' && method !== 'HEAD') {
+    return false
+  }
+
+  if (!options.accept?.trim()) {
+    return false
+  }
+
+  // Only a URL with more than one representation can refuse them all. Rules
+  // out the assets, the excluded prefixes and the `.md` twins in one call.
+  if (!isNegotiablePath(config, options.path)) {
+    return false
+  }
+
+  if (isAgentUserAgent(config, options.userAgent)) {
+    return false
+  }
+
+  if (options.secFetchMode && options.secFetchMode.toLowerCase() === 'navigate') {
+    return false
+  }
+
+  const entries = parseAccept(options.accept)
+  if (!entries.some(entry => entry.type.includes('/'))) {
+    return false
+  }
+
+  return REPRESENTATIONS.every(type => acceptQuality(entries, type) === 0)
+}
+
+/**
  * Whether an error response should be rendered as markdown rather than the
  * HTML error page (or the JSON payload Nitro falls back to).
  */
@@ -564,6 +634,7 @@ const STATUS_TEXT: Record<number, string> = {
   403: 'Forbidden',
   404: 'Page Not Found',
   405: 'Method Not Allowed',
+  406: 'Not Acceptable',
   410: 'Gone',
   429: 'Too Many Requests'
 }
@@ -593,9 +664,13 @@ export function errorMarkdown(config: NegotiationConfig, options: { path: string
     ? STATUS_TEXT[404]!
     : statusMessage || STATUS_TEXT[status] || (status < 500 ? 'Request Error' : 'Server Error')
 
+  // A 406 says which representations exist, which is the "list of available
+  // representation characteristics" RFC 9110 asks a 406 body to carry.
   const intro = status === 404
     ? `The page \`${pathname}\` does not exist on ${siteUrl}.`
-    : `The request for \`${pathname}\` failed with status ${status}.`
+    : status === 406
+      ? `\`${pathname}\` is available as ${REPRESENTATIONS.map(type => `\`${type}\``).join(' and ')}, and the request's \`Accept\` header allows neither.`
+      : `The request for \`${pathname}\` failed with status ${status}.`
 
   const links = config.links
     .filter(link => link.title)

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -190,4 +190,10 @@ export interface NegotiationConfig {
    * CDN-level rewrites still apply because they run before the cache.
    */
   cachedRoutes: string[]
+  /**
+   * Whether a negotiated page answers 406 to an `Accept` that allows neither
+   * of its two representations. Off unless the site asks for it: the strictly
+   * correct answer breaks any client sending a narrow `Accept` it did not mean.
+   */
+  notAcceptable: boolean
 }

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -1,8 +1,26 @@
+import { get } from 'node:http'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { fetch, setup } from '@nuxt/test-utils/e2e'
-import { BROWSER_ACCEPT, CLAUDE_BOT, MARKDOWN_VARY, SITE_URL } from './expected'
+import { fetch, setup, url } from '@nuxt/test-utils/e2e'
+import { BROWSER_ACCEPT, CLAUDE_BOT, MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY, SITE_URL } from './expected'
 import { describeSharedDocuments } from './shared'
+
+/**
+ * A request `fetch()` cannot make. `Sec-Fetch-Mode` is a forbidden header
+ * name, so undici replaces whatever is passed with `cors` and sends it on
+ * every request, which is neither the navigation nor the bare non-browser
+ * client the error rules are written against.
+ */
+function request(path: string, headers: Record<string, string> = {}): Promise<{ status: number, headers: Record<string, string | string[] | undefined>, body: string }> {
+  return new Promise((resolve, reject) => {
+    get(url(path), { headers }, (response) => {
+      let body = ''
+      response.setEncoding('utf8')
+      response.on('data', chunk => (body += chunk))
+      response.on('end', () => resolve({ status: response.statusCode!, headers: response.headers, body }))
+    }).on('error', reject)
+  })
+}
 
 /**
  * The `@nuxt/content` fixture, built and served on the Node preset. Covers the
@@ -38,6 +56,71 @@ describe('content negotiation', () => {
     const response = await fetch('/docs/getting-started', { headers: { Accept: 'text/markdown;q=0.4, text/html;q=0.9' } })
 
     expect(response.headers.get('content-type')).toContain('text/html')
+  })
+})
+
+// `notAcceptable: true` in this fixture. A page has an HTML and a markdown
+// representation and nothing else, so an `Accept` allowing neither has nothing
+// to be answered with.
+describe('406 on a page whose representations were all refused', () => {
+  it('refuses an `Accept` that rules out both, and says which they are', async () => {
+    const response = await request('/docs/getting-started', { Accept: 'application/xml' })
+
+    expect(response.status).toBe(406)
+    expect(response.headers.vary).toBe(MARKDOWN_VARY)
+    expect(response.headers['content-type']).toBe(MARKDOWN_CONTENT_TYPE)
+    expect(response.body).toContain('# 406 Not Acceptable')
+    expect(response.body).toContain('`text/html` and `text/markdown`')
+  })
+
+  // A browser `fetch()` keeps the JSON error it was written against, the same
+  // rule that already governs every other status.
+  it('refuses a browser `fetch()` too, in the shape that client expects', async () => {
+    const response = await fetch('/docs/getting-started', { headers: { Accept: 'application/xml' } })
+
+    expect(response.status).toBe(406)
+    expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
+    expect(response.headers.get('content-type')).toContain('application/json')
+  })
+
+  it('refuses markdown explicitly refused with no html to fall back on', async () => {
+    const response = await fetch('/docs/getting-started', { headers: { Accept: 'text/markdown;q=0' } })
+
+    expect(response.status).toBe(406)
+  })
+
+  it('keeps serving every client that sends a wildcard', async () => {
+    for (const accept of [BROWSER_ACCEPT, '*/*', 'text/*']) {
+      const response = await fetch('/docs/getting-started', { headers: { Accept: accept } })
+      expect(response.status).toBe(200)
+    }
+  })
+
+  it('never refuses a navigation', async () => {
+    const response = await request('/docs/getting-started', {
+      'Accept': 'application/xml',
+      'Sec-Fetch-Mode': 'navigate'
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers['content-type']).toContain('text/html')
+  })
+
+  it('never refuses a known agent', async () => {
+    const response = await fetch('/docs/getting-started', {
+      headers: { 'Accept': 'application/xml', 'User-Agent': CLAUDE_BOT }
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
+  })
+
+  // Only the pages negotiate, so only the pages can refuse them all.
+  it('leaves the single-representation URLs alone', async () => {
+    for (const path of ['/docs/getting-started.md', '/raw/docs/getting-started.md', '/llms.txt', '/sitemap.md']) {
+      const response = await fetch(path, { headers: { Accept: 'application/xml' } })
+      expect(response.status, path).toBe(200)
+    }
   })
 })
 
@@ -263,6 +346,11 @@ describe('openapi fragments', () => {
     expect(doc.paths['/{path}']!.get.parameters?.[0]).toMatchObject({ name: 'path', in: 'path', required: true })
     expect(doc.paths['/']!.get.responses['200']!.content).toHaveProperty('text/markdown')
     expect(doc.paths['/']!.get.responses['200']!.headers.Vary).toEqual({ $ref: '#/components/headers/Vary' })
+    // The twin and `/sitemap.md` carry the header too, so the document has to
+    // say so or it understates what the raw route returns.
+    for (const path of ['/raw/index.md', '/raw/{path}.md', '/sitemap.md']) {
+      expect(doc.paths[path]!.get.responses['200']!.headers.Vary, path).toEqual({ $ref: '#/components/headers/Vary' })
+    }
   })
 
   it('names every operation, so a generated client keeps its method names', async () => {

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -57,6 +57,16 @@ describe('content negotiation', () => {
 
     expect(response.headers.get('content-type')).toContain('text/html')
   })
+
+  // HTML is the one representation this client refused, and markdown rates
+  // through its wildcard, so there is nothing else left to answer with.
+  it('serves markdown when html is refused and a wildcard permits it', async () => {
+    const response = await fetch('/docs/getting-started', { headers: { Accept: 'text/html;q=0, */*;q=1' } })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
+    expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
+  })
 })
 
 // `notAcceptable: true` in this fixture. A page has an HTML and a markdown

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -89,6 +89,23 @@ describe('406 on a page whose representations were all refused', () => {
     expect(response.status).toBe(406)
   })
 
+  // The only range here is JSON. A supported type sitting inside a parameter
+  // value is not an offer, which the edge matcher has to agree on.
+  it('does not read a representation out of a parameter value', async () => {
+    const response = await fetch('/docs/getting-started', { headers: { Accept: 'application/json;profile="text/html"' } })
+
+    expect(response.status).toBe(406)
+  })
+
+  // A mangled header is not an unacceptable one, so a proxy rewriting `Accept`
+  // cannot take a page down.
+  it('serves the page for a half-mangled `Accept`', async () => {
+    for (const accept of ['text/', '/html', 'text/html/extra']) {
+      const response = await fetch('/docs/getting-started', { headers: { Accept: accept } })
+      expect(response.status, accept).toBe(200)
+    }
+  })
+
   it('keeps serving every client that sends a wildcard', async () => {
     for (const accept of [BROWSER_ACCEPT, '*/*', 'text/*']) {
       const response = await fetch('/docs/getting-started', { headers: { Accept: accept } })
@@ -374,6 +391,25 @@ describe('openapi fragments', () => {
     // A client generator turns these into method names, so a duplicate would
     // silently drop an operation.
     expect(new Set(Object.values(ids)).size).toBe(Object.values(ids).length)
+  })
+
+  // `notAcceptable: true` in this fixture, so the pages can answer 406 and the
+  // document has to say so or a generated client will not handle it.
+  it('describes the 406 where the site turned strict negotiation on', async () => {
+    const doc = (await (await fetch('/openapi.json')).json()) as {
+      paths: Record<string, { get: { responses: Record<string, unknown> } }>
+      components: { responses: Record<string, { content: Record<string, unknown>, headers: Record<string, unknown> }> }
+    }
+
+    expect(doc.paths['/']!.get.responses['406']).toEqual({ $ref: '#/components/responses/NotAcceptable' })
+    expect(doc.paths['/{path}']!.get.responses['406']).toEqual({ $ref: '#/components/responses/NotAcceptable' })
+    // Only the pages negotiate, so only the pages can refuse them all.
+    expect(doc.paths['/raw/index.md']!.get.responses).not.toHaveProperty('406')
+    expect(doc.paths['/sitemap.md']!.get.responses).not.toHaveProperty('406')
+
+    const response = doc.components.responses.NotAcceptable!
+    expect(response.headers.Vary).toEqual({ $ref: '#/components/headers/Vary' })
+    expect(Object.keys(response.content)).toEqual(['text/markdown', 'application/json'])
   })
 
   it('only describes the discovery documents this site actually serves', async () => {

--- a/test/e2e/custom-source.test.ts
+++ b/test/e2e/custom-source.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { fetch, setup } from '@nuxt/test-utils/e2e'
-import { MARKDOWN_CONTENT_TYPE, SITE_URL } from './expected'
+import { MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY, SITE_URL } from './expected'
 import { describeSharedDocuments } from './shared'
 
 /**
@@ -23,6 +23,16 @@ await setup({
 
 describeSharedDocuments()
 
+describe('content negotiation', () => {
+  // `notAcceptable` is off here, which is the default. The strict answer would
+  // be a 406, and turning it on is the site's call: see the `basic` fixture.
+  it('serves the page for an `Accept` allowing neither representation', async () => {
+    const response = await fetch('/docs/getting-started', { headers: { Accept: 'application/xml' } })
+
+    expect(response.status).not.toBe(406)
+  })
+})
+
 describe('discovery documents', () => {
   // Without the `/sitemap.md` exclusion the module adds, the negotiation
   // middleware would treat this as the `.md` twin of a page called
@@ -40,6 +50,11 @@ describe('discovery documents', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
+    // Asserted here rather than in the shared documents for the same reason:
+    // the `@nuxt/content` fixture prerenders this file, so the handler that
+    // sets the header never runs there. On Vercel the CDN route covers it, see
+    // the `Vary on the markdown representations` unit tests.
+    expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
 
     const body = await response.text()
     expect(body).toContain('# Basic Sitemap')

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -121,9 +121,10 @@ describe('O(1) route table', () => {
     const exact = config.routes.filter(route => !route.path.includes('*')).length
     const glob = config.routes.filter(route => route.path.includes('*')).length
 
-    // 2 header routes (`Vary`, `Link`) + 2 per exact path + 3 per glob, and
-    // nothing that scales with the 5 content files or the 2 locales.
-    expect(routes).toHaveLength(2 + exact * 2 + glob * 3)
+    // 3 header routes (`Vary` on the pages, `Vary` on the markdown twins,
+    // `Link`) + 2 per exact path + 3 per glob, and nothing that scales with
+    // the 5 content files or the 2 locales.
+    expect(routes).toHaveLength(3 + exact * 2 + glob * 3)
   })
 
   it('captures the locale segment rather than enumerating locales', async () => {

--- a/test/e2e/shared.ts
+++ b/test/e2e/shared.ts
@@ -56,10 +56,10 @@ export function describeSharedDocuments(): void {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
-      // No `Vary`: this URL answers markdown to every client, so nothing about
-      // the response depends on `Accept` or `User-Agent`. Only the page it is
-      // the twin of carries the header.
-      expect(response.headers.get('vary')).toBeNull()
+      // `Vary` even though this URL answers markdown to every client. It is
+      // where a negotiated page sends a client, so it is the response the
+      // client keeps and the one a shared cache stores.
+      expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
       expect(response.headers.get('link')).toBe(GETTING_STARTED_LINK)
       expect(await response.text()).toBe(GETTING_STARTED_MARKDOWN)
     })
@@ -69,7 +69,7 @@ export function describeSharedDocuments(): void {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
-      expect(response.headers.get('vary')).toBeNull()
+      expect(response.headers.get('vary')).toBe(MARKDOWN_VARY)
       expect(await response.text()).toBe(GETTING_STARTED_MARKDOWN)
     })
 

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -35,6 +35,10 @@ function isModuleRoute(route: VercelRoute): boolean {
   if (route.status === 307 && route.headers?.Location?.startsWith('/raw/')) {
     return true
   }
+  // The opt-in 406, which answers a status and goes nowhere at all.
+  if (route.status === 406) {
+    return true
+  }
   return route.continue === true && Boolean(route.headers?.Vary || route.headers?.Link)
 }
 
@@ -71,14 +75,35 @@ beforeAll(() => {
 }, 300000)
 
 describe('vercel build output', () => {
-  it('leads with a `continue: true` `Vary` route', () => {
-    expect(routes[0]).toBeDefined()
-    expect(routes[0]!.continue).toBe(true)
-    expect(routes[0]!.headers?.Vary).toBe(MARKDOWN_VARY)
+  it('leads with two `continue: true` `Vary` routes', () => {
     // Nitro emits its own `routeRules` header routes after the rewrites and
-    // without `continue`, so this one has to come first to reach a request
+    // without `continue`, so these have to come first to reach a request
     // rewritten to a prerendered raw markdown file.
-    expect(routes[0]!.dest).toBeUndefined()
+    for (const route of [routes[0], routes[1]]) {
+      expect(route).toBeDefined()
+      expect(route!.continue).toBe(true)
+      expect(route!.headers?.Vary).toBe(MARKDOWN_VARY)
+      expect(route!.dest).toBeUndefined()
+    }
+
+    // The page, then the markdown representation it sends a client to. The
+    // prerendered files are the reason this is a CDN route at all: they never
+    // reach the handler that sets the header.
+    expect(new RegExp(routes[0]!.src!).test('/docs/getting-started')).toBe(true)
+    expect(new RegExp(routes[1]!.src!).test('/raw/index.md')).toBe(true)
+    expect(new RegExp(routes[1]!.src!).test('/sitemap.md')).toBe(true)
+  })
+
+  it('refuses at the edge what the middleware refuses at the origin', () => {
+    const refusal = routes.find(route => route.status === 406)
+
+    // A prerendered page never reaches the middleware, so the option would
+    // otherwise be on for the pages Nitro renders and off for the rest.
+    expect(refusal).toBeDefined()
+    expect(refusal!.dest).toBeUndefined()
+    expect(new RegExp(refusal!.src!).test('/docs/getting-started')).toBe(true)
+    expect(refusal!.has?.[0]?.key).toBe('accept')
+    expect(refusal!.missing?.map(entry => entry.key)).toEqual(['accept', 'sec-fetch-mode', 'user-agent'])
   })
 
   it('emits a `continue: true` `Link` route on the homepage', () => {
@@ -90,7 +115,10 @@ describe('vercel build output', () => {
   })
 
   it('negotiates on the `Accept` header', () => {
-    const acceptRoutes = routes.filter(route => route.has?.some(has => has.type === 'header' && has.key === 'accept'))
+    // The 406 matches on `Accept` too, but to refuse rather than to resolve a
+    // twin, so it is not one of the routes this asserts about.
+    const acceptRoutes = routes.filter(route => route.status !== 406
+      && route.has?.some(has => has.type === 'header' && has.key === 'accept'))
 
     expect(acceptRoutes.length).toBeGreaterThanOrEqual(2)
     for (const route of acceptRoutes) {
@@ -153,11 +181,12 @@ describe('vercel build output', () => {
     const patterns = 2 // `routes: ['/', '/**']`
     const exact = 1 // `/`
     const cachedRules = 1 // `/docs/components/**`
-    const headerRoutes = 2 // `Vary` and `Link`
+    const headerRoutes = 3 // `Vary` on the pages, `Vary` on the markdown twins, `Link`
+    const refusals = 1 // `notAcceptable: true` in the fixture
     // Per pattern: an `Accept` route and a User-Agent route, plus a `.md` alias
     // for a wildcard. Per cached rule narrower than the pattern over it: its own
     // redirect pair.
-    expect(count).toBe(headerRoutes + patterns * 2 + (patterns - exact) + cachedRules * 2)
+    expect(count).toBe(headerRoutes + refusals + patterns * 2 + (patterns - exact) + cachedRules * 2)
   })
 
   // The cache-correctness path, asserted against real emitted output rather

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -29,6 +29,11 @@ export default defineNuxtConfig({
 
   agentDiscovery: {
     siteName: 'Basic',
+    // The opt-in strict answer, on here so both halves of it are covered: the
+    // middleware on this build, and the CDN route in the Build Output the
+    // `vercel` suite reads. Every other fixture leaves it off, which is where
+    // the default is covered.
+    notAcceptable: true,
     // `/agent-resources.md` is served by its own handler, so it has to be
     // excluded or the catch-all route pattern would rewrite it to its raw twin.
     excludePrefixes: { extend: ['/agent-resources.md', '/openapi.json'] },

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -89,6 +89,15 @@ async function setupModule(options: Partial<ModuleOptions> = {}, routeRules: Rec
   return nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
 }
 
+describe('module setup: notAcceptable', () => {
+  // Off unless asked for. The strictly correct 406 breaks any client sending a
+  // narrow `Accept` it did not mean, so a site has to opt into it.
+  it('is off by default and carried into the runtime config when set', async () => {
+    expect((await setupModule()).notAcceptable).toBe(false)
+    expect((await setupModule({ notAcceptable: true })).notAcceptable).toBe(true)
+  })
+})
+
 describe('module setup: shared defaults', () => {
   it('never mutates the module-level defaults, however many instances run', async () => {
     const first = await setupModule()

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -397,9 +397,27 @@ describe('notAcceptable', () => {
 
   // RFC 9110 says to ignore a header it cannot parse rather than fail the
   // request over it, and a proxy mangling `Accept` must not take a page down.
+  // A half-mangled range is the shape one of those leaves behind.
   it('ignores an `Accept` carrying no media range at all', () => {
     expect(notAcceptable(strict, { path: '/docs/foo', accept: 'garbage' })).toBe(false)
     expect(notAcceptable(strict, { path: '/docs/foo', accept: ',,' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: '/html' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/html/extra' })).toBe(false)
+  })
+
+  // One intelligible range is enough to judge the request on, so a mangled
+  // entry alongside a real one does not buy a page back.
+  it('still refuses when a real range sits next to a mangled one', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml, text/' })).toBe(true)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'garbage, text/html' })).toBe(false)
+  })
+
+  // The type has to be a range of its own, not a string inside a parameter
+  // value. The edge matcher was reading one out of there and serving the page.
+  it('does not read a representation out of a parameter value', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/json;profile="text/html"' })).toBe(true)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/json;profile="x", text/html' })).toBe(false)
   })
 })
 

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -144,6 +144,24 @@ describe('acceptsMarkdown', () => {
     expect(acceptsMarkdown('text/*;q=1, text/html;q=0.1')).toBe(false)
   })
 
+  // A client that refused html and left a wildcard open ruled out the only
+  // other representation there is, so html would hand it the one thing it said
+  // it could not read, and the page is not unacceptable either since markdown
+  // rates through that wildcard.
+  it('counts a wildcard once html is refused outright', () => {
+    expect(acceptsMarkdown('text/html;q=0, */*;q=1')).toBe(true)
+    expect(acceptsMarkdown('text/html;q=0, text/*')).toBe(true)
+  })
+
+  it('leaves every client that rates html through its wildcard alone', () => {
+    expect(acceptsMarkdown('text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8')).toBe(false)
+    expect(acceptsMarkdown('*/*;q=0.8')).toBe(false)
+    // Nothing left to fall back on: refusing html without a wildcard is not a
+    // markdown request, it is a request for something the page does not have.
+    expect(acceptsMarkdown('text/html;q=0')).toBe(false)
+    expect(acceptsMarkdown('application/xml')).toBe(false)
+  })
+
   it('is case-insensitive on media types', () => {
     expect(acceptsMarkdown('TEXT/MARKDOWN')).toBe(true)
     expect(acceptsMarkdown('Text/Markdown;Q=0')).toBe(false)
@@ -165,6 +183,10 @@ describe('negotiatedRawPath: headers', () => {
 
   it('does not serve markdown for q=0', () => {
     expect(negotiatedRawPath(config, '/docs/foo', { accept: 'text/markdown;q=0' })).toBeUndefined()
+  })
+
+  it('serves markdown when html is refused and a wildcard permits it', () => {
+    expect(negotiatedRawPath(config, '/docs/foo', { accept: 'text/html;q=0, */*;q=1' })).toBe('/raw/docs/foo.md')
   })
 
   it('does not serve markdown when html outranks it', () => {
@@ -362,6 +384,13 @@ describe('notAcceptable', () => {
     // One of the two still acceptable is a page, not an error.
     expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/markdown;q=0, text/html' })).toBe(false)
     expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml, text/markdown;q=0.1' })).toBe(false)
+  })
+
+  // Markdown rates through the wildcard, so there is nothing to refuse. The
+  // page is served as markdown instead, see `acceptsMarkdown`.
+  it('does not refuse a request one representation still satisfies', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/html;q=0, */*;q=1' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/html;q=0, text/*' })).toBe(false)
   })
 
   it('leaves browsers and `fetch()` alone', () => {

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -12,6 +12,7 @@ import {
   matchRoute,
   negotiatedRawPath,
   normalizeAgentRoute,
+  notAcceptable,
   normalizePathname,
   parseAccept,
   patternsOverlap,
@@ -38,6 +39,7 @@ function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationCo
     linkHeader: true,
     cachedRoutes: [],
     sitemapSections: { expand: [], labels: {} },
+    notAcceptable: false,
     ...overrides
   }
 }
@@ -336,6 +338,71 @@ describe('prefersMarkdownError', () => {
   })
 })
 
+// The opt-in strict answer. Every case below that returns `false` is a page
+// that used to render and has to keep rendering, which is why the option
+// exists at all rather than this being the default.
+describe('notAcceptable', () => {
+  const strict = createConfig({ notAcceptable: true })
+
+  it('is off unless the site turns it on', () => {
+    expect(notAcceptable(config, { path: '/docs/foo', accept: 'application/xml' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml' })).toBe(true)
+  })
+
+  it('refuses an `Accept` that rules out both representations', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml' })).toBe(true)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'image/png, application/pdf' })).toBe(true)
+    expect(notAcceptable(strict, { path: '/', accept: 'application/xml' })).toBe(true)
+  })
+
+  // A quality of zero is a refusal, so refusing both leaves nothing to send.
+  it('reads `q=0` as a refusal', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/markdown;q=0' })).toBe(true)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/html;q=0, text/markdown;q=0' })).toBe(true)
+    // One of the two still acceptable is a page, not an error.
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/markdown;q=0, text/html' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml, text/markdown;q=0.1' })).toBe(false)
+  })
+
+  it('leaves browsers and `fetch()` alone', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/html,application/xhtml+xml,*/*;q=0.8' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: '*/*' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'text/*' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: '' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo' })).toBe(false)
+  })
+
+  it('never refuses a navigation or a known agent', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml', secFetchMode: 'navigate' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml', userAgent: CLAUDE_BOT })).toBe(false)
+    // Any other `Sec-Fetch-Mode` is a subresource request, which is refused
+    // like every other client that asked for something the page does not have.
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'application/xml', secFetchMode: 'cors' })).toBe(true)
+  })
+
+  it('only answers GET and HEAD', () => {
+    expect(notAcceptable(strict, { method: 'POST', path: '/docs/foo', accept: 'application/xml' })).toBe(false)
+    expect(notAcceptable(strict, { method: 'head', path: '/docs/foo', accept: 'application/xml' })).toBe(true)
+  })
+
+  // A URL with one representation cannot refuse them all: nothing about it
+  // depended on `Accept` in the first place.
+  it('only covers the pages that negotiate', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo.md', accept: 'application/xml' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/raw/docs/foo.md', accept: 'application/xml' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/api/x', accept: 'application/xml' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/logo.png', accept: 'application/xml' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/blog/x', accept: 'application/xml' })).toBe(false)
+  })
+
+  // RFC 9110 says to ignore a header it cannot parse rather than fail the
+  // request over it, and a proxy mangling `Accept` must not take a page down.
+  it('ignores an `Accept` carrying no media range at all', () => {
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: 'garbage' })).toBe(false)
+    expect(notAcceptable(strict, { path: '/docs/foo', accept: ',,' })).toBe(false)
+  })
+})
+
 // What `Vary` is derived from: a URL with two representations, independent of
 // what the client asked for. A route rule cannot express these exclusions,
 // which is why the header does not come from one.
@@ -438,6 +505,15 @@ describe('errorMarkdown', () => {
     expect(body).toContain('status: 404')
     expect(body).toContain('# 404 Page Not Found')
     expect(body).toContain('The page `/docs/gone` does not exist on https://example.com.')
+  })
+
+  // RFC 9110 asks a 406 body to carry a list of available representation
+  // characteristics, which for a negotiated page is exactly its two.
+  it('lists the representations a 406 refused', () => {
+    const body = errorMarkdown(config, { path: '/docs/foo', status: 406, statusMessage: 'Not Acceptable', siteUrl: 'https://example.com' })
+    expect(body).toContain('title: "Not Acceptable"')
+    expect(body).toContain('# 406 Not Acceptable')
+    expect(body).toContain('`/docs/foo` is available as `text/html` and `text/markdown`, and the request\'s `Accept` header allows neither.')
   })
 
   it('strips backticks and backslashes from the path', () => {

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -195,6 +195,17 @@ describe('vercelMarkdownRoutes: 406', () => {
     expect(offers('application/json;profile="x", text/html')).toBe(true)
   })
 
+  // A comma inside a quoted value is not a list separator, so the fragment
+  // after it is not the head of a new media range. Reading it as one put the
+  // quoted `text/html` at the front of an entry and skipped the refusal.
+  it('does not split the header on a comma inside a quoted value', () => {
+    const offers = accepts(refusal)
+    expect(offers('application/json;profile="x,text/html;q=0"')).toBe(false)
+    expect(offers('application/json;profile="a,text/markdown"')).toBe(false)
+    // A separator outside the quotes still separates.
+    expect(offers('application/json;profile="a,b", text/html')).toBe(true)
+  })
+
   // A matcher is a plain regex over the raw header, so a representation
   // offered and then refused at `q=0` still reads as offered. The edge serves
   // the page where the origin answers 406, which is the fail-safe direction.

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -136,6 +136,9 @@ describe('vercelMarkdownRoutes: 406', () => {
   const refusal = vercelMarkdownRoutes(strict).find(route => route.status === 406)!
   const matcher = (route: VercelRoute, key: string, list: 'has' | 'missing') =>
     route[list]?.find(entry => entry.key === key)?.value
+  /** The `missing` `Accept` matcher, read the way the edge reads it: anchored, case-insensitive. */
+  const accepts = (route: VercelRoute) => (header: string) =>
+    new RegExp(`^(?:${matcher(route, 'accept', 'missing')})$`, 'i').test(header)
 
   it('is absent unless the site turns it on', () => {
     expect(vercelMarkdownRoutes(createConfig()).some(route => route.status === 406)).toBe(false)
@@ -156,29 +159,47 @@ describe('vercelMarkdownRoutes: 406', () => {
   // carry a media range, must not offer a representation, and a navigation or
   // a known agent is never refused.
   it('carries the same guards the middleware applies', () => {
-    const offers = new RegExp(matcher(refusal, 'accept', 'missing')!, 'i')
-    expect(offers.test('text/html,application/xhtml+xml,*/*;q=0.8')).toBe(true)
-    expect(offers.test('*/*')).toBe(true)
-    expect(offers.test('text/*')).toBe(true)
-    expect(offers.test('text/markdown')).toBe(true)
-    expect(offers.test('application/xml')).toBe(false)
-    expect(offers.test('image/png, application/pdf')).toBe(false)
+    const offers = accepts(refusal)
+    expect(offers('text/html,application/xhtml+xml,*/*;q=0.8')).toBe(true)
+    expect(offers('*/*')).toBe(true)
+    expect(offers('text/*')).toBe(true)
+    expect(offers('text/markdown')).toBe(true)
+    expect(offers('application/xml')).toBe(false)
+    expect(offers('image/png, application/pdf')).toBe(false)
 
     // Present and carrying a media range, so a mangled header cannot refuse.
-    const present = new RegExp(matcher(refusal, 'accept', 'has')!, 'i')
+    // Both halves have to be there, or the edge would 406 what the origin
+    // serves, which is the one divergence this route cannot have.
+    const present = new RegExp(`^(?:${matcher(refusal, 'accept', 'has')})$`, 'i')
     expect(present.test('application/xml')).toBe(true)
+    expect(present.test('image/png, application/pdf')).toBe(true)
     expect(present.test('garbage')).toBe(false)
+    expect(present.test('text/')).toBe(false)
+    expect(present.test('/html')).toBe(false)
+    expect(present.test('text/html/extra')).toBe(false)
 
     expect(matcher(refusal, 'sec-fetch-mode', 'missing')).toBe('navigate')
     expect(matcher(refusal, 'user-agent', 'missing')).toContain('ClaudeBot')
+  })
+
+  // A bare substring matched a supported type inside a parameter value, so
+  // `application/json;profile="text/html"` read as offering HTML when the only
+  // range in it is JSON. Anchored at media-range boundaries the same way the
+  // rewrite matcher already was.
+  it('does not read a supported type out of a parameter value', () => {
+    const offers = accepts(refusal)
+    expect(offers('application/json;profile="text/html"')).toBe(false)
+    expect(offers('application/json;profile="text/markdown", image/png')).toBe(false)
+    expect(offers('text/htmlish')).toBe(false)
+    // The real range still counts wherever it sits in the list.
+    expect(offers('application/json;profile="x", text/html')).toBe(true)
   })
 
   // A matcher is a plain regex over the raw header, so a representation
   // offered and then refused at `q=0` still reads as offered. The edge serves
   // the page where the origin answers 406, which is the fail-safe direction.
   it('is lenient about `q=0` where the runtime is strict', () => {
-    const offers = new RegExp(matcher(refusal, 'accept', 'missing')!, 'i')
-    expect(offers.test('text/markdown;q=0')).toBe(true)
+    expect(accepts(refusal)('text/markdown;q=0')).toBe(true)
   })
 
   it('drops the user-agent guard when the site emptied the agent list', () => {

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -19,6 +19,7 @@ function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationCo
     linkHeader: true,
     cachedRoutes: [],
     sitemapSections: { expand: [], labels: {} },
+    notAcceptable: false,
     ...overrides
   }
 }
@@ -63,10 +64,9 @@ describe('vercelMarkdownRoutes: Vary', () => {
     expect(matches(vary!, '/blog/x')).toBe(false)
   })
 
-  // `Vary` belongs on a URL with two representations and nowhere else. A `.md`
-  // twin only ever serves markdown, and a shared cache keyed per user-agent on
-  // the documents agents fetch most is close to no caching at all.
-  it('leaves the single-representation documents alone', () => {
+  // This route labels the HTML half only. The markdown half is the next one,
+  // so that each says why it is there.
+  it('leaves the documents that never serve HTML alone', () => {
     const [exact] = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/changelog' }] }))
     expect(matches(exact!, '/changelog')).toBe(true)
     expect(matches(exact!, '/changelog.md')).toBe(false)
@@ -79,10 +79,118 @@ describe('vercelMarkdownRoutes: Vary', () => {
   })
 })
 
+// A negotiated page rewrites or 307s to one of these, so this is the response
+// a client keeps and a shared cache stores. Labelling only the page leaves the
+// URL the hop lands on saying nothing about the pair behind it.
+describe('vercelMarkdownRoutes: Vary on the markdown representations', () => {
+  const config = createConfig({ links: [{ href: '/sitemap.md', rel: 'sitemap', type: 'text/markdown' }] })
+  const markdown = vercelMarkdownRoutes(config)[1]
+
+  it('comes second and keeps routing, ahead of the rewrites below it', () => {
+    expect(markdown?.continue).toBe(true)
+    expect(markdown?.dest).toBeUndefined()
+    expect(markdown?.headers).toEqual({ Vary: MARKDOWN_VARY })
+  })
+
+  it('covers the raw prefix, the `.md` twins and `/sitemap.md`', () => {
+    expect(matches(markdown!, '/raw/index.md')).toBe(true)
+    expect(matches(markdown!, '/raw/docs/foo.md')).toBe(true)
+    expect(matches(markdown!, '/docs/foo.md')).toBe(true)
+    expect(matches(markdown!, '/docs/3.x/guide.md')).toBe(true)
+    expect(matches(markdown!, '/sitemap.md')).toBe(true)
+  })
+
+  it('leaves the pages and the other documents alone', () => {
+    expect(matches(markdown!, '/docs/foo')).toBe(false)
+    expect(matches(markdown!, '/')).toBe(false)
+    expect(matches(markdown!, '/llms.txt')).toBe(false)
+    expect(matches(markdown!, '/sitemap.xml')).toBe(false)
+    expect(matches(markdown!, '/logo.png')).toBe(false)
+  })
+
+  it('covers the twin of an exact pattern, and skips the root which has none', () => {
+    const [, exact] = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/' }, { path: '/changelog' }] }))
+    expect(matches(exact!, '/changelog.md')).toBe(true)
+    expect(matches(exact!, '/.md')).toBe(false)
+  })
+
+  it('follows `rawPrefix`', () => {
+    const [, moved] = vercelMarkdownRoutes(createConfig({ rawPrefix: '/md' }))
+    expect(matches(moved!, '/md/docs/foo.md')).toBe(true)
+    expect(matches(moved!, '/raw/docs/foo.md')).toBe(false)
+  })
+
+  // Keyed on the registered link: a site serving its own through
+  // `discovery.links` needs the label just as much as one using the route.
+  it('skips `/sitemap.md` when no link registers it', () => {
+    const [, none] = vercelMarkdownRoutes(createConfig())
+    expect(matches(none!, '/sitemap.md')).toBe(false)
+  })
+})
+
+// The edge half of the opt-in 406. A prerendered page is answered off the
+// filesystem and never reaches the middleware, so without this the option
+// would be on for the pages Nitro renders and off for the rest of the site.
+describe('vercelMarkdownRoutes: 406', () => {
+  const strict = createConfig({ notAcceptable: true })
+  const refusal = vercelMarkdownRoutes(strict).find(route => route.status === 406)!
+  const matcher = (route: VercelRoute, key: string, list: 'has' | 'missing') =>
+    route[list]?.find(entry => entry.key === key)?.value
+
+  it('is absent unless the site turns it on', () => {
+    expect(vercelMarkdownRoutes(createConfig()).some(route => route.status === 406)).toBe(false)
+    expect(refusal).toBeDefined()
+  })
+
+  it('answers the status itself, on the negotiated pages only', () => {
+    expect(refusal.dest).toBeUndefined()
+    expect(refusal.continue).toBeUndefined()
+    expect(refusal.headers).toEqual({ Vary: MARKDOWN_VARY })
+    expect(matches(refusal, '/docs/foo')).toBe(true)
+    expect(matches(refusal, '/docs/foo.md')).toBe(false)
+    expect(matches(refusal, '/api/x')).toBe(false)
+    expect(matches(refusal, '/logo.png')).toBe(false)
+  })
+
+  // The middleware's guards, as matchers: an `Accept` has to be there and
+  // carry a media range, must not offer a representation, and a navigation or
+  // a known agent is never refused.
+  it('carries the same guards the middleware applies', () => {
+    const offers = new RegExp(matcher(refusal, 'accept', 'missing')!, 'i')
+    expect(offers.test('text/html,application/xhtml+xml,*/*;q=0.8')).toBe(true)
+    expect(offers.test('*/*')).toBe(true)
+    expect(offers.test('text/*')).toBe(true)
+    expect(offers.test('text/markdown')).toBe(true)
+    expect(offers.test('application/xml')).toBe(false)
+    expect(offers.test('image/png, application/pdf')).toBe(false)
+
+    // Present and carrying a media range, so a mangled header cannot refuse.
+    const present = new RegExp(matcher(refusal, 'accept', 'has')!, 'i')
+    expect(present.test('application/xml')).toBe(true)
+    expect(present.test('garbage')).toBe(false)
+
+    expect(matcher(refusal, 'sec-fetch-mode', 'missing')).toBe('navigate')
+    expect(matcher(refusal, 'user-agent', 'missing')).toContain('ClaudeBot')
+  })
+
+  // A matcher is a plain regex over the raw header, so a representation
+  // offered and then refused at `q=0` still reads as offered. The edge serves
+  // the page where the origin answers 406, which is the fail-safe direction.
+  it('is lenient about `q=0` where the runtime is strict', () => {
+    const offers = new RegExp(matcher(refusal, 'accept', 'missing')!, 'i')
+    expect(offers.test('text/markdown;q=0')).toBe(true)
+  })
+
+  it('drops the user-agent guard when the site emptied the agent list', () => {
+    const none = vercelMarkdownRoutes(createConfig({ notAcceptable: true, userAgents: [] })).find(route => route.status === 406)!
+    expect(none.missing?.some(entry => entry.key === 'user-agent')).toBe(false)
+  })
+})
+
 describe('vercelMarkdownRoutes: Link', () => {
   it('emits a continue route on the homepage when links exist', () => {
     const config = createConfig({ links: LINKS })
-    const link = vercelMarkdownRoutes(config)[1]
+    const link = vercelMarkdownRoutes(config)[2]
     expect(link?.src).toBe('^/$')
     expect(link?.continue).toBe(true)
     expect(link?.headers).toEqual({ Link: formatLinkHeader(LINKS) })
@@ -91,29 +199,29 @@ describe('vercelMarkdownRoutes: Link', () => {
   it('is absent without links', () => {
     const routes = vercelMarkdownRoutes(createConfig())
     expect(routes.filter(route => route.headers?.Link)).toHaveLength(0)
-    expect(routes[1]?.dest).toBeDefined()
+    expect(routes[2]?.dest).toBeDefined()
   })
 })
 
 describe('vercelMarkdownRoutes: route count', () => {
-  it('emits 3 rewrites per glob pattern and 2 for the exact root', () => {
+  it('emits 3 rewrites per glob pattern and 2 for the exact root, behind the two `Vary` routes', () => {
     const routes = vercelMarkdownRoutes(createConfig())
     expect(rewrites(routes).filter(route => route.dest === '/raw/docs/$1.md')).toHaveLength(3)
     expect(rewrites(routes).filter(route => route.dest === '/raw/index.md')).toHaveLength(2)
-    expect(routes).toHaveLength(6)
+    expect(routes).toHaveLength(7)
   })
 
   it('emits 3 rewrites for an exact pattern that is not the root', () => {
     const routes = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/changelog' }] }))
     expect(rewrites(routes).filter(route => route.dest === '/raw/changelog.md')).toHaveLength(3)
-    expect(routes).toHaveLength(4)
+    expect(routes).toHaveLength(5)
   })
 
   it('stays O(patterns), never O(pages)', () => {
     const base = createConfig()
     const many = createConfig({ routes: [...base.routes, { path: '/blog/**' }, { path: '/*/docs/**' }] })
-    expect(vercelMarkdownRoutes(base)).toHaveLength(6)
-    expect(vercelMarkdownRoutes(many)).toHaveLength(6 + 3 + 3)
+    expect(vercelMarkdownRoutes(base)).toHaveLength(7)
+    expect(vercelMarkdownRoutes(many)).toHaveLength(7 + 3 + 3)
     // Nothing in the table depends on the pages behind a pattern.
     expect(JSON.stringify(vercelMarkdownRoutes(base))).not.toContain('foo')
   })


### PR DESCRIPTION
acceptmarkdown.com scores a site running this module as failed on markdown content negotiation: "Two-representation negotiation works but Vary header missing Accept (got `none`)". The header is correct on every negotiated page. The gap is the hop after it.

```sh
# the page: correct
curl -sI -H 'Accept: text/markdown' https://whichcoding.tools/tools | grep -i '^vary'
# vary: Accept, User-Agent

# where it sends you: nothing
curl -sI https://whichcoding.tools/raw/tools.md | grep -i '^vary'
curl -sI https://whichcoding.tools/sitemap.md | grep -i '^vary'
```

`/tools` with `Accept: text/markdown` is a CDN 307 to `/raw/tools.md`, so the response a client actually keeps, and the one a shared cache stores, is the twin's. Anything following the redirect lands on a URL with two representations behind it and no header saying so.

Leaving it off was deliberate: a `.md` twin and everything under `/raw/**` answer markdown to every client, so nothing about them depends on the request. That holds for the URL in isolation and breaks for the chain the CDN routes create.

## Vary on the markdown representations

`Vary` now goes on the raw route (the 302 to a section's first leaf included), on `/sitemap.md`, and unconditionally on the middleware's markdown branch, so a `.md` twin doesn't answer differently depending on the preset.

The handlers alone don't close it. With the `@nuxt/content` source, `/sitemap.md` and the raw twin of every exact pattern are prerendered, so on Vercel they're served off the filesystem and never reach a handler. `src/presets/vercel.ts` gets a second `continue: true` header route covering the raw prefix, the `.md` twins and `/sitemap.md`. It has to sit ahead of the twin rewrites, which carry no `continue`, so nothing after them runs for a request they match.

The openapi fragments now declare the header on those responses too, since they were understating what the raw route returns.

One thing worth knowing: `Vary: User-Agent` on `/sitemap.md` does cost something. That document is byte-identical for every client, so the header buys a per-UA cache key for information it doesn't carry. That's the price of the pair being consistent end to end. Off Vercel a prerendered `/sitemap.md` or `/raw/index.md` still has no `Vary`, same caveat as prerendered pages bypassing the middleware, documented in `Other hosts`.

## `notAcceptable`, off by default

The other acceptmarkdown check that fails today:

```sh
curl -so /dev/null -w '%{http_code} %{content_type}\n' -H 'Accept: application/xml' https://whichcoding.tools/tools
# 200 text/html;charset=utf-8
```

A negotiated page has exactly two representations, so per RFC 9110 an `Accept` matching neither is a 406. `notAcceptable: true` turns that on, at the origin and at the edge.

Off by default because the strictly correct answer breaks any client sending a narrow `Accept` it didn't mean. Guards, all covered by tests:

* browsers (`*/*;q=0.8`) and `fetch()` (`*/*`) rate both representations through the wildcard and are never refused
* `Sec-Fetch-Mode: navigate` and a known agent User-Agent are never refused, the same protections `prefersMarkdownError` already has
* `Accept: text/markdown;q=0` on its own is a 406, same reading that makes `application/xml` one
* an `Accept` carrying no media range at all is ignored rather than refused, so a proxy mangling the header can't take a page down
* only the pages negotiate, so a `.md` twin, `/raw/**`, the assets and the discovery documents are served whatever the header says

The body lists both representations, in whichever format the client's error rules resolve to. At the edge the guards are Build Output matchers rather than q-value ranking, so a representation refused at `q=0` still reads as offered there and the page is served where the origin answers 406. Same known divergence the `text/markdown;q=0` rewrite matcher has, same fail-safe direction.

## Markdown when the client refuses HTML

Found in review. `Accept: text/html;q=0, */*;q=1` was served HTML, the one representation it gave quality zero, and `notAcceptable` correctly declined to refuse it because markdown rates 1 through the wildcard. So the two halves disagreed about the same header.

`acceptsMarkdown()` now returns true when HTML is exactly 0 and some range still permits markdown. This changes the default path, not just the opt-in one, so it's the part worth a close look. It cannot reach a normal client: a browser (`*/*;q=0.8`) and a `fetch()` (`*/*`) both rate HTML non-zero, and `text/html;q=0` on its own still isn't a markdown request since nothing is acceptable. The `How negotiation decides` list in the README gains it as a fourth step.

It does create a known divergence, documented rather than fixed: the CDN matcher looks for a literal `text/markdown` range and there isn't one, so the edge serves HTML where the origin serves markdown. Closing it needs a second route pair per pattern to test the refusal and the wildcard separately, which is a real cost to an O(patterns) table for a header almost nothing sends.

## Notes

`Sec-Fetch-Mode` is a forbidden header name, so undici overwrites it with `cors` on every request. The navigation test goes through `node:http` instead. That's also why a browser `fetch()` gets a JSON 406 body rather than markdown, which is the existing error rule and not new behaviour.

`test/fixtures/basic` opts into `notAcceptable` so both halves are covered, the middleware on that build and the CDN route in the Build Output the vercel suite reads. Every other fixture leaves it off.

The 406 matchers are anchored at media-range boundaries, so a supported type inside a parameter value is not read as an offer, and a comma inside a quoted value is not read as a list separator. Both were caught in review, and both were regressions against a bug this file had already fixed once for the rewrite matcher.

**Not verified against a real Vercel edge.** The existing matchers carry a comment saying they were confirmed there; the new ones have only been run against JS `RegExp`. Everything unverified sits behind `notAcceptable`, which is off by default, so nothing in it is reachable until a site opts in. Worth a preview check before turning it on anywhere.

367 tests pass, lint and typecheck clean.

Follow-up in a separate PR: `agentDiscoveryOpenApi()` generates operation ids a caller can't see, and can already collide with itself.
