### PR TITLE
fix(vercel): collect late route rules and scope edge routes to GET/HEAD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+  # No base-branch filter: stacked PRs target the previous PR's branch and
+  # still need the suite to run.
   pull_request:
-    branches:
-      - main
 
 jobs:
   ci:

--- a/src/module.ts
+++ b/src/module.ts
@@ -569,6 +569,11 @@ export {}
      * snapshot is authoritative, and a rule flipped back to `{ isr: false }`
      * has to drop off the list or the CDN keeps redirecting a route that is
      * no longer cached.
+     *
+     * The street runs one way only: what lands on `nuxt.options.routeRules`
+     * before `createNitro` (this module's own `/` header rule included) is
+     * defu'd into Nitro's table, so pass one still sees everything written
+     * through `nuxt.options` and the header rule reaches every preset.
      */
     const collectCachedRoutes = (routeRules?: Record<string, { isr?: unknown, swr?: unknown, cache?: unknown, static?: unknown } | undefined>) => {
       const previous = config.cachedRoutes.splice(0, config.cachedRoutes.length)
@@ -607,6 +612,13 @@ export {}
           if (!previous.includes(key)) {
             logger.info(`Route rule \`${key}\` has a response cache: request-time markdown negotiation is disabled there, and the CDN routes redirect to the raw markdown instead of rewriting.`)
           }
+        }
+      }
+      // The other direction of the rebuild, so a disappearing cache is as
+      // visible as an appearing one.
+      for (const key of previous) {
+        if (!config.cachedRoutes.includes(key)) {
+          logger.info(`Route rule \`${key}\` no longer has a response cache: the CDN routes rewrite it again instead of redirecting.`)
         }
       }
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -564,12 +564,15 @@ export {}
      * build after every hook here. Missing one means emitting a
      * URL-preserving rewrite onto a route that really is cached, which is the
      * one error here that poisons a cache.
+     *
+     * Rebuilt from scratch on every pass rather than accumulated: each later
+     * snapshot is authoritative, and a rule flipped back to `{ isr: false }`
+     * has to drop off the list or the CDN keeps redirecting a route that is
+     * no longer cached.
      */
     const collectCachedRoutes = (routeRules?: Record<string, { isr?: unknown, swr?: unknown, cache?: unknown, static?: unknown } | undefined>) => {
+      const previous = config.cachedRoutes.splice(0, config.cachedRoutes.length)
       for (const [key, rule] of Object.entries(routeRules || {})) {
-        if (config.cachedRoutes.includes(key)) {
-          continue
-        }
         // Every shape Nitro turns into a response cache, read the way Nitro
         // reads it. `isr: 0` and `swr: 0` are not one: the Vercel builder skips
         // a falsy `isr` outright and `normalizeRouteRules` only configures a
@@ -599,7 +602,11 @@ export {}
           : Boolean(matchRoute(routes, key)) && !hasFileExtension(key)
         if (negotiable) {
           config.cachedRoutes.push(key)
-          logger.info(`Route rule \`${key}\` has a response cache: request-time markdown negotiation is disabled there, and the CDN routes redirect to the raw markdown instead of rewriting.`)
+          // Only for rules the earlier passes had not seen, so a rebuild does
+          // not repeat the whole list on every pass.
+          if (!previous.includes(key)) {
+            logger.info(`Route rule \`${key}\` has a response cache: request-time markdown negotiation is disabled there, and the CDN routes redirect to the raw markdown instead of rewriting.`)
+          }
         }
       }
     }

--- a/src/module.ts
+++ b/src/module.ts
@@ -554,15 +554,19 @@ export {}
      * Route-rule patterns with a response cache that a negotiated pattern
      * reaches, which decide where the CDN redirects instead of rewriting.
      *
-     * Run twice: once at `modules:done`, and again at `nitro:init` for the
-     * rules that do not exist yet at the first pass. A page calling
-     * `defineRouteRules({ isr })` under `experimental.inlineRouteRules` is
-     * applied through `nitro.updateConfig` after every module has set up, and
-     * missing it means emitting a URL-preserving rewrite onto a route that
-     * really is cached, which is the one error here that poisons a cache.
+     * Collected three times, because rules keep arriving as the build goes:
+     * at `modules:done` from `nuxt.options.routeRules`, which is what the
+     * runtime config snapshots; at `nitro:build:before` from Nitro's own
+     * table, the only place a rule added in a `nitro:config` hook ever lands
+     * (`createNitro` builds a fresh object, so those never reach
+     * `nuxt.options`); and once more when the Vercel preset emits its table,
+     * for a page-level `defineRouteRules({ isr })` applied during the Nuxt
+     * build after every hook here. Missing one means emitting a
+     * URL-preserving rewrite onto a route that really is cached, which is the
+     * one error here that poisons a cache.
      */
-    const collectCachedRoutes = () => {
-      for (const [key, rule] of Object.entries(nuxt.options.routeRules || {})) {
+    const collectCachedRoutes = (routeRules?: Record<string, { isr?: unknown, swr?: unknown, cache?: unknown, static?: unknown } | undefined>) => {
+      for (const [key, rule] of Object.entries(routeRules || {})) {
         if (config.cachedRoutes.includes(key)) {
           continue
         }
@@ -798,7 +802,7 @@ export {}
       // A cached response cannot vary on Accept/User-Agent, so request-time
       // negotiation is disabled there. The CDN rewrites still cover those
       // pages because they run before the cache.
-      collectCachedRoutes()
+      collectCachedRoutes(nuxt.options.routeRules)
 
       /* ---------------------------- runtime config --------------------------- */
 
@@ -826,13 +830,23 @@ export {}
     /* ------------------------------- presets ------------------------------- */
 
     if (negotiates) {
+      // Nitro's rule table is a fresh object built at `createNitro`, so rules
+      // another module added in `nitro:config` exist only there. The runtime
+      // config was deep-cloned at the same point; syncing Nitro's copy here
+      // still reaches the server bundle, because rollup stringifies it later.
+      nuxt.hook('nitro:build:before', (nitro) => {
+        collectCachedRoutes(nitro.options.routeRules)
+        const runtime = nitro.options.runtimeConfig.agentDiscovery as NegotiationConfig | undefined
+        if (runtime) {
+          runtime.cachedRoutes = [...config.cachedRoutes]
+        }
+      })
       nuxt.hook('nitro:init', (nitro) => {
-        // Once more before the preset reads the config: a page-level
-        // `defineRouteRules({ isr })` is merged in after every module has set
-        // up, so the first pass never saw it and the pattern would get a
-        // URL-preserving rewrite onto a route that really is cached.
-        collectCachedRoutes()
-        setupVercelPreset(nitro, config)
+        // The preset collects once more when it emits its table: an inline
+        // `defineRouteRules({ isr })` lands on Nitro's rules during the Nuxt
+        // build, after both passes above, and the CDN table is the one output
+        // late enough to honour it.
+        setupVercelPreset(nitro, config, collectCachedRoutes)
       })
     }
   }

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -368,7 +368,12 @@ export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig, colle
   nitro.hooks.hook('compiled', async () => {
     // The last read of the rule table before it decides rewrite or 307: an
     // inline `defineRouteRules({ isr })` only lands on it during the Nuxt
-    // build, after every module hook has run.
+    // build, after every module hook has run. The runtime config is already
+    // inlined by now, so a rule that changed between `nitro:build:before` and
+    // here reaches this table only and the origin keeps the earlier list.
+    // Benign in both directions: a rule appearing here demotes the pattern to
+    // a 307, and one disappearing leaves a rewrite landing on `/raw/**.md`,
+    // where the middleware never takes its 307 branch.
     collectCachedRoutes?.(nitro.options.routeRules)
     const vcJSON = resolve(nitro.options.output.dir, 'config.json')
     const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8'))

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -14,9 +14,18 @@ export interface VercelRoute {
   has?: RouteMatcher[]
   /** Negated matchers: the route applies only when none of them match. */
   missing?: RouteMatcher[]
+  /** Methods the route applies to; absent means every method. */
+  methods?: string[]
   check?: boolean
   continue?: boolean
 }
+
+/**
+ * The negotiation middleware returns early for anything but GET/HEAD, so every
+ * emitted route carries the same restriction. Without it a POST to a page path
+ * was rewritten or 406ed at the edge where the origin runs its handler.
+ */
+const METHODS = ['GET', 'HEAD']
 
 interface RouteMatcher {
   type: string
@@ -130,11 +139,11 @@ const NO_DOTTED_LAST_SEGMENT = String.raw`(?!.*\.[^/]*$)`
  */
 function negotiatedRoute(src: string, dest: string, has: RouteMatcher[], cached: boolean, missing?: RouteMatcher[]): VercelRoute {
   if (cached) {
-    return { src, status: 307, headers: { Location: dest, Vary: MARKDOWN_VARY }, has, ...(missing ? { missing } : {}) }
+    return { src, status: 307, headers: { Location: dest, Vary: MARKDOWN_VARY }, has, ...(missing ? { missing } : {}), methods: METHODS }
   }
   // `check: true` looks the destination up in the filesystem first, which is
   // where prerendered raw files live.
-  return { src, dest, has, ...(missing ? { missing } : {}), check: true }
+  return { src, dest, has, ...(missing ? { missing } : {}), methods: METHODS, check: true }
 }
 
 /**
@@ -190,6 +199,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   routes.push({
     src: `^${NO_DOTTED_LAST_SEGMENT}${excluded}(?:${varySources.join('|')})$`,
     headers: { Vary: MARKDOWN_VARY },
+    methods: METHODS,
     continue: true
   })
 
@@ -224,6 +234,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   routes.push({
     src: `^(?:${markdownSources.join('|')})$`,
     headers: { Vary: MARKDOWN_VARY },
+    methods: METHODS,
     continue: true
   })
 
@@ -249,12 +260,14 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
         { type: 'header', key: 'accept', value: ACCEPTS_A_REPRESENTATION },
         { type: 'header', key: 'sec-fetch-mode', value: 'navigate' },
         ...(agentUserAgent ? [agentUserAgent] : [])
-      ]
+      ],
+      methods: METHODS
     })
   }
 
   // The `/` routeRule carries the same `Link` header, but a homepage request
   // rewritten below to a prerendered raw markdown file never reaches it.
+  // Deliberately method-agnostic, mirroring the route rule it stands in for.
   const linkHeader = config.linkHeader ? formatLinkHeader(config.links) : ''
   if (linkHeader) {
     routes.push({
@@ -315,7 +328,8 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
       // capture stops before the suffix thanks to the `\.md$` anchor.
       routes.push({
         src: `^${excluded}${body}\\.md$`,
-        dest
+        dest,
+        methods: METHODS
       })
       // The dotted-last-segment lookahead keeps `.md` URLs on the rewrite above
       // and assets (`_payload.json`, images) out.
@@ -323,7 +337,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     } else {
       const dest = rawDestination(config, route, route.path)
       if (route.path !== '/') {
-        routes.push({ src: `^${escapeRegExp(route.path)}\\.md$`, dest })
+        routes.push({ src: `^${escapeRegExp(route.path)}\\.md$`, dest, methods: METHODS })
       }
       // The same two guards the wildcard branch carries. Without them an exact
       // pattern negotiated at the edge where the runtime refuses it: a dotted
@@ -343,7 +357,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
  * documented on the Source route type:
  * https://vercel.com/docs/build-output-api/configuration
  */
-export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig) {
+export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig, collectCachedRoutes?: (routeRules: Nitro['options']['routeRules']) => void) {
   // `nuxt generate` on Vercel resolves the `vercel-static` preset, whose name
   // contains "vercel" but which emits no function routes at all. Patching the
   // table there leaves rewrites pointing at a filesystem that only holds what
@@ -352,6 +366,10 @@ export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig) {
     return
   }
   nitro.hooks.hook('compiled', async () => {
+    // The last read of the rule table before it decides rewrite or 307: an
+    // inline `defineRouteRules({ isr })` only lands on it during the Nuxt
+    // build, after every module hook has run.
+    collectCachedRoutes?.(nitro.options.routeRules)
     const vcJSON = resolve(nitro.options.output.dir, 'config.json')
     const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8'))
     vcConfig.routes.unshift(...vercelMarkdownRoutes(config))

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -180,7 +180,7 @@ describe('vercel build output', () => {
 
     const patterns = 2 // `routes: ['/', '/**']`
     const exact = 1 // `/`
-    const cachedRules = 1 // `/docs/components/**`
+    const cachedRules = 2 // `/docs/components/**`, plus `/docs/late/**` from `nitro:config`
     const headerRoutes = 3 // `Vary` on the pages, `Vary` on the markdown twins, `Link`
     const refusals = 1 // `notAcceptable: true` in the fixture
     // Per pattern: an `Accept` route and a User-Agent route, plus a `.md` alias
@@ -194,21 +194,33 @@ describe('vercel build output', () => {
   // rules to know the section is cached at all.
   it('redirects the cached section and rewrites everything else', () => {
     const cached = routes.filter(route => route.status === 307)
-    expect(cached).toHaveLength(2)
+    expect(cached).toHaveLength(4)
 
-    for (const route of cached) {
-      expect(route.headers?.Location).toBe('/raw/docs/components/$1.md')
+    const components = cached.filter(route => route.headers?.Location === '/raw/docs/components/$1.md')
+    expect(components).toHaveLength(2)
+    for (const route of components) {
       expect(route.headers?.Vary).toBe(MARKDOWN_VARY)
       expect(route.dest).toBeUndefined()
       expect(new RegExp(route.src!).test('/docs/components/button')).toBe(true)
       expect(new RegExp(route.src!).test('/docs/getting-started')).toBe(false)
     }
-    expect(cached.map(route => route.has?.[0]?.key)).toEqual(['accept', 'user-agent'])
+    expect(components.map(route => route.has?.[0]?.key)).toEqual(['accept', 'user-agent'])
 
-    // The catch-all is untouched by the narrower rule.
+    // The catch-all is untouched by the narrower rules.
     const catchAll = routes.filter(route => route.dest === '/raw/$1.md' && route.has)
     expect(catchAll).toHaveLength(2)
     expect(catchAll.every(route => route.check && !route.status)).toBe(true)
+  })
+
+  // The rule arrives through a companion module's `nitro:config` hook, so it
+  // exists only on Nitro's own table. Missing it emitted a URL-preserving
+  // rewrite onto a cached route, which poisons a path-keyed response cache.
+  it('redirects a section cached through `nitro:config`', () => {
+    const late = routes.filter(route => route.headers?.Location === '/raw/docs/late/$1.md')
+
+    expect(late).toHaveLength(2)
+    expect(late.every(route => route.status === 307)).toBe(true)
+    expect(late.map(route => route.has?.[0]?.key)).toEqual(['accept', 'user-agent'])
   })
 
   it('prerenders the homepage raw markdown into the static output', () => {

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -1,5 +1,20 @@
+import { defineNuxtModule } from 'nuxt/kit'
+
+// A companion module adding a cached rule in `nitro:config`. That rule lands
+// on Nitro's own table only, never on `nuxt.options.routeRules`, so it covers
+// the late-collection pass end to end.
+const lateCachedRule = defineNuxtModule({
+  meta: { name: 'late-cached-rule' },
+  setup(_options, nuxt) {
+    nuxt.hook('nitro:config', (config) => {
+      config.routeRules ||= {}
+      config.routeRules['/docs/late/**'] = { isr: 120 }
+    })
+  }
+})
+
 export default defineNuxtConfig({
-  modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms', '@nuxtjs/mcp-toolkit', '@nuxtjs/sitemap'],
+  modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms', '@nuxtjs/mcp-toolkit', '@nuxtjs/sitemap', lateCachedRule],
   devtools: { enabled: false },
   // Multi-theme highlighting makes the highlighter append a `<style>` node
   // carrying the per-document CSS variables, which the raw markdown must not

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -228,6 +228,30 @@ describe('module setup: cached routes', () => {
     expect(cloned.cachedRoutes).toEqual(['/tools', '/docs/late'])
   })
 
+  it('drops a rule a later snapshot flipped back to uncached', async () => {
+    // Each snapshot is authoritative: a site or module overriding an earlier
+    // `{ isr }` with `{ isr: false }` really uncaches the route, and keeping
+    // the stale entry made the CDN 307 a route that serves uncached HTML.
+    const nuxt = await runModule({ routes: ['/', '/**'] }, { '/tools': { isr: 3600 } })
+    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+
+    expect(config.cachedRoutes).toEqual(['/tools'])
+
+    const cloned = JSON.parse(JSON.stringify(config)) as NegotiationConfig
+    const nitro = {
+      options: {
+        dev: false,
+        preset: 'node-server',
+        routeRules: { '/tools': { isr: false } },
+        runtimeConfig: { agentDiscovery: cloned }
+      }
+    }
+    await nuxt.hooks.callHook('nitro:build:before' as never, nitro as never)
+
+    expect(config.cachedRoutes).toEqual([])
+    expect(cloned.cachedRoutes).toEqual([])
+  })
+
   // `experimental.inlineRouteRules` applies a page's `defineRouteRules({ isr })`
   // during the Nuxt build, after `nitro:build:before` too. The CDN table is
   // emitted late enough to honour it, and is the half that matters: the

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -1,4 +1,7 @@
 import { fileURLToPath } from 'node:url'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { nuxtCtx } from '@nuxt/kit'
 import module from '../../src/module'
@@ -198,22 +201,65 @@ describe('module setup: cached routes', () => {
     expect(await cached({ swr: 0 })).toBe(false)
   })
 
-  // `experimental.inlineRouteRules` merges a page's `defineRouteRules({ isr })`
-  // in after every module has set up, so the pass at `modules:done` never sees
-  // it. Missing it emits a URL-preserving rewrite onto a route that really is
-  // cached, which is the one error in this area that poisons a cache.
+  // A rule added inside a `nitro:config` hook only ever lands on Nitro's own
+  // table: `createNitro` builds a fresh object, so `nuxt.options.routeRules`
+  // never sees it. Missing it emits a URL-preserving rewrite onto a route that
+  // really is cached, which is the one error in this area that poisons a cache.
   it('picks up a route rule that lands after `modules:done`', async () => {
     const nuxt = await runModule({ routes: ['/', '/**'] }, { '/tools': { isr: 3600 } })
     const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
 
     expect(config.cachedRoutes).toEqual(['/tools'])
 
-    // What `nitro.updateConfig` does with an inline page rule, then the hook
-    // the preset reads the config from.
-    nuxt.options.routeRules['/docs/late'] = { isr: 60 }
-    await nuxt.hooks.callHook('nitro:init' as never, { options: { dev: false, preset: 'node-server' } } as never)
+    // The runtime config Nitro carries is a deep clone taken at `createNitro`,
+    // so the pass has to sync it as well as the module's own reference.
+    const cloned = JSON.parse(JSON.stringify(config)) as NegotiationConfig
+    const nitro = {
+      options: {
+        dev: false,
+        preset: 'node-server',
+        routeRules: { '/tools': { isr: 3600 }, '/docs/late': { isr: 60 } },
+        runtimeConfig: { agentDiscovery: cloned }
+      }
+    }
+    await nuxt.hooks.callHook('nitro:build:before' as never, nitro as never)
 
     expect(config.cachedRoutes).toEqual(['/tools', '/docs/late'])
+    expect(cloned.cachedRoutes).toEqual(['/tools', '/docs/late'])
+  })
+
+  // `experimental.inlineRouteRules` applies a page's `defineRouteRules({ isr })`
+  // during the Nuxt build, after `nitro:build:before` too. The CDN table is
+  // emitted late enough to honour it, and is the half that matters: the
+  // rewrite-or-307 decision lives there.
+  it('collects an inline rule when the Vercel preset emits its table', async () => {
+    const nuxt = await runModule({ routes: ['/', '/**'] })
+    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+
+    expect(config.cachedRoutes).toEqual([])
+
+    const dir = mkdtempSync(join(tmpdir(), 'agent-discovery-vercel-'))
+    writeFileSync(join(dir, 'config.json'), JSON.stringify({ routes: [] }))
+    const hooks: Record<string, () => Promise<void>> = {}
+    const nitro = {
+      options: {
+        dev: false,
+        static: false,
+        preset: 'vercel',
+        output: { dir },
+        routeRules: {} as Record<string, unknown>,
+        runtimeConfig: { agentDiscovery: config }
+      },
+      hooks: { hook: (name: string, callback: () => Promise<void>) => { hooks[name] = callback } }
+    }
+    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
+    // What the inline rule does during the build: Nitro's table only.
+    nitro.options.routeRules['/docs/**'] = { isr: 60 }
+    await hooks['compiled']!()
+
+    expect(config.cachedRoutes).toEqual(['/docs/**'])
+    const written = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8')) as { routes: { status?: number }[] }
+    expect(written.routes.some(route => route.status === 307)).toBe(true)
   })
 
   it('only lists a rule the routes actually negotiate', async () => {

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -265,6 +265,9 @@ describe('module setup: cached routes', () => {
     const dir = mkdtempSync(join(tmpdir(), 'agent-discovery-vercel-'))
     writeFileSync(join(dir, 'config.json'), JSON.stringify({ routes: [] }))
     const hooks: Record<string, () => Promise<void>> = {}
+    // A distinct clone, the way `createNitro` really hands the runtime config
+    // over, so the test can also pin that this pass does not sync it.
+    const cloned = JSON.parse(JSON.stringify(config)) as NegotiationConfig
     const nitro = {
       options: {
         dev: false,
@@ -272,7 +275,7 @@ describe('module setup: cached routes', () => {
         preset: 'vercel',
         output: { dir },
         routeRules: {} as Record<string, unknown>,
-        runtimeConfig: { agentDiscovery: config }
+        runtimeConfig: { agentDiscovery: cloned }
       },
       hooks: { hook: (name: string, callback: () => Promise<void>) => { hooks[name] = callback } }
     }
@@ -284,6 +287,10 @@ describe('module setup: cached routes', () => {
     expect(config.cachedRoutes).toEqual(['/docs/**'])
     const written = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8')) as { routes: { status?: number }[] }
     expect(written.routes.some(route => route.status === 307)).toBe(true)
+    // The runtime config was inlined before `compiled`, so this pass reaches
+    // the CDN table only. Benign: the leftover rewrite lands on `/raw/**.md`,
+    // where the middleware never takes its 307 branch.
+    expect(cloned.cachedRoutes).toEqual([])
   })
 
   it('only lists a rule the routes actually negotiate', async () => {

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -562,3 +562,21 @@ describe('vercelMarkdownRoutes: explicit markdown refusal', () => {
     expect(refuses('text/markdown;q=0.1, text/html;q=0.9')).toBe(false)
   })
 })
+
+describe('vercelMarkdownRoutes: methods', () => {
+  it('scopes every route to GET/HEAD, matching the middleware', () => {
+    // The negotiation middleware returns early for anything but GET/HEAD, so
+    // an unscoped edge route 406ed or rewrote a POST the origin would serve.
+    const config = createConfig({ notAcceptable: true, cachedRoutes: ['/docs/**'], links: LINKS })
+
+    for (const route of vercelMarkdownRoutes(config)) {
+      if (route.headers?.Link) {
+        // The Link route stands in for the `/` route rule, which the origin
+        // applies to every method.
+        expect(route.methods).toBeUndefined()
+      } else {
+        expect(route.methods, route.src).toEqual(['GET', 'HEAD'])
+      }
+    }
+  })
+})


### PR DESCRIPTION
two edge/CDN fixes, both found in a full review of the module:

- `collectCachedRoutes()` only ever read `nuxt.options.routeRules`, but a rule added in a `nitro:config` hook lands on Nitro's own table (`createNitro` builds a fresh object, nothing writes back), and an inline `defineRouteRules({ isr })` applies during the Nuxt build, after every hook. both slipped past the detection, so the preset emitted a URL-preserving `check: true` rewrite onto a route that really is cached, and a path-keyed ISR cache could store markdown under the HTML URL. the collection now runs three times: `modules:done` (what the runtime config snapshots), `nitro:build:before` reading `nitro.options.routeRules` (synced onto Nitro's cloned runtime config so the origin 307 branch agrees), and once more in the preset's `compiled` hook right before the table is written, which is the only spot late enough for inline rules.
- every emitted route now carries `methods: ['GET', 'HEAD']`, matching the middleware's early return. without it a browser JSON POST to a page path outside `/api/` got an empty 406 at the edge (with `notAcceptable` on) where dev and Node run the handler. the `Link` route on `/` stays method-agnostic on purpose, mirroring the route rule it stands in for.

tests: unit coverage for the `nitro:build:before` sync and the `compiled` collection (against a real config.json on disk), a methods shape check, and the basic fixture now adds an isr rule from a `nitro:config` hook so the vercel build output suite asserts it comes out as a 307 pair instead of rewrites.

first PR of a stack of 7, each based on the previous so the diffs stay focused. merge order: #9 → #10 → #11 → #12 → #13 → #15 → #16, squash each; I will rebase the rest of the stack onto main after every merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached routes now accurately reflect the latest route configuration, including newly added, removed, or disabled routes.
  * Vercel-generated cache, negotiation, markdown, and error routes now apply only to `GET` and `HEAD` requests.
  * Cached routes discovered during later configuration stages are now included in the generated Vercel setup.

* **Tests**
  * Expanded coverage for route synchronization, cache behavior, late configuration rules, and HTTP method restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
