### PR TITLE
fix(llms): make list() optional and gate the full-document fallback

### DIFF
--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -4,10 +4,10 @@ import { withBase } from 'ufo'
 import type { NitroApp } from 'nitropack/types'
 import { defineNitroPlugin } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
-import type { AgentListEntry } from '../../shared/types'
+import type { AgentListEntry, NegotiationConfig } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { getSourcePage } from '../utils/document'
-import { hasFileExtension, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
+import { hasFileExtension, isNegotiablePath, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 interface LlmsSection {
   title: string
@@ -32,10 +32,40 @@ function toLocalUrl(href: string, domain: string): { pathname: string, suffix: s
   }
 }
 
-/** A link to a negotiable page, as opposed to `llms-full.txt` or an asset. */
-function isPageLink(href: string, domain: string): boolean {
+/**
+ * The page route a link points at, or `undefined` when it names something with
+ * no markdown representation: another origin, `llms-full.txt`, an asset, an
+ * endpoint under an excluded prefix, a path no configured route covers.
+ *
+ * The same predicate the negotiation itself runs, so a link counts as a page
+ * here exactly when the site serves markdown for it. Reading the extension
+ * alone counted `/openapi` and `/api/v1/tools` as documentation.
+ */
+function pageRoute(config: NegotiationConfig, href: string, domain: string): string | undefined {
   const local = toLocalUrl(href, domain)
-  return !!local && (local.pathname === '/' || !hasFileExtension(local.pathname))
+  return local && isNegotiablePath(config, local.pathname) ? local.pathname : undefined
+}
+
+/** At most this many adapter calls in flight, per fan-out. */
+const CONCURRENCY = 8
+
+/**
+ * `Promise.all` with a bounded number of workers, results in input order.
+ *
+ * A documentation site hands this hundreds of routes and sections, and firing
+ * every `get()` at once is what turns building `llms-full.txt` into a burst
+ * the content backend has to absorb in one go.
+ */
+async function mapLimit<T, R>(items: T[], task: (item: T) => R | Promise<R>): Promise<R[]> {
+  const results: R[] = []
+  let cursor = 0
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, items.length) }, async () => {
+    while (cursor < items.length) {
+      const index = cursor++
+      results[index] = await task(items[index]!)
+    }
+  }))
+  return results
 }
 
 function toLink(entry: AgentListEntry, domain: string) {
@@ -81,13 +111,17 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     const domain = options.domain || getAgentSiteUrl(event)
 
     if (source) {
+      // Narrowed once, because the check above does not carry into the
+      // closures below.
+      const adapter = source
+
       // Sections the site declared. One that already carries links is left
       // alone; otherwise the adapter is asked whether the section names
       // something it can resolve. Sections do not depend on each other, so the
       // adapter is asked about all of them at once.
-      const resolved = await Promise.all(options.sections.map(section => section.links?.length
+      const resolved = await mapLimit(options.sections, section => section.links?.length
         ? null
-        : (source?.list?.(section as unknown as Record<string, unknown>, event) ?? null)))
+        : (adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null))
 
       const unresolved: LlmsSection[] = []
       for (const [index, section] of options.sections.entries()) {
@@ -108,12 +142,13 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         options.sections.splice(options.sections.indexOf(section), 1)
       }
 
-      // Nothing resolved to pages, so list them all. `nuxt-llms` contributes a
-      // "Documentation Sets" section pointing at `llms-full.txt`, which must
-      // not count as an otherwise empty document having content.
-      const hasPageLinks = options.sections.some(section => section.links?.some(link => isPageLink(link.href, domain)))
+      // Nothing resolved to pages, so list them all. Only a link the site
+      // serves markdown for counts as a page: the "Documentation Sets" section
+      // `nuxt-llms` contributes points at `llms-full.txt`, and a site listing
+      // its API endpoints has named no documentation either.
+      const hasPageLinks = options.sections.some(section => section.links?.some(link => pageRoute(config, link.href, domain)))
       if (!hasPageLinks) {
-        const entries = (await source.list?.(undefined, event)) || []
+        const entries = (await adapter.list?.(undefined, event)) || []
         for (const [title, group] of groupBySection(entries)) {
           options.sections.push({
             title,
@@ -169,12 +204,17 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     if (!source) {
       return
     }
+    // Narrowed once, because the check above does not carry into the closures
+    // below.
+    const adapter = source
+    const config = useAgentDiscoveryConfig(event)
+    const domain = options.domain || getAgentSiteUrl(event)
 
     // The full document follows the sections the site declared, the same set
     // `llms.txt` lists. Rendering every route instead pulls in pages kept out
     // of the documentation on purpose: a landing page, a showcase, a template
-    // gallery. Sections carrying hand-written links resolve to nothing here,
-    // exactly as they did while `@nuxt/content` owned this.
+    // gallery. A section names its pages through a selector the adapter
+    // resolves, or through the links it curates by hand, and both end up here.
     const routes: string[] = []
     const seen = new Set<string>()
     const add = (route: string) => {
@@ -184,32 +224,39 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       }
     }
 
-    // Resolved together, then added in section order: the dedupe keeps the
-    // first route it sees, so the order the document comes out in has to be
-    // the order the sections are declared in.
-    const resolved = await Promise.all((options.sections || []).map(section => source?.list?.(section as unknown as Record<string, unknown>, event) ?? null))
-    for (const entries of resolved) {
-      for (const entry of entries || []) {
+    // Selectors resolved together, then added in section order: the dedupe
+    // keeps the first route it sees, so the order the document comes out in
+    // has to be the order the sections are declared in.
+    const sections = options.sections || []
+    const resolved = await mapLimit(sections, section => adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null)
+    for (const [index, section] of sections.entries()) {
+      for (const entry of resolved[index] || []) {
         add(entry.route)
       }
+      // A section curating its documentation by hand names it in its links, so
+      // the pages behind them are what the full document is. Everything else a
+      // section can point at (`/openapi.json`, an API endpoint, another site)
+      // has no page to render, and `llms.txt` reads those links the same way.
+      for (const link of section.links || []) {
+        const route = pageRoute(config, link.href, domain)
+        if (route) {
+          add(route)
+        }
+      }
     }
-    // Nothing resolved to pages, so render them all, on the same condition
-    // `llms.txt` lists them all: sections curating page links by hand are the
-    // documentation, and dumping the whole site would contradict the index
-    // built from the very same predicate. Sections pointing only at data
-    // (`/openapi.json`, an API endpoint, a repository) name no documentation,
-    // so that site still gets its whole site, as does one with no sections.
-    const domain = options.domain || getAgentSiteUrl(event)
-    const hasPageLinks = options.sections?.some(section => section.links?.some(link => isPageLink(link.href, domain)))
-    if (!routes.length && !hasPageLinks) {
-      for (const entry of (await source.list?.(undefined, event)) || []) {
+    // No section named a page, so render them all, on the same condition
+    // `llms.txt` lists them all. Sections pointing only at data name no
+    // documentation, so that site still gets its whole site, as does one with
+    // no sections at all.
+    if (!routes.length) {
+      for (const entry of (await adapter.list?.(undefined, event)) || []) {
         add(entry.route)
       }
     }
 
     // The same `get()` the raw route calls, so a page reads identically whether
     // an agent fetches `/raw/**.md` or the single full document.
-    const pages = await Promise.all(routes.map(route => getSourcePage(route, event)))
+    const pages = await mapLimit(routes, route => getSourcePage(route, event))
     for (const page of pages) {
       if (page?.markdown) {
         contents.push(page.markdown)

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -7,7 +7,7 @@ import source from '#agent-discovery/source'
 import type { AgentListEntry, NegotiationConfig } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { getSourcePage } from '../utils/document'
-import { hasFileExtension, isNegotiablePath, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
+import { hasFileExtension, isNegotiablePath, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 interface LlmsSection {
   title: string
@@ -43,7 +43,14 @@ function toLocalUrl(href: string, domain: string): { pathname: string, suffix: s
  */
 function pageRoute(config: NegotiationConfig, href: string, domain: string): string | undefined {
   const local = toLocalUrl(href, domain)
-  return local && isNegotiablePath(config, local.pathname) ? local.pathname : undefined
+  if (!local) {
+    return undefined
+  }
+  // `URL.pathname` comes out percent-encoded while every backend stores
+  // decoded paths, so the route is decoded the same way the raw handler
+  // decodes its slug, or a curated link to `/docs/café` resolves no page.
+  const route = normalizeAgentRoute(local.pathname)
+  return isNegotiablePath(config, route) ? route : undefined
 }
 
 /** At most this many adapter calls in flight, per fan-out. */

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -228,7 +228,11 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // keeps the first route it sees, so the order the document comes out in
     // has to be the order the sections are declared in.
     const sections = options.sections || []
-    const resolved = await mapLimit(sections, section => adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null)
+    // The same guard `llms.txt` applies: a section carrying its own links owns
+    // its curation, so its selector must not smuggle in pages the index hides.
+    const resolved = await mapLimit(sections, section => section.links?.length
+      ? null
+      : (adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null))
     for (const [index, section] of sections.entries()) {
       for (const entry of resolved[index] || []) {
         add(entry.route)

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -83,13 +83,18 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     if (source) {
       // Sections the site declared. One that already carries links is left
       // alone; otherwise the adapter is asked whether the section names
-      // something it can resolve.
+      // something it can resolve. Sections do not depend on each other, so the
+      // adapter is asked about all of them at once.
+      const resolved = await Promise.all(options.sections.map(section => section.links?.length
+        ? null
+        : (source?.list?.(section as unknown as Record<string, unknown>, event) ?? null)))
+
       const unresolved: LlmsSection[] = []
-      for (const section of options.sections) {
+      for (const [index, section] of options.sections.entries()) {
         if (section.links?.length) {
           continue
         }
-        const entries = await source.list(section as unknown as Record<string, unknown>, event)
+        const entries = resolved[index]
         if (entries?.length) {
           section.links = entries.map(entry => toLink(entry, domain))
         } else if (!section.description) {
@@ -108,7 +113,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       // not count as an otherwise empty document having content.
       const hasPageLinks = options.sections.some(section => section.links?.some(link => isPageLink(link.href, domain)))
       if (!hasPageLinks) {
-        const entries = (await source.list(undefined, event)) || []
+        const entries = (await source.list?.(undefined, event)) || []
         for (const [title, group] of groupBySection(entries)) {
           options.sections.push({
             title,
@@ -179,23 +184,33 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       }
     }
 
-    for (const section of options.sections || []) {
-      const entries = await source.list(section as unknown as Record<string, unknown>, event)
+    // Resolved together, then added in section order: the dedupe keeps the
+    // first route it sees, so the order the document comes out in has to be
+    // the order the sections are declared in.
+    const resolved = await Promise.all((options.sections || []).map(section => source?.list?.(section as unknown as Record<string, unknown>, event) ?? null))
+    for (const entries of resolved) {
       for (const entry of entries || []) {
         add(entry.route)
       }
     }
-    // A site declaring no resolvable section still wants its whole site.
-    if (!routes.length) {
-      for (const entry of (await source.list(undefined, event)) || []) {
+    // Nothing resolved to pages, so render them all, on the same condition
+    // `llms.txt` lists them all: sections curating page links by hand are the
+    // documentation, and dumping the whole site would contradict the index
+    // built from the very same predicate. Sections pointing only at data
+    // (`/openapi.json`, an API endpoint, a repository) name no documentation,
+    // so that site still gets its whole site, as does one with no sections.
+    const domain = options.domain || getAgentSiteUrl(event)
+    const hasPageLinks = options.sections?.some(section => section.links?.some(link => isPageLink(link.href, domain)))
+    if (!routes.length && !hasPageLinks) {
+      for (const entry of (await source.list?.(undefined, event)) || []) {
         add(entry.route)
       }
     }
 
     // The same `get()` the raw route calls, so a page reads identically whether
     // an agent fetches `/raw/**.md` or the single full document.
-    for (const route of routes) {
-      const page = await getSourcePage(route, event)
+    const pages = await Promise.all(routes.map(route => getSourcePage(route, event)))
+    for (const page of pages) {
       if (page?.markdown) {
         contents.push(page.markdown)
       }

--- a/src/runtime/server/utils/pages.ts
+++ b/src/runtime/server/utils/pages.ts
@@ -36,16 +36,16 @@ export interface AgentPageListOptions {
  * `routes` changes. Both URLs here come from the same `rawUrl()` the
  * negotiation and the `llms.txt` bridge resolve.
  *
- * Without `list()` on the adapter this falls back to bare `routes()`, with no
- * metadata: filling each entry in would cost a full render per page, and
- * neither caller is worth that.
+ * An adapter that cannot enumerate its pages leaves `list()` off, and the
+ * listing comes back empty. There is no fallback: rebuilding it out of `get()`
+ * would cost a full render per page, and neither caller is worth that.
  */
 export async function listAgentPages(event: H3Event, options: AgentPageListOptions = {}): Promise<AgentPageListing[]> {
   if (!source) {
     return []
   }
 
-  const entries = (await source.list(undefined, event)) || []
+  const entries = (await source.list?.(undefined, event)) ?? []
 
   const config = useAgentDiscoveryConfig(event)
   const siteUrl = getAgentSiteUrl(event)

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -98,6 +98,11 @@ export interface AgentPage {
   markdown: string
   title?: string
   description?: string
+  /**
+   * Last modification date. Adapters may supply it, and sites do, but nothing
+   * in the module reads it yet; it is reserved for freshness signals such as
+   * a sitemap `lastmod`.
+   */
   updatedAt?: string
 }
 
@@ -152,8 +157,12 @@ export interface AgentContentSource {
    * With a `selector`, a `llms.sections` entry handed over verbatim, return
    * only the pages it names, or `null` when the selector is not one this
    * adapter understands.
+   *
+   * Optional, for a backend that can resolve a route but cannot enumerate its
+   * pages. Every listing then comes out empty: `/sitemap.md` and the `llms.txt`
+   * bridge list nothing, while the documents `get()` resolves keep working.
    */
-  list: (selector: AgentSectionSelector | undefined, event: H3Event) => Promise<AgentListEntry[] | null>
+  list?: (selector: AgentSectionSelector | undefined, event: H3Event) => Promise<AgentListEntry[] | null>
   /** Resolve one route to its markdown representation, `null` when unknown. */
   get: (route: string, event: H3Event) => Promise<AgentPage | null>
   /**

--- a/test/e2e/llms-handwritten.test.ts
+++ b/test/e2e/llms-handwritten.test.ts
@@ -34,7 +34,10 @@ describe('llms.txt', () => {
     expect(body.split('\n').filter(line => line.startsWith('- '))).toEqual([
       `- [Handwritten](${SITE_URL}/raw/index.md)`,
       `- [Handwritten](${SITE_URL}/llms-full.txt): The curated documentation.`,
-      `- [Alpha](${SITE_URL}/raw/docs/alpha.md): The documented page.`
+      `- [Alpha](${SITE_URL}/raw/docs/alpha.md): The documented page.`,
+      // The mixed section keeps only its hand-written link: its selector
+      // resolves `/docs/beta`, which neither document may pick up.
+      `- [Alpha again](${SITE_URL}/raw/docs/alpha.md): The same page, curated by hand.`
     ])
   })
 

--- a/test/e2e/llms-handwritten.test.ts
+++ b/test/e2e/llms-handwritten.test.ts
@@ -1,0 +1,89 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { fetch, setup } from '@nuxt/test-utils/e2e'
+
+/**
+ * A site that curates `llms.sections` by hand, which is the shape the bridge
+ * used to get wrong: every section carries its own links, so the adapter
+ * resolves none of them, and `llms-full.txt` answered that by rendering every
+ * route it could find. The index stayed curated while the full document held
+ * the whole site, `/private/hidden` included.
+ *
+ * The adapter here lists all four pages, so a document coming out short is
+ * curation rather than an adapter with nothing to say: `/sitemap.md` below is
+ * the control.
+ */
+const SITE_URL = 'https://handwritten.example.com'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../fixtures/llms-handwritten', import.meta.url)),
+  build: true,
+  server: true,
+  setupTimeout: 300000
+})
+
+describe('llms.txt', () => {
+  it('lists the hand-written links, rewritten to raw twins, and nothing else', async () => {
+    const body = await (await fetch('/llms.txt')).text()
+
+    // The landing page the module adds, `nuxt-llms`'s own pointer at the full
+    // document, then the one link the site wrote. `/docs/beta` and
+    // `/private/hidden` are pages the adapter knows and the site did not link.
+    expect(body.split('\n').filter(line => line.startsWith('- '))).toEqual([
+      `- [Handwritten](${SITE_URL}/raw/index.md)`,
+      `- [Handwritten](${SITE_URL}/llms-full.txt): The curated documentation.`,
+      `- [Alpha](${SITE_URL}/raw/docs/alpha.md): The documented page.`
+    ])
+  })
+})
+
+describe('llms-full.txt', () => {
+  it('renders no page the index does not link', async () => {
+    const body = await (await fetch('/llms-full.txt')).text()
+
+    expect(body).not.toContain('# Beta')
+    expect(body).not.toContain('A page the sections leave out.')
+    expect(body).not.toContain('# Hidden')
+    expect(body).not.toContain('kept out of the documentation on purpose')
+  })
+
+  it('comes out empty when every section is hand-written', async () => {
+    const response = await fetch('/llms-full.txt')
+
+    expect(response.status).toBe(200)
+    // A hand-written link is not a selector the adapter can resolve back to a
+    // page, so the sections name nothing to render. Empty is what agrees with
+    // the index: the alternative was the whole site, which agreed with nothing.
+    expect((await response.text()).trim()).toBe('')
+  })
+
+  it('still renders the whole site for sections linking only data', async () => {
+    // `/llms-datalinks.txt` runs the same hook over sections whose links are an
+    // `openapi.json` and a repository. Those name no documentation, so the
+    // fallback has to stay: it is the only thing such a site's full document
+    // would ever hold. `llms.txt` keys its own fallback on the same predicate,
+    // so the two documents cannot disagree about it.
+    const body = await (await fetch('/llms-datalinks.txt')).text()
+
+    expect(body).toContain('# Alpha')
+    expect(body).toContain('# Beta')
+    expect(body).toContain('# Hidden')
+  })
+})
+
+describe('the pages the documents leave out', () => {
+  it('keeps them in the adapter, and in `/sitemap.md`', async () => {
+    const body = await (await fetch('/sitemap.md')).text()
+
+    expect(body).toContain(`[Alpha](${SITE_URL}/raw/docs/alpha.md)`)
+    expect(body).toContain(`[Beta](${SITE_URL}/raw/docs/beta.md)`)
+    expect(body).toContain(`[Hidden](${SITE_URL}/raw/private/hidden.md)`)
+  })
+
+  it('still serves their raw markdown', async () => {
+    const response = await fetch('/raw/docs/beta.md')
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('# Beta')
+  })
+})

--- a/test/e2e/llms-handwritten.test.ts
+++ b/test/e2e/llms-handwritten.test.ts
@@ -35,6 +35,7 @@ describe('llms.txt', () => {
       `- [Handwritten](${SITE_URL}/raw/index.md)`,
       `- [Handwritten](${SITE_URL}/llms-full.txt): The curated documentation.`,
       `- [Alpha](${SITE_URL}/raw/docs/alpha.md): The documented page.`,
+      `- [Café](${SITE_URL}/raw/docs/caf%C3%A9.md): The accented page.`,
       // The mixed section keeps only its hand-written link: its selector
       // resolves `/docs/beta`, which neither document may pick up.
       `- [Alpha again](${SITE_URL}/raw/docs/alpha.md): The same page, curated by hand.`
@@ -77,6 +78,10 @@ describe('llms-full.txt', () => {
     expect(body.trim()).not.toBe('')
     expect(body).toContain('# Alpha')
     expect(body).toContain('The one page the hand-written section links.')
+    // The link arrives percent-encoded through `URL.pathname` while the
+    // adapter stores the decoded slug, so the route has to be decoded on the
+    // way to `get()` or the page silently drops out of the full document.
+    expect(body).toContain('# Café')
   })
 
   it('still renders the whole site for sections linking only data', async () => {

--- a/test/e2e/llms-handwritten.test.ts
+++ b/test/e2e/llms-handwritten.test.ts
@@ -9,9 +9,11 @@ import { fetch, setup } from '@nuxt/test-utils/e2e'
  * route it could find. The index stayed curated while the full document held
  * the whole site, `/private/hidden` included.
  *
- * The adapter here lists all four pages, so a document coming out short is
- * curation rather than an adapter with nothing to say: `/sitemap.md` below is
- * the control.
+ * Both documents read the same links now: the curated pages are what the full
+ * document renders, and a section pointing only at data names no page in
+ * either. The adapter here lists all four pages, so a document coming out
+ * short is curation rather than an adapter with nothing to say: `/sitemap.md`
+ * below is the control.
  */
 const SITE_URL = 'https://handwritten.example.com'
 
@@ -35,6 +37,19 @@ describe('llms.txt', () => {
       `- [Alpha](${SITE_URL}/raw/docs/alpha.md): The documented page.`
     ])
   })
+
+  it('lists every page when the hand-written links are all data', async () => {
+    // `/llms-datalinks-index.txt` runs the same hook over a section linking an
+    // API endpoint and an `openapi.json`. Neither has a markdown
+    // representation, so the section names no documentation and the listing
+    // fallback has to fire. `/api/v1/tools` carries no extension, which is
+    // what the old page-link test read it by.
+    const body = await (await fetch('/llms-datalinks-index.txt')).text()
+
+    expect(body).toContain(`- [Alpha](${SITE_URL}/raw/docs/alpha.md)`)
+    expect(body).toContain(`- [Beta](${SITE_URL}/raw/docs/beta.md)`)
+    expect(body).toContain(`- [Hidden](${SITE_URL}/raw/private/hidden.md)`)
+  })
 })
 
 describe('llms-full.txt', () => {
@@ -47,22 +62,26 @@ describe('llms-full.txt', () => {
     expect(body).not.toContain('kept out of the documentation on purpose')
   })
 
-  it('comes out empty when every section is hand-written', async () => {
+  it('renders the pages the hand-written links name', async () => {
     const response = await fetch('/llms-full.txt')
 
     expect(response.status).toBe(200)
-    // A hand-written link is not a selector the adapter can resolve back to a
-    // page, so the sections name nothing to render. Empty is what agrees with
-    // the index: the alternative was the whole site, which agreed with nothing.
-    expect((await response.text()).trim()).toBe('')
+    const body = await response.text()
+
+    // The links are the section's documentation, so the full document is the
+    // pages behind them. Answering 200 with an empty body was the other half
+    // of the bug: `llms.txt` advertised a document holding nothing.
+    expect(body.trim()).not.toBe('')
+    expect(body).toContain('# Alpha')
+    expect(body).toContain('The one page the hand-written section links.')
   })
 
   it('still renders the whole site for sections linking only data', async () => {
     // `/llms-datalinks.txt` runs the same hook over sections whose links are an
-    // `openapi.json` and a repository. Those name no documentation, so the
-    // fallback has to stay: it is the only thing such a site's full document
-    // would ever hold. `llms.txt` keys its own fallback on the same predicate,
-    // so the two documents cannot disagree about it.
+    // `openapi.json`, an API endpoint and a repository. Those name no
+    // documentation, so the fallback has to stay: it is the only thing such a
+    // site's full document would ever hold. `llms.txt` reads the links the same
+    // way, so the two documents cannot disagree about it.
     const body = await (await fetch('/llms-datalinks.txt')).text()
 
     expect(body).toContain('# Alpha')

--- a/test/fixtures/llms-handwritten/app.vue
+++ b/test/fixtures/llms-handwritten/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <main>
+    <h1>Handwritten</h1>
+    <p>Fixture site whose llms sections are all hand-written.</p>
+  </main>
+</template>

--- a/test/fixtures/llms-handwritten/nuxt.config.ts
+++ b/test/fixtures/llms-handwritten/nuxt.config.ts
@@ -20,7 +20,12 @@ export default defineNuxtConfig({
     sections: [{
       title: 'Docs',
       description: 'The one page this site puts in front of an agent.',
-      links: [{ title: 'Alpha', href: '/docs/alpha', description: 'The documented page.' }]
+      links: [
+        { title: 'Alpha', href: '/docs/alpha', description: 'The documented page.' },
+        // A non-ASCII slug: `URL.pathname` spells it percent-encoded while the
+        // adapter stores it decoded, so the full document has to decode it.
+        { title: 'Café', href: '/docs/café', description: 'The accented page.' }
+      ]
     }, {
       // Hand-written links next to a selector the adapter resolves: the links
       // own the section, so the selector must stay unread in both documents.

--- a/test/fixtures/llms-handwritten/nuxt.config.ts
+++ b/test/fixtures/llms-handwritten/nuxt.config.ts
@@ -1,0 +1,26 @@
+export default defineNuxtConfig({
+  modules: ['../../../src/module', 'nuxt-llms'],
+  devtools: { enabled: false },
+  compatibilityDate: '2026-01-01',
+  agentDiscovery: {
+    siteName: 'Handwritten',
+    source: '~~/server/agent-source'
+  },
+  llms: {
+    domain: 'https://handwritten.example.com',
+    title: 'Handwritten',
+    description: 'Fixture site whose llms sections are all hand-written.',
+    full: {
+      title: 'Handwritten',
+      description: 'The curated documentation.'
+    },
+    // Every section carries its own links, so the adapter resolves none of
+    // them. The site has more pages than these, and neither document may grow
+    // the ones it left out.
+    sections: [{
+      title: 'Docs',
+      description: 'The one page this site puts in front of an agent.',
+      links: [{ title: 'Alpha', href: '/docs/alpha', description: 'The documented page.' }]
+    }]
+  }
+})

--- a/test/fixtures/llms-handwritten/nuxt.config.ts
+++ b/test/fixtures/llms-handwritten/nuxt.config.ts
@@ -21,6 +21,13 @@ export default defineNuxtConfig({
       title: 'Docs',
       description: 'The one page this site puts in front of an agent.',
       links: [{ title: 'Alpha', href: '/docs/alpha', description: 'The documented page.' }]
+    }, {
+      // Hand-written links next to a selector the adapter resolves: the links
+      // own the section, so the selector must stay unread in both documents.
+      title: 'Mixed',
+      description: 'Hand-written links beside a resolvable selector.',
+      docs: true,
+      links: [{ title: 'Alpha again', href: '/docs/alpha', description: 'The same page, curated by hand.' }]
     }]
   }
 })

--- a/test/fixtures/llms-handwritten/server/agent-source.ts
+++ b/test/fixtures/llms-handwritten/server/agent-source.ts
@@ -1,0 +1,65 @@
+import { defineAgentContentSource } from '#agent-discovery'
+
+/**
+ * In-memory adapter for a site that curates its `llms.sections` by hand.
+ *
+ * `list()` returns `null` for any selector, which is the contract for a
+ * section the adapter does not recognise, and a hand-written section never
+ * names anything it could. So every section resolves to nothing here, and the
+ * pages outside the curated links have to stay out of both documents.
+ */
+const pages: Record<string, { title: string, description: string, markdown: string }> = {
+  '/': {
+    title: 'Handwritten',
+    description: 'Fixture site whose llms sections are all hand-written.',
+    markdown: `# Handwritten
+
+> Fixture site whose llms sections are all hand-written.
+
+Browse the [documentation](/docs/alpha).
+`
+  },
+  '/docs/alpha': {
+    title: 'Alpha',
+    description: 'The documented page.',
+    markdown: `# Alpha
+
+> The documented page.
+
+The one page the hand-written section links.
+`
+  },
+  '/docs/beta': {
+    title: 'Beta',
+    description: 'A page the sections leave out.',
+    markdown: `# Beta
+
+> A page the sections leave out.
+
+Reachable as raw markdown, absent from the curated documents.
+`
+  },
+  '/private/hidden': {
+    title: 'Hidden',
+    description: 'A page kept out of the documentation on purpose.',
+    markdown: `# Hidden
+
+> A page kept out of the documentation on purpose.
+
+Kept out of the documentation on purpose.
+`
+  }
+}
+
+export default defineAgentContentSource({
+  async list(selector) {
+    if (selector) {
+      return null
+    }
+    return Object.entries(pages).map(([route, page]) => ({ route, title: page.title, description: page.description }))
+  },
+
+  async get(route: string) {
+    return pages[route] || null
+  }
+})

--- a/test/fixtures/llms-handwritten/server/agent-source.ts
+++ b/test/fixtures/llms-handwritten/server/agent-source.ts
@@ -5,8 +5,8 @@ import { defineAgentContentSource } from '#agent-discovery'
  *
  * `list()` returns `null` for any selector, which is the contract for a
  * section the adapter does not recognise, and a hand-written section never
- * names anything it could. So every section resolves to nothing here, and the
- * pages outside the curated links have to stay out of both documents.
+ * names anything it could. So the curated links are the only thing either
+ * document has to go on, and the pages outside them have to stay out of both.
  */
 const pages: Record<string, { title: string, description: string, markdown: string }> = {
   '/': {

--- a/test/fixtures/llms-handwritten/server/agent-source.ts
+++ b/test/fixtures/llms-handwritten/server/agent-source.ts
@@ -54,7 +54,11 @@ Kept out of the documentation on purpose.
 export default defineAgentContentSource({
   async list(selector) {
     if (selector) {
-      return null
+      // One recognized selector, so the mixed-section rule is testable: a
+      // section carrying its own links must not also resolve it.
+      return (selector as { docs?: boolean }).docs === true
+        ? [{ route: '/docs/beta', title: 'Beta', description: 'A page the sections leave out.' }]
+        : null
     }
     return Object.entries(pages).map(([route, page]) => ({ route, title: page.title, description: page.description }))
   },

--- a/test/fixtures/llms-handwritten/server/agent-source.ts
+++ b/test/fixtures/llms-handwritten/server/agent-source.ts
@@ -29,6 +29,16 @@ Browse the [documentation](/docs/alpha).
 The one page the hand-written section links.
 `
   },
+  '/docs/café': {
+    title: 'Café',
+    description: 'The accented page.',
+    markdown: `# Café
+
+> The accented page.
+
+Stored under a decoded slug, linked through a percent-encoded URL.
+`
+  },
   '/docs/beta': {
     title: 'Beta',
     description: 'A page the sections leave out.',

--- a/test/fixtures/llms-handwritten/server/routes/llms-datalinks-index.txt.get.ts
+++ b/test/fixtures/llms-handwritten/server/routes/llms-datalinks-index.txt.get.ts
@@ -1,0 +1,30 @@
+import { useNitroApp } from 'nitropack/runtime'
+
+/**
+ * The `llms.txt` side of the data-only section, with one link carrying no
+ * extension: `/api/v1/tools` sits under an excluded prefix, so the site has no
+ * markdown for it whatever it looks like. Reading the extension alone counted
+ * it as a page and left the index with nothing but the API links.
+ *
+ * `llms.sections` is build-time config, so calling the hook is the only way to
+ * put a second section shape in front of the bridge without a second fixture.
+ * Only the links are rendered, which is all the assertion reads.
+ */
+export default defineEventHandler(async (event) => {
+  const options = {
+    domain: 'https://handwritten.example.com',
+    sections: [{
+      title: 'API',
+      links: [
+        { title: 'Tools', href: '/api/v1/tools' },
+        { title: 'OpenAPI', href: '/openapi.json' }
+      ]
+    }]
+  }
+
+  await useNitroApp().hooks.callHook('llms:generate' as never, event as never, options as never)
+
+  return options.sections
+    .flatMap(section => (section.links || []).map(link => `- [${link.title}](${link.href})`))
+    .join('\n')
+})

--- a/test/fixtures/llms-handwritten/server/routes/llms-datalinks.txt.get.ts
+++ b/test/fixtures/llms-handwritten/server/routes/llms-datalinks.txt.get.ts
@@ -1,0 +1,28 @@
+import { useNitroApp } from 'nitropack/runtime'
+
+/**
+ * The other shape of a hand-written section: links pointing at data rather
+ * than at pages, which is what a site listing its `openapi.json`, its API
+ * endpoints and its repository ends up with. That site named no documentation,
+ * so `llms-full.txt` still renders the whole site for it.
+ *
+ * `llms.sections` is build-time config, so calling the hook is the only way to
+ * put a second section shape in front of the bridge without a second fixture.
+ * The document is built exactly the way `/llms-full.txt` builds its own.
+ */
+export default defineEventHandler(async (event) => {
+  const contents: string[] = []
+
+  await useNitroApp().hooks.callHook('llms:generate:full' as never, event as never, {
+    domain: 'https://handwritten.example.com',
+    sections: [{
+      title: 'API',
+      links: [
+        { title: 'OpenAPI', href: '/openapi.json' },
+        { title: 'Repository', href: 'https://github.com/nuxt/nuxt' }
+      ]
+    }]
+  } as never, contents as never)
+
+  return contents.join('\n\n')
+})

--- a/test/fixtures/llms-handwritten/server/routes/llms-datalinks.txt.get.ts
+++ b/test/fixtures/llms-handwritten/server/routes/llms-datalinks.txt.get.ts
@@ -4,11 +4,14 @@ import { useNitroApp } from 'nitropack/runtime'
  * The other shape of a hand-written section: links pointing at data rather
  * than at pages, which is what a site listing its `openapi.json`, its API
  * endpoints and its repository ends up with. That site named no documentation,
- * so `llms-full.txt` still renders the whole site for it.
+ * so `llms-full.txt` still renders the whole site for it. `/api/v1/tools`
+ * carries no extension and is data all the same, which is the case an
+ * extension test got wrong.
  *
  * `llms.sections` is build-time config, so calling the hook is the only way to
  * put a second section shape in front of the bridge without a second fixture.
- * The document is built exactly the way `/llms-full.txt` builds its own.
+ * The document is built exactly the way `/llms-full.txt` builds its own, and
+ * `/llms-datalinks-index.txt` runs the same shape through the index hook.
  */
 export default defineEventHandler(async (event) => {
   const contents: string[] = []
@@ -19,6 +22,7 @@ export default defineEventHandler(async (event) => {
       title: 'API',
       links: [
         { title: 'OpenAPI', href: '/openapi.json' },
+        { title: 'Tools', href: '/api/v1/tools' },
         { title: 'Repository', href: 'https://github.com/nuxt/nuxt' }
       ]
     }]

--- a/test/unit/comark.test.ts
+++ b/test/unit/comark.test.ts
@@ -117,7 +117,7 @@ describe('comark source', () => {
 
 describe('comark listing', () => {
   it('lists every page in the navigation', async () => {
-    const routes = ((await source.list(undefined, event)) || []).map(entry => entry.route)
+    const routes = ((await source.list!(undefined, event)) || []).map(entry => entry.route)
 
     expect(routes).toContain('/')
     expect(routes).toContain('/about')
@@ -126,7 +126,7 @@ describe('comark listing', () => {
   })
 
   it('carries the title and the navigation group into the listing', async () => {
-    const entries = await source.list(undefined, event)
+    const entries = await source.list!(undefined, event)
     const button = entries?.find(entry => entry.route === '/docs/components/button')
 
     expect(button?.title).toBe('Button')
@@ -134,7 +134,7 @@ describe('comark listing', () => {
   })
 
   it('scopes a listing to the subtree a `navigation` selector names', async () => {
-    const entries = await source.list({ navigation: '/docs' }, event)
+    const entries = await source.list!({ navigation: '/docs' }, event)
 
     expect(entries?.length).toBeGreaterThan(0)
     expect(entries?.every(entry => entry.route.startsWith('/docs'))).toBe(true)
@@ -144,7 +144,7 @@ describe('comark listing', () => {
     // A site swapping backend keeps its `llms.sections` config, so the
     // `@nuxt/content` keys arrive here. Claiming them would list the wrong
     // pages; the bridge drops the section instead.
-    expect(await source.list({ contentCollection: 'docs' }, event)).toBe(null)
+    expect(await source.list!({ contentCollection: 'docs' }, event)).toBe(null)
   })
 
   it('resolves a section path to its first document', async () => {

--- a/test/unit/pages.test.ts
+++ b/test/unit/pages.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { H3Event } from 'h3'
+
+/**
+ * `list()` is optional on the seam: a backend can resolve a route without
+ * being able to enumerate its pages. The listing is then empty, and the point
+ * of this file is that it comes out empty rather than throwing, which is what
+ * every caller of `listAgentPages()` would have seen.
+ *
+ * The config accessor is the real one, through the aliased `#imports`, so the
+ * raw URLs come out of the same route matching a site would get. Nitro's
+ * runtime only has to import: it is reached through the barrel, which
+ * re-exports the document helpers, and nothing here calls into it.
+ */
+vi.mock('nitropack/runtime', () => ({ useNitroApp: () => ({ hooks: { callHook: async () => {} } }) }))
+
+const { listAgentPages } = await import('../../src/runtime/server/utils/pages')
+const { setAgentContentSource } = await import('./source.stub')
+const { setRuntimeConfig } = await import('./imports.stub')
+
+const event = {} as H3Event
+
+beforeEach(() => {
+  setAgentContentSource(null)
+  setRuntimeConfig({
+    agentDiscovery: {
+      siteUrl: 'https://example.com',
+      rawPrefix: '/raw',
+      routes: [{ path: '/', raw: '/raw/index.md' }, { path: '/**' }],
+      excludePrefixes: ['/_', '/api/']
+    }
+  })
+})
+
+describe('listAgentPages: an adapter without `list()`', () => {
+  it('lists nothing instead of throwing', async () => {
+    setAgentContentSource({
+      async get() {
+        return { markdown: '# Getting Started\n' }
+      }
+    })
+
+    await expect(listAgentPages(event)).resolves.toEqual([])
+  })
+
+  it('still lists the pages of an adapter that has it', async () => {
+    setAgentContentSource({
+      async list() {
+        return [{ route: '/docs/getting-started', title: 'Getting Started' }]
+      },
+      async get() {
+        return { markdown: '# Getting Started\n' }
+      }
+    })
+
+    await expect(listAgentPages(event)).resolves.toEqual([{
+      route: '/docs/getting-started',
+      title: 'Getting Started',
+      description: undefined,
+      section: undefined,
+      url: 'https://example.com/docs/getting-started',
+      rawUrl: 'https://example.com/raw/docs/getting-started.md'
+    }])
+  })
+})

--- a/test/unit/source.stub.ts
+++ b/test/unit/source.stub.ts
@@ -1,0 +1,22 @@
+import type { AgentContentSource } from '../../src/runtime/shared/types'
+
+/**
+ * Stands in for `#agent-discovery/source`, the alias the module points at the
+ * site's content adapter.
+ *
+ * The server utils import it directly, so an adapter that only implements part
+ * of the seam can otherwise only be exercised from an e2e fixture. Aliased in
+ * `vitest.config.ts`; the e2e suites run against a real fixture build and never
+ * load this.
+ */
+// Mutable on purpose: the utils import the default binding directly, so
+// reassigning it is the only way a test can hand them another adapter.
+// eslint-disable-next-line import/no-mutable-exports
+let source: AgentContentSource | null = null
+
+export { source as default }
+
+/** Replaces the stubbed adapter wholesale, so a test cannot inherit another's. */
+export function setAgentContentSource(next: AgentContentSource | null): void {
+  source = next
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
       // The server utils read their config through Nitro's `#imports`, which
       // only resolves inside a build. The stub lets them be unit tested; the
       // e2e suites run against a real fixture server and never load it.
-      '#imports': fileURLToPath(new URL('./test/unit/imports.stub.ts', import.meta.url))
+      '#imports': fileURLToPath(new URL('./test/unit/imports.stub.ts', import.meta.url)),
+      // The alias the module points at the site's content adapter, which the
+      // server utils import directly. The stub lets a test hand them an
+      // adapter of its own, an incomplete one most of all.
+      '#agent-discovery/source': fileURLToPath(new URL('./test/unit/source.stub.ts', import.meta.url))
     }
   },
   test: {


### PR DESCRIPTION
- `list()`'s docstring promised the module degrades gracefully without it, but the method was required in the type and called unguarded in five places, so a get-only custom source 500d `/sitemap.md`, `/llms.txt` and `/llms-full.txt`. it is genuinely optional now: listings come out empty, `get()` documents keep working, and the docstring says what actually happens.
- `llms-full.txt` dumped every page on the site whenever no section resolved routes through the adapter, which is exactly what a config whose `llms.sections` are all hand-written produces, contradicting the comment right above the fallback while `llms.txt` stayed curated. the fallback is now keyed on the same `hasPageLinks` predicate `llms.txt` uses: curated page links suppress the dump, data-only links (an `/openapi.json`, API endpoints) keep the whole-site fallback, and the two documents agree by construction. new `llms-handwritten` fixture pins both shapes.
- the per-section resolution and the per-route renders behind `llms-full.txt` were sequential awaits with no dependency between iterations, so a large site paid hundreds of round trips one at a time. they run through `Promise.all` now, order preserved.
- a hand-written link to a non-ASCII slug vanished from `llms-full.txt`: `URL.pathname` spells `/docs/café` percent-encoded while every adapter stores decoded paths, so `get()` found nothing and the page was silently skipped. the route now goes through `normalizeAgentRoute`, the same decoding the raw handler runs on its slug. the handwritten fixture curates a café page and asserts it lands in both documents.

stacked on the runtime pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for content sources that provide page retrieval without page enumeration.
  * Added optional page freshness metadata for discovered pages.
  * Improved curated LLMS links, including percent-encoded local paths and accented routes.

* **Bug Fixes**
  * Corrected full-document and section output for curated and data-only links.
  * Preserved raw markdown access and sitemap coverage for unlinked pages.
  * Improved fallback behavior when page listings are unavailable.

* **Tests**
  * Added coverage for handwritten LLMS configurations, curated links, fallback rendering, and non-enumerating content sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
