### PR TITLE
refactor: shared helpers, defaults and the adapter pipeline

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -28,13 +28,13 @@ export const AGENT_USER_AGENTS = [
 ]
 
 /**
- * MCP definition groups the public server card hides. Groups come from the
- * subdirectory a definition sits in under `server/mcp/tools`, and
- * `mcpServerCard.excludeGroups` extends this list rather than replacing it: a
- * site naming its own private group should not silently start publishing its
- * admin tools.
+ * MCP definition groups the public server card hides.
+ *
+ * Defined in `runtime/shared/defaults.ts`, since the card route applies it
+ * again per request rather than trusting the merged runtime config, and
+ * re-exported here so the defaults still read as one list.
  */
-export const MCP_EXCLUDED_GROUPS = ['admin']
+export { MCP_EXCLUDED_GROUPS } from './runtime/shared/defaults'
 
 /** Paths owned by the framework or the API, never markdown. */
 export const EXCLUDE_PREFIXES = ['/_', '/api/', '/mcp', '/.well-known/']

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -27,5 +27,14 @@ export const AGENT_USER_AGENTS = [
   'Bytespider'
 ]
 
+/**
+ * MCP definition groups the public server card hides. Groups come from the
+ * subdirectory a definition sits in under `server/mcp/tools`, and
+ * `mcpServerCard.excludeGroups` extends this list rather than replacing it: a
+ * site naming its own private group should not silently start publishing its
+ * admin tools.
+ */
+export const MCP_EXCLUDED_GROUPS = ['admin']
+
 /** Paths owned by the framework or the API, never markdown. */
 export const EXCLUDE_PREFIXES = ['/_', '/api/', '/mcp', '/.well-known/']

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,8 @@ import {
 import { defu } from 'defu'
 import { join } from 'pathe'
 import { withLeadingSlash, withoutTrailingSlash } from 'ufo'
-import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from './defaults'
+import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES, MCP_EXCLUDED_GROUPS } from './defaults'
+import { SKILLS_INDEX, SKILLS_PREFIX } from './runtime/shared/paths'
 import { isValidRel } from './rels'
 import { scanSkills } from './skills'
 import { setupVercelPreset } from './presets/vercel'
@@ -40,8 +41,10 @@ export interface McpServerCardOptions {
   version?: string
   /**
    * Definition groups kept off the public card, by the subdirectory they live
-   * in under `server/mcp/tools`. Admin tools behind a bearer token are on the
-   * server but are not something to advertise.
+   * in under `server/mcp/tools`. Extends the built-in default (`admin`, see
+   * `MCP_EXCLUDED_GROUPS` in `defaults.ts`) rather than replacing it: admin
+   * tools behind a bearer token are on the server but are not something to
+   * advertise.
    */
   excludeGroups?: string[]
 }
@@ -411,7 +414,13 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/.well-known/api-catalog', handler: resolve('./runtime/server/routes/api-catalog') })
     }
     if (options.discovery?.mcpServerCard) {
-      runtimeConfig.agentDiscoveryMcp = options.discovery.mcpServerCard
+      // The default lives in `defaults.ts` with the other lists, and the
+      // option extends it rather than replacing it, so the merge happens here
+      // and the route reads the resolved list.
+      runtimeConfig.agentDiscoveryMcp = {
+        ...options.discovery.mcpServerCard,
+        excludeGroups: [...new Set([...MCP_EXCLUDED_GROUPS, ...(options.discovery.mcpServerCard.excludeGroups || [])])]
+      }
       addServerHandler({ route: '/.well-known/mcp/server-card.json', handler: resolve('./runtime/server/routes/mcp-server-card') })
     }
 
@@ -581,11 +590,11 @@ export {}
         nitroConfig.serverAssets.push({ baseName: 'agentSkills', dir: skillsDir })
       })
 
-      addServerHandler({ route: '/.well-known/skills/index.json', handler: resolve('./runtime/server/routes/skills-index') })
-      addServerHandler({ route: '/.well-known/skills/**', handler: resolve('./runtime/server/routes/skills-files') })
+      addServerHandler({ route: SKILLS_INDEX, handler: resolve('./runtime/server/routes/skills-index') })
+      addServerHandler({ route: `${SKILLS_PREFIX}**`, handler: resolve('./runtime/server/routes/skills-files') })
       addPrerenderRoutes([
-        '/.well-known/skills/index.json',
-        ...skills.flatMap(skill => skill.files.map(file => `/.well-known/skills/${skill.name}/${file}`))
+        SKILLS_INDEX,
+        ...skills.flatMap(skill => skill.files.map(file => `${SKILLS_PREFIX}${skill.name}/${file}`))
       ])
     }
 
@@ -812,11 +821,11 @@ export {}
         }
       }
       if (skills.length) {
-        links.push({ href: '/.well-known/skills/index.json', rel: 'index', type: 'application/json', title: 'Agent skills index: every skill published by this site' })
+        links.push({ href: SKILLS_INDEX, rel: 'index', type: 'application/json', title: 'Agent skills index: every skill published by this site' })
         // The skills themselves stay out of the `Link` header, which
         // advertises the discovery documents rather than every resource.
         for (const skill of skills) {
-          links.push({ href: `/.well-known/skills/${skill.name}/SKILL.md`, rel: 'service-doc', type: 'text/markdown', title: `Agent skill: ${skill.name}`, anchor: '/', header: false })
+          links.push({ href: `${SKILLS_PREFIX}${skill.name}/SKILL.md`, rel: 'service-doc', type: 'text/markdown', title: `Agent skill: ${skill.name}`, anchor: '/', header: false })
         }
       }
       if (matchRoute(routes, '/')) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -15,7 +15,8 @@ import {
 import { defu } from 'defu'
 import { join } from 'pathe'
 import { withLeadingSlash, withoutTrailingSlash } from 'ufo'
-import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES, MCP_EXCLUDED_GROUPS } from './defaults'
+import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from './defaults'
+import { mcpExcludedGroups } from './runtime/shared/defaults'
 import { SKILLS_INDEX, SKILLS_PREFIX } from './runtime/shared/paths'
 import { isValidRel } from './rels'
 import { scanSkills } from './skills'
@@ -419,7 +420,7 @@ export default defineNuxtModule<ModuleOptions>({
       // and the route reads the resolved list.
       runtimeConfig.agentDiscoveryMcp = {
         ...options.discovery.mcpServerCard,
-        excludeGroups: [...new Set([...MCP_EXCLUDED_GROUPS, ...(options.discovery.mcpServerCard.excludeGroups || [])])]
+        excludeGroups: [...mcpExcludedGroups(options.discovery.mcpServerCard.excludeGroups)]
       }
       addServerHandler({ route: '/.well-known/mcp/server-card.json', handler: resolve('./runtime/server/routes/mcp-server-card') })
     }

--- a/src/runtime/server/error.ts
+++ b/src/runtime/server/error.ts
@@ -1,6 +1,6 @@
 import type { NitroErrorHandler } from 'nitropack/types'
-import { getRequestHeader, getRequestURL, send, setResponseHeader, setResponseStatus } from 'h3'
-import { useAgentDiscoveryConfig } from './utils/agent-discovery'
+import { getRequestHeader, send, setResponseHeader, setResponseStatus } from 'h3'
+import { getAgentSiteUrl, useAgentDiscoveryConfig } from './utils/agent-discovery'
 import { errorMarkdown, prefersMarkdownError, MARKDOWN_VARY } from '../shared/negotiation'
 
 /**
@@ -57,7 +57,7 @@ const errorHandler: NitroErrorHandler = async (error, event, { defaultHandler })
     // Not sanitized on the way here: `createError` only warns about an unsafe
     // status message, and Nitro returns it verbatim. `errorMarkdown` strips it.
     statusMessage: res.statusText,
-    siteUrl: config.siteUrl || getRequestURL(event).origin
+    siteUrl: getAgentSiteUrl(event)
   }))
 }
 

--- a/src/runtime/server/plugins/sitemap.ts
+++ b/src/runtime/server/plugins/sitemap.ts
@@ -1,6 +1,7 @@
 import { parseURL } from 'ufo'
 import { defineNitroPlugin } from 'nitropack/runtime'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
+import { isRawPath } from '../../shared/negotiation'
 
 /** A sitemap URL as the sources hand it over, before `@nuxtjs/sitemap` normalizes it. */
 type SitemapUrlInput = string | { loc?: string }
@@ -25,7 +26,6 @@ interface SitemapInputContext {
  */
 export default defineNitroPlugin((nitroApp) => {
   const { rawPrefix } = useAgentDiscoveryConfig()
-  const prefix = `${rawPrefix}/`
 
   const onSitemapInput = nitroApp.hooks.hook as unknown as (
     name: 'sitemap:input',
@@ -36,7 +36,7 @@ export default defineNitroPlugin((nitroApp) => {
     ctx.urls = ctx.urls.filter((url) => {
       const loc = typeof url === 'string' ? url : url?.loc
       // Sources may hand over absolute URLs, so compare on the pathname.
-      return !loc || !(parseURL(loc).pathname || loc).startsWith(prefix)
+      return !loc || !isRawPath({ rawPrefix }, parseURL(loc).pathname || loc)
     })
   })
 })

--- a/src/runtime/server/routes/api-catalog.ts
+++ b/src/runtime/server/routes/api-catalog.ts
@@ -1,5 +1,6 @@
 import { defineEventHandler, setResponseHeader } from 'h3'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
+import { absolutizeHref } from '../../shared/negotiation'
 
 /**
  * RFC 9727 api-catalog: the discovery links carrying an anchor, grouped into
@@ -8,21 +9,20 @@ import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discove
 export default defineEventHandler((event) => {
   const config = useAgentDiscoveryConfig(event)
   const siteUrl = getAgentSiteUrl(event)
-  const absolute = (href: string) => href.startsWith('/') ? `${siteUrl}${href}` : href
 
   const groups = new Map<string, Record<string, unknown>>()
   for (const link of config.links) {
     if (!link.anchor || (link.rel !== 'service-desc' && link.rel !== 'service-doc')) {
       continue
     }
-    const anchor = absolute(link.anchor === '/' ? '/' : link.anchor).replace(/\/$/, '') || `${siteUrl}/`
+    const anchor = absolutizeHref(link.anchor === '/' ? '/' : link.anchor, siteUrl).replace(/\/$/, '') || `${siteUrl}/`
     let group = groups.get(anchor)
     if (!group) {
-      group = { anchor: link.anchor === '/' ? `${siteUrl}/` : absolute(link.anchor) }
+      group = { anchor: link.anchor === '/' ? `${siteUrl}/` : absolutizeHref(link.anchor, siteUrl) }
       groups.set(anchor, group)
     }
     const entries = (group[link.rel] ||= []) as { href: string, type?: string }[]
-    entries.push({ href: absolute(link.href), ...(link.type ? { type: link.type } : {}) })
+    entries.push({ href: absolutizeHref(link.href, siteUrl), ...(link.type ? { type: link.type } : {}) })
   }
 
   setResponseHeader(event, 'Content-Type', 'application/linkset+json; charset=utf-8')

--- a/src/runtime/server/routes/mcp-server-card.ts
+++ b/src/runtime/server/routes/mcp-server-card.ts
@@ -3,6 +3,7 @@ import { useNitroApp } from 'nitropack/runtime'
 import { useRuntimeConfig } from '#imports'
 import { listMcpDefinitions } from '#agent-discovery/mcp'
 import { getAgentSiteUrl } from '../utils/agent-discovery'
+import { absolutizeHref } from '../../shared/negotiation'
 
 interface McpServerCardConfig {
   endpoint: string
@@ -41,7 +42,6 @@ interface McpDefinition {
 export default defineEventHandler(async (event) => {
   const card = useRuntimeConfig(event).agentDiscoveryMcp as McpServerCardConfig
   const siteUrl = getAgentSiteUrl(event)
-  const absolute = (href: string) => href.startsWith('/') ? `${siteUrl}${href}` : href
 
   // No `$schema`: the URL this used to carry 404s, and so does the one the
   // draft that would define it (SEP-2127) proposes, because that draft is
@@ -55,14 +55,14 @@ export default defineEventHandler(async (event) => {
       ...(card.title ? { title: card.title } : {}),
       ...(card.description ? { description: card.description } : {}),
       homepage: siteUrl,
-      ...(card.documentation ? { documentation: absolute(card.documentation) } : {}),
+      ...(card.documentation ? { documentation: absolutizeHref(card.documentation, siteUrl) } : {}),
       ...(card.license ? { license: card.license } : {}),
       ...(card.repository ? { repository: card.repository } : {})
     },
     endpoints: [
       {
         type: 'streamable-http',
-        url: absolute(card.endpoint)
+        url: absolutizeHref(card.endpoint, siteUrl)
       }
     ],
     authentication: {
@@ -77,10 +77,10 @@ export default defineEventHandler(async (event) => {
       prompts: McpDefinition[]
     }
     // Groups come from the subdirectory a definition sits in, which is how a
-    // site separates its admin tools from the ones anybody may call.
-    // Extends the default rather than replacing it: a site naming its own
-    // private group should not silently start publishing its admin tools.
-    const excluded = new Set(['admin', ...(card.excludeGroups ?? [])])
+    // site separates its admin tools from the ones anybody may call. The
+    // `admin` default is merged into `excludeGroups` at build time, next to
+    // the other defaults in `defaults.ts`.
+    const excluded = new Set(card.excludeGroups ?? [])
     const isPublic = (definition: McpDefinition) => !definition.group || !excluded.has(definition.group)
 
     serverCard.capabilities = {

--- a/src/runtime/server/routes/mcp-server-card.ts
+++ b/src/runtime/server/routes/mcp-server-card.ts
@@ -4,6 +4,7 @@ import { useRuntimeConfig } from '#imports'
 import { listMcpDefinitions } from '#agent-discovery/mcp'
 import { getAgentSiteUrl } from '../utils/agent-discovery'
 import { absolutizeHref } from '../../shared/negotiation'
+import { mcpExcludedGroups } from '../../shared/defaults'
 
 interface McpServerCardConfig {
   endpoint: string
@@ -77,10 +78,13 @@ export default defineEventHandler(async (event) => {
       prompts: McpDefinition[]
     }
     // Groups come from the subdirectory a definition sits in, which is how a
-    // site separates its admin tools from the ones anybody may call. The
-    // `admin` default is merged into `excludeGroups` at build time, next to
-    // the other defaults in `defaults.ts`.
-    const excluded = new Set(card.excludeGroups ?? [])
+    // site separates its admin tools from the ones anybody may call. The build
+    // merges the `admin` default into `excludeGroups` already, but this list
+    // arrives through runtime config, where
+    // `NUXT_AGENT_DISCOVERY_MCP_EXCLUDE_GROUPS` replaces it wholesale. Unioning
+    // the defaults back in keeps a deploy-time override from publishing the
+    // admin tools.
+    const excluded = mcpExcludedGroups(card.excludeGroups)
     const isPublic = (definition: McpDefinition) => !definition.group || !excluded.has(definition.group)
 
     serverCard.capabilities = {

--- a/src/runtime/server/routes/skills-files.ts
+++ b/src/runtime/server/routes/skills-files.ts
@@ -2,6 +2,7 @@ import { createError, defineEventHandler, getRequestURL, setResponseHeader } fro
 import { useStorage } from 'nitropack/runtime'
 import { useRuntimeConfig } from '#imports'
 import type { SkillEntry } from '../../shared/types'
+import { SKILLS_PREFIX } from '../../shared/paths'
 
 const CONTENT_TYPES: Record<string, string> = {
   '.md': 'text/markdown; charset=utf-8',
@@ -25,16 +26,15 @@ function contentType(path: string): string {
  * outside the skills directory.
  */
 export default defineEventHandler(async (event) => {
-  const prefix = '/.well-known/skills/'
   const pathname = getRequestURL(event).pathname
-  const index = pathname.indexOf(prefix)
+  const index = pathname.indexOf(SKILLS_PREFIX)
   if (index === -1) {
     throw createError({ statusCode: 404, statusMessage: 'Not Found' })
   }
 
   let path: string
   try {
-    path = decodeURIComponent(pathname.slice(index + prefix.length))
+    path = decodeURIComponent(pathname.slice(index + SKILLS_PREFIX.length))
   } catch {
     // A malformed escape (`%`, `%zz`) is a bad request, not a server error.
     throw createError({ statusCode: 400, statusMessage: 'Bad Request' })

--- a/src/runtime/server/sources/comark.ts
+++ b/src/runtime/server/sources/comark.ts
@@ -1,11 +1,9 @@
 import type { H3Event } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import type { AgentContentSource, AgentListEntry, AgentSectionSelector } from '../../shared/types'
-import { absolutizeTreeLinks } from '../../shared/negotiation'
+import { prepareDocumentTree } from './pipeline'
+import type { DocNode } from './pipeline'
 import { getAgentSiteUrl } from '../utils/agent-discovery'
-
-/** Same shape minimark uses: `[tag, props, ...children]`. */
-type ComarkNode = [string, Record<string, unknown>, ...unknown[]]
 
 interface ComarkNavigationItem {
   title?: string
@@ -129,10 +127,10 @@ export function createComarkSource(getContent: (event: H3Event) => Promise<Comar
     },
 
     /**
-     * Step for step what the `@nuxt/content` adapter does to a minimark tree,
-     * on a comark one. The two have to come out byte-identical: a site moving
-     * backend changes the adapter and nothing else, and `test/e2e/expected.ts`
-     * is what holds them to it.
+     * The shared document pipeline on a comark tree, with only the fetch and
+     * the render around it. The two adapters have to come out byte-identical:
+     * a site moving backend changes the adapter and nothing else, and
+     * `test/e2e/expected.ts` is what holds them to it.
      */
     async get(route: string, event: H3Event) {
       const content = await getContent(event)
@@ -153,43 +151,20 @@ export function createComarkSource(getContent: (event: H3Event) => Promise<Comar
       // so a transformer can swap them wholesale.
       await useNitroApp().hooks.callHook('agent-discovery:document', event, page)
 
-      const nodes = page.nodes as ComarkNode[]
+      const nodes = page.nodes as DocNode[]
       const frontmatter = (page.data || {}) as { title?: string, description?: string, links?: unknown }
 
       // comark 0.6 declares `removeLastStyle` and reads it nowhere, so a
       // highlighter's `<style>` node would render into the markdown verbatim.
-      // Dropped here rather than at the end for the same reason as the other
-      // adapter: the related links below would strand it mid-document.
-      for (let i = nodes.length - 1; i >= 0; i--) {
-        if (nodes[i]?.[0] === 'style') {
-          nodes.splice(i, 1)
-        }
-      }
-
-      // Pushed as nodes, not as a `# ${title}` string, so the title and the
-      // description go through the same escaper the body does.
-      if (!(Array.isArray(nodes[0]) && nodes[0][0] === 'h1')) {
-        if (frontmatter.description) {
-          nodes.unshift(['blockquote', {}, frontmatter.description])
-        }
-        if (frontmatter.title) {
-          nodes.unshift(['h1', {}, frontmatter.title])
-        }
-      }
-
-      // comark keeps all frontmatter in `data`, with no `meta` split.
-      const links = frontmatter.links
-      if (Array.isArray(links) && links.length > 0) {
-        const items = links
-          .filter((link: { label?: string, to?: string }) => link.label && link.to)
-          .map((link: { label: string, to: string }) => ['li', {}, ['a', { href: link.to }, link.label]] as ComarkNode)
-        if (items.length > 0) {
-          nodes.push(['hr', {}])
-          nodes.push(['ul', {}, ...items])
-        }
-      }
-
-      absolutizeTreeLinks(nodes, getAgentSiteUrl(event))
+      // The pipeline drops it, along with the rest of what the `@nuxt/content`
+      // adapter does to its tree. comark keeps all frontmatter in `data`, with
+      // no `meta` split, so the links come from there.
+      prepareDocumentTree(nodes, {
+        title: frontmatter.title,
+        description: frontmatter.description,
+        links: frontmatter.links,
+        siteUrl: getAgentSiteUrl(event)
+      })
 
       // `render`, not `renderMarkdown`: the latter routes through
       // `renderFrontmatter`, which re-emits `data` as a YAML block the raw

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -93,18 +93,19 @@ const source: AgentContentSource = {
     if (prefix.includes('%')) {
       return null
     }
-    // Queried in parallel, read back in collection order, so the collection
-    // that wins is still the first one declared with a match.
-    const results = await Promise.all(pageCollections().map(async (collection) => {
-      return await queryCollection(event, collection)
+    // One collection at a time, returning on the first match. `list()` needs
+    // every collection and parallelizes; this one needs the first that answers,
+    // so a later collection is a query nothing asked for. It is also the raw
+    // route's 404 path, where the common case is no match at all, and a
+    // `Promise.all` there would reject the whole lookup over a collection the
+    // answer never depended on.
+    for (const collection of pageCollections()) {
+      const pages = await queryCollection(event, collection)
         .select('path', 'stem')
         .where('path', 'LIKE', `${prefix}%`)
         .where('path', 'NOT LIKE', '%/.navigation')
         .order('stem', 'ASC')
         .all() as { path: string }[]
-    }))
-
-    for (const pages of results) {
       // `where` has no `ESCAPE` clause, and the path comes from the URL, where
       // `%` and `_` are `LIKE` wildcards: `/raw/do_s.md` matches `/docs/...`.
       // The pattern only ever widens the match, so a plain prefix check on the

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -6,10 +6,9 @@ import type { H3Event } from 'h3'
 import collections from '#content/manifest'
 import { useNitroApp } from 'nitropack/runtime'
 import { getAgentSiteUrl } from '../utils/agent-discovery'
-import { absolutizeTreeLinks } from '../../shared/negotiation'
+import { prepareDocumentTree } from './pipeline'
+import type { DocNode } from './pipeline'
 import type { AgentContentSource, AgentListEntry, AgentSectionSelector } from '../../shared/types'
-
-type MinimarkNode = [string, Record<string, unknown>, ...unknown[]]
 
 /** What `@nuxt/content`'s own llms feature reads off a `llms.sections` entry. */
 interface ContentSelector {
@@ -55,8 +54,10 @@ const source: AgentContentSource = {
       return null
     }
 
-    const entries: AgentListEntry[] = []
-    for (const collection of names) {
+    // One query per collection, all in flight at once. `Promise.all` keeps the
+    // results in the order the collections were declared, which is the order
+    // the flattened listing has to come out in.
+    const results = await Promise.all(names.map(async (collection) => {
       const query = queryCollection(event, collection)
         .select('path', 'title', 'description')
         .where('path', 'NOT LIKE', '%/.navigation')
@@ -64,14 +65,14 @@ const source: AgentContentSource = {
         query.where(filter.field as never, filter.operator as never, filter.value as never)
       }
       const pages = await query.order('path', 'ASC').all() as { path: string, title?: string, description?: string }[]
-      entries.push(...pages.map(page => ({
+      return pages.map((page): AgentListEntry => ({
         route: page.path,
         title: page.title,
         description: page.description,
         section: titleCase(String(collection))
-      })))
-    }
-    return entries
+      }))
+    }))
+    return results.flat()
   },
 
   /**
@@ -92,13 +93,18 @@ const source: AgentContentSource = {
     if (prefix.includes('%')) {
       return null
     }
-    for (const collection of pageCollections()) {
-      const pages = await queryCollection(event, collection)
+    // Queried in parallel, read back in collection order, so the collection
+    // that wins is still the first one declared with a match.
+    const results = await Promise.all(pageCollections().map(async (collection) => {
+      return await queryCollection(event, collection)
         .select('path', 'stem')
         .where('path', 'LIKE', `${prefix}%`)
         .where('path', 'NOT LIKE', '%/.navigation')
         .order('stem', 'ASC')
         .all() as { path: string }[]
+    }))
+
+    for (const pages of results) {
       // `where` has no `ESCAPE` clause, and the path comes from the URL, where
       // `%` and `_` are `LIKE` wildcards: `/raw/do_s.md` matches `/docs/...`.
       // The pattern only ever widens the match, so a plain prefix check on the
@@ -136,40 +142,17 @@ const source: AgentContentSource = {
     // markdown) without replacing the whole source.
     await useNitroApp().hooks.callHook('agent-discovery:document', event, page)
 
-    const value = page.body.value as unknown as MinimarkNode[]
-
-    // Syntax highlighters append a `<style>` node carrying the per-document
-    // CSS variables. It is meaningless in a markdown representation, and the
-    // stringifier only drops it while it is the last node, so anything
-    // appended below (the related links) would otherwise expose it.
-    for (let i = value.length - 1; i >= 0; i--) {
-      if (value[i]?.[0] === 'style') {
-        value.splice(i, 1)
-      }
-    }
-
-    if (value[0]?.[0] !== 'h1') {
-      if (page.description) {
-        value.unshift(['blockquote', {}, page.description])
-      }
-      if (page.title) {
-        value.unshift(['h1', {}, page.title])
-      }
-    }
-
-    // Append related links at the end if present, like @nuxt/content does.
-    const links = (page as unknown as Record<string, unknown>).links || (page.meta as Record<string, unknown> | undefined)?.links
-    if (Array.isArray(links) && links.length > 0) {
-      const items = links
-        .filter((link: { label?: string, to?: string }) => link.label && link.to)
-        .map((link: { label: string, to: string }) => ['li', {}, ['a', { href: link.to }, link.label]] as MinimarkNode)
-      if (items.length > 0) {
-        value.push(['hr', {}])
-        value.push(['ul', {}, ...items])
-      }
-    }
-
-    absolutizeTreeLinks(value, getAgentSiteUrl(event))
+    // Mutated in place: `page.body` below stringifies this same array. The
+    // minimark stringifier drops a highlighter's `<style>` node only while it
+    // is the last one, so the pipeline strips it before appending anything.
+    // `@nuxt/content` keeps `links` either at the root or under `meta`,
+    // depending on the collection schema.
+    prepareDocumentTree(page.body.value as unknown as DocNode[], {
+      title: page.title,
+      description: page.description,
+      links: (page as unknown as Record<string, unknown>).links || (page.meta as Record<string, unknown> | undefined)?.links,
+      siteUrl: getAgentSiteUrl(event)
+    })
 
     return {
       markdown: stringify({ ...page.body, type: 'minimark' }, { format: 'markdown/html' }),

--- a/src/runtime/server/sources/pipeline.ts
+++ b/src/runtime/server/sources/pipeline.ts
@@ -53,9 +53,13 @@ function appendRelatedLinks(nodes: DocNode[], links: unknown): void {
   if (!Array.isArray(links) || links.length === 0) {
     return
   }
+  // Frontmatter is user content: a `links: [null]` or a half-filled entry
+  // must be skipped, not thrown on.
   const items = links
-    .filter((link: { label?: string, to?: string }) => link.label && link.to)
-    .map((link: { label: string, to: string }) => ['li', {}, ['a', { href: link.to }, link.label]] as DocNode)
+    .filter((link): link is { label: string, to: string } => typeof link === 'object' && link !== null
+      && typeof (link as { label?: unknown }).label === 'string' && (link as { label: string }).label !== ''
+      && typeof (link as { to?: unknown }).to === 'string' && (link as { to: string }).to !== '')
+    .map(link => ['li', {}, ['a', { href: link.to }, link.label]] as DocNode)
   if (items.length > 0) {
     nodes.push(['hr', {}])
     nodes.push(['ul', {}, ...items])

--- a/src/runtime/server/sources/pipeline.ts
+++ b/src/runtime/server/sources/pipeline.ts
@@ -54,12 +54,14 @@ function appendRelatedLinks(nodes: DocNode[], links: unknown): void {
     return
   }
   // Frontmatter is user content: a `links: [null]` or a half-filled entry
-  // must be skipped, not thrown on.
+  // must be skipped, not thrown on. A numeric label stays a label, because
+  // YAML reads `label: 2024` as a number and the adapters rendered it before.
   const items = links
-    .filter((link): link is { label: string, to: string } => typeof link === 'object' && link !== null
-      && typeof (link as { label?: unknown }).label === 'string' && (link as { label: string }).label !== ''
+    .filter((link): link is { label: string | number, to: string } => typeof link === 'object' && link !== null
+      && (typeof (link as { label?: unknown }).label === 'number'
+        || (typeof (link as { label?: unknown }).label === 'string' && (link as { label: string }).label !== ''))
       && typeof (link as { to?: unknown }).to === 'string' && (link as { to: string }).to !== '')
-    .map(link => ['li', {}, ['a', { href: link.to }, link.label]] as DocNode)
+    .map(link => ['li', {}, ['a', { href: link.to }, String(link.label)]] as DocNode)
   if (items.length > 0) {
     nodes.push(['hr', {}])
     nodes.push(['ul', {}, ...items])

--- a/src/runtime/server/sources/pipeline.ts
+++ b/src/runtime/server/sources/pipeline.ts
@@ -1,0 +1,77 @@
+import { absolutizeTreeLinks } from '../../shared/negotiation'
+
+/**
+ * The node shape minimark and comark agree on: `[tag, props, ...children]`.
+ * Enough to walk and edit a document without importing either backend, which
+ * is what lets both adapters run the same pipeline.
+ */
+export type DocNode = [string, Record<string, unknown>?, ...unknown[]]
+
+export interface PrepareDocumentOptions {
+  /** Prepended as an `h1` when the body does not open with one. */
+  title?: string
+  /** Prepended as a blockquote under that title. */
+  description?: string
+  /** Frontmatter `links`, appended as a list when any carries a label and a target. */
+  links?: unknown
+  /** Origin site-relative hrefs are resolved against. */
+  siteUrl: string
+}
+
+/**
+ * A highlighter appends a `<style>` node carrying the per-document CSS
+ * variables. It is meaningless in a markdown representation, and neither
+ * backend drops it once something follows it, so it goes before the related
+ * links are appended.
+ */
+function removeStyleNodes(nodes: DocNode[]): void {
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    if (nodes[i]?.[0] === 'style') {
+      nodes.splice(i, 1)
+    }
+  }
+}
+
+/**
+ * Pushed as nodes, not as a `# ${title}` string, so the title and the
+ * description go through the same escaper the body does.
+ */
+function prependLead(nodes: DocNode[], title?: string, description?: string): void {
+  if (Array.isArray(nodes[0]) && nodes[0][0] === 'h1') {
+    return
+  }
+  if (description) {
+    nodes.unshift(['blockquote', {}, description])
+  }
+  if (title) {
+    nodes.unshift(['h1', {}, title])
+  }
+}
+
+/** Related links at the end if present, like `@nuxt/content` does. */
+function appendRelatedLinks(nodes: DocNode[], links: unknown): void {
+  if (!Array.isArray(links) || links.length === 0) {
+    return
+  }
+  const items = links
+    .filter((link: { label?: string, to?: string }) => link.label && link.to)
+    .map((link: { label: string, to: string }) => ['li', {}, ['a', { href: link.to }, link.label]] as DocNode)
+  if (items.length > 0) {
+    nodes.push(['hr', {}])
+    nodes.push(['ul', {}, ...items])
+  }
+}
+
+/**
+ * Everything both adapters do to a parsed document before handing the tree to
+ * their own stringifier. The two renderings have to come out byte-identical,
+ * which is easier to hold when the steps live in one place.
+ *
+ * Mutates in place: the callers hand the same array to their renderer.
+ */
+export function prepareDocumentTree(nodes: DocNode[], options: PrepareDocumentOptions): void {
+  removeStyleNodes(nodes)
+  prependLead(nodes, options.title, options.description)
+  appendRelatedLinks(nodes, options.links)
+  absolutizeTreeLinks(nodes, options.siteUrl)
+}

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import type { AgentContentSource, NegotiationConfig } from '../../shared/types'
-import { hasFileExtension, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
+import { absolutizeHref, hasFileExtension, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 export function useAgentDiscoveryConfig(event?: H3Event): NegotiationConfig {
   // Through `unknown`: a site's generated `runtimeConfig` type narrows the
@@ -65,7 +65,7 @@ export function renderAgentResources(event: H3Event, options: { heading?: string
 
   const lines = config.links
     .filter(link => link.title)
-    .map(link => `- [${link.title}](${link.href.startsWith('/') ? `${siteUrl}${link.href}` : link.href})`)
+    .map(link => `- [${link.title}](${absolutizeHref(link.href, siteUrl)})`)
 
   return lines.length ? [`## ${heading}`, '', ...lines, ''].join('\n') : ''
 }

--- a/src/runtime/server/utils/openapi.ts
+++ b/src/runtime/server/utils/openapi.ts
@@ -35,6 +35,9 @@ import type { AgentRoute, NegotiationConfig } from '../../shared/types'
  * Spreading the site's own values last means any path here can be replaced
  * with a richer, site-specific description.
  *
+ * Every call builds its fragments from scratch, so what comes back is the
+ * caller's to edit in place. Nothing is shared with the next call.
+ *
  * Pass the `paths` being merged in and every `operationId` in them is claimed
  * before one is derived here, so a site's own operation keeps its name and the
  * generated one takes a numeric suffix. Without it the two namespaces are
@@ -280,7 +283,13 @@ interface DocumentRow {
   href: string
   summary: string
   description: string
-  response: Json
+  /**
+   * Built per call, not stored. The document handed back is the caller's to
+   * merge into and edit, and a row holding one object would put that same
+   * reference in every document this module ever emits, so one caller's edit
+   * would land in the next request's response.
+   */
+  response: () => Json
 }
 
 /**
@@ -295,48 +304,56 @@ const DOCUMENTS: DocumentRow[] = [
     href: '/sitemap.md',
     summary: 'Markdown sitemap',
     description: 'Every page, grouped into sections, linking to the Markdown URLs.',
-    response: markdown('Markdown index of every page.')
+    response: () => markdown('Markdown index of every page.')
   },
   {
     href: '/sitemap.xml',
     summary: 'XML sitemap',
     description: 'Every indexable page, in the sitemaps.org XML format.',
-    response: { description: 'Sitemap in the sitemaps.org XML format.', content: { 'application/xml': { schema: { type: 'string' } } } }
+    response: () => ({ description: 'Sitemap in the sitemaps.org XML format.', content: { 'application/xml': { schema: { type: 'string' } } } })
   },
   {
     href: '/llms.txt',
     summary: 'llms.txt index',
     description: 'Index of the documentation for LLMs, following the llms.txt convention.',
-    response: text('Markdown index.')
+    response: () => text('Markdown index.')
   },
   {
     href: '/llms-full.txt',
     summary: 'Full documentation for LLMs',
     description: 'Every documentation page concatenated as Markdown. Large response.',
-    response: text('Full documentation as Markdown.')
+    response: () => text('Full documentation as Markdown.')
   },
   {
     href: '/.well-known/api-catalog',
     summary: 'API catalog (RFC 9727)',
     description: 'Linkset pointing at the documents this site publishes for agents.',
-    response: { description: 'Linkset document.', content: { 'application/linkset+json': { schema: { $ref: '#/components/schemas/Linkset' } } } }
+    response: () => ({ description: 'Linkset document.', content: { 'application/linkset+json': { schema: { $ref: '#/components/schemas/Linkset' } } } })
   },
   {
     href: '/.well-known/mcp/server-card.json',
     summary: 'MCP server card',
     description: 'Describes the MCP endpoint, its capabilities and what it exposes.',
-    response: { description: 'MCP server card, following the schema it declares in `$schema`.', content: { 'application/json': { schema: { type: 'object' } } } }
+    response: () => ({ description: 'MCP server card, following the schema it declares in `$schema`.', content: { 'application/json': { schema: { type: 'object' } } } })
   },
   {
     href: SKILLS_INDEX,
     summary: 'Agent skills index',
     description: 'Lists the agent skills published by this site and the files each one is made of, served under `/.well-known/skills/{name}/`.',
-    response: { description: 'Skills index.', content: { 'application/json': { schema: { $ref: '#/components/schemas/SkillsIndex' } } } }
+    response: () => ({ description: 'Skills index.', content: { 'application/json': { schema: { $ref: '#/components/schemas/SkillsIndex' } } } })
   }
 ]
 
 /** Index of the first row in {@link DOCUMENTS} that comes after the MCP endpoint's own path. */
 const MCP_SPLIT = DOCUMENTS.findIndex(document => document.href === '/.well-known/mcp/server-card.json')
+
+// Rename or drop that row and the split silently becomes `slice(0, -1)` and
+// `slice(-1)`, which are both valid: the skills index moves ahead of the other
+// documents and the MCP endpoint lands in the wrong place, with nothing to say
+// so. Cheaper to refuse to load.
+if (MCP_SPLIT === -1) {
+  throw new Error('nuxt-agent-discovery: no `/.well-known/mcp/server-card.json` row in the OpenAPI document table, so the MCP endpoint has nowhere to sit. Restore the row, or split the table on whatever replaced it.')
+}
 
 export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptions = {}): { tags: Json[], paths: Json, components: { headers: Json, responses: Json, schemas: Json } } {
   const config = useAgentDiscoveryConfig(event)
@@ -375,7 +392,7 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
 
   for (const document of DOCUMENTS.slice(0, MCP_SPLIT)) {
     if (has(document.href)) {
-      paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response)
+      paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response())
     }
   }
   // The MCP endpoint itself, alongside the card that describes it. Not a route
@@ -408,7 +425,7 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
   }
   for (const document of DOCUMENTS.slice(MCP_SPLIT)) {
     if (has(document.href)) {
-      paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response)
+      paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response())
     }
   }
 

--- a/src/runtime/server/utils/openapi.ts
+++ b/src/runtime/server/utils/openapi.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import { useAgentDiscoveryConfig } from './agent-discovery'
+import { SKILLS_INDEX } from '../../shared/paths'
 import type { AgentRoute, NegotiationConfig } from '../../shared/types'
 
 /**
@@ -87,7 +88,7 @@ const DISCOVERY_OPERATIONS: Record<string, string> = {
   '/llms-full.txt': 'getLlmsFullTxt',
   '/.well-known/api-catalog': 'getApiCatalog',
   '/.well-known/mcp/server-card.json': 'getMcpServerCard',
-  '/.well-known/skills/index.json': 'getSkillsIndex'
+  [SKILLS_INDEX]: 'getSkillsIndex'
 }
 
 /** The MCP endpoint, which follows the server card rather than a link of its own. */
@@ -274,6 +275,69 @@ function discoveryDocument(operationId: string, summary: string, description: st
   return { get: { tags: ['Discovery'], operationId, summary, description, responses: { 200: response } } }
 }
 
+/** A row of {@link DOCUMENTS}: everything about a discovery document that varies between them. */
+interface DocumentRow {
+  href: string
+  summary: string
+  description: string
+  response: Json
+}
+
+/**
+ * The discovery documents that are a plain `href` → response mapping, in
+ * insertion order. The MCP endpoint's own path is not one of these: it is a
+ * `post` with a request body, not a document with a `get`, and it sits
+ * between the api catalog and the server card below, so building `paths`
+ * splits this table at {@link MCP_SPLIT} rather than walking it in one pass.
+ */
+const DOCUMENTS: DocumentRow[] = [
+  {
+    href: '/sitemap.md',
+    summary: 'Markdown sitemap',
+    description: 'Every page, grouped into sections, linking to the Markdown URLs.',
+    response: markdown('Markdown index of every page.')
+  },
+  {
+    href: '/sitemap.xml',
+    summary: 'XML sitemap',
+    description: 'Every indexable page, in the sitemaps.org XML format.',
+    response: { description: 'Sitemap in the sitemaps.org XML format.', content: { 'application/xml': { schema: { type: 'string' } } } }
+  },
+  {
+    href: '/llms.txt',
+    summary: 'llms.txt index',
+    description: 'Index of the documentation for LLMs, following the llms.txt convention.',
+    response: text('Markdown index.')
+  },
+  {
+    href: '/llms-full.txt',
+    summary: 'Full documentation for LLMs',
+    description: 'Every documentation page concatenated as Markdown. Large response.',
+    response: text('Full documentation as Markdown.')
+  },
+  {
+    href: '/.well-known/api-catalog',
+    summary: 'API catalog (RFC 9727)',
+    description: 'Linkset pointing at the documents this site publishes for agents.',
+    response: { description: 'Linkset document.', content: { 'application/linkset+json': { schema: { $ref: '#/components/schemas/Linkset' } } } }
+  },
+  {
+    href: '/.well-known/mcp/server-card.json',
+    summary: 'MCP server card',
+    description: 'Describes the MCP endpoint, its capabilities and what it exposes.',
+    response: { description: 'MCP server card, following the schema it declares in `$schema`.', content: { 'application/json': { schema: { type: 'object' } } } }
+  },
+  {
+    href: SKILLS_INDEX,
+    summary: 'Agent skills index',
+    description: 'Lists the agent skills published by this site and the files each one is made of, served under `/.well-known/skills/{name}/`.',
+    response: { description: 'Skills index.', content: { 'application/json': { schema: { $ref: '#/components/schemas/SkillsIndex' } } } }
+  }
+]
+
+/** Index of the first row in {@link DOCUMENTS} that comes after the MCP endpoint's own path. */
+const MCP_SPLIT = DOCUMENTS.findIndex(document => document.href === '/.well-known/mcp/server-card.json')
+
 export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptions = {}): { tags: Json[], paths: Json, components: { headers: Json, responses: Json, schemas: Json } } {
   const config = useAgentDiscoveryConfig(event)
   const has = (href: string) => config.links.some(link => link.href === href)
@@ -309,45 +373,10 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
     )
   }
 
-  if (has('/sitemap.md')) {
-    paths['/sitemap.md'] = discoveryDocument(
-      discovery['/sitemap.md']!,
-      'Markdown sitemap',
-      'Every page, grouped into sections, linking to the Markdown URLs.',
-      markdown('Markdown index of every page.')
-    )
-  }
-  if (has('/sitemap.xml')) {
-    paths['/sitemap.xml'] = discoveryDocument(
-      discovery['/sitemap.xml']!,
-      'XML sitemap',
-      'Every indexable page, in the sitemaps.org XML format.',
-      { description: 'Sitemap in the sitemaps.org XML format.', content: { 'application/xml': { schema: { type: 'string' } } } }
-    )
-  }
-  if (has('/llms.txt')) {
-    paths['/llms.txt'] = discoveryDocument(
-      discovery['/llms.txt']!,
-      'llms.txt index',
-      'Index of the documentation for LLMs, following the llms.txt convention.',
-      text('Markdown index.')
-    )
-  }
-  if (has('/llms-full.txt')) {
-    paths['/llms-full.txt'] = discoveryDocument(
-      discovery['/llms-full.txt']!,
-      'Full documentation for LLMs',
-      'Every documentation page concatenated as Markdown. Large response.',
-      text('Full documentation as Markdown.')
-    )
-  }
-  if (has('/.well-known/api-catalog')) {
-    paths['/.well-known/api-catalog'] = discoveryDocument(
-      discovery['/.well-known/api-catalog']!,
-      'API catalog (RFC 9727)',
-      'Linkset pointing at the documents this site publishes for agents.',
-      { description: 'Linkset document.', content: { 'application/linkset+json': { schema: { $ref: '#/components/schemas/Linkset' } } } }
-    )
+  for (const document of DOCUMENTS.slice(0, MCP_SPLIT)) {
+    if (has(document.href)) {
+      paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response)
+    }
   }
   // The MCP endpoint itself, alongside the card that describes it. Not a route
   // this module serves, the same as `/sitemap.xml` and the two llms documents
@@ -377,21 +406,10 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
       }
     }
   }
-  if (has('/.well-known/mcp/server-card.json')) {
-    paths['/.well-known/mcp/server-card.json'] = discoveryDocument(
-      discovery['/.well-known/mcp/server-card.json']!,
-      'MCP server card',
-      'Describes the MCP endpoint, its capabilities and what it exposes.',
-      { description: 'MCP server card, following the schema it declares in `$schema`.', content: { 'application/json': { schema: { type: 'object' } } } }
-    )
-  }
-  if (has('/.well-known/skills/index.json')) {
-    paths['/.well-known/skills/index.json'] = discoveryDocument(
-      discovery['/.well-known/skills/index.json']!,
-      'Agent skills index',
-      'Lists the agent skills published by this site and the files each one is made of, served under `/.well-known/skills/{name}/`.',
-      { description: 'Skills index.', content: { 'application/json': { schema: { $ref: '#/components/schemas/SkillsIndex' } } } }
-    )
+  for (const document of DOCUMENTS.slice(MCP_SPLIT)) {
+    if (has(document.href)) {
+      paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response)
+    }
   }
 
   const schemas: Json = {}
@@ -427,7 +445,7 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
       }
     }
   }
-  if (has('/.well-known/skills/index.json')) {
+  if (has(SKILLS_INDEX)) {
     schemas.SkillsIndex = {
       type: 'object',
       description: 'Agent skills published by this site, served under `/.well-known/skills/{name}/`.',

--- a/src/runtime/shared/defaults.ts
+++ b/src/runtime/shared/defaults.ts
@@ -1,0 +1,32 @@
+/**
+ * Defaults the runtime has to know about too, rather than only the build.
+ *
+ * The build merges these into `runtimeConfig` so `defaults.ts` stays the one
+ * place a reader looks them up, but `runtimeConfig` is overridable per deploy
+ * and an override replaces a list wholesale. Anything that has to hold whatever
+ * the resolved config says lives here and is applied again at request time.
+ */
+
+/**
+ * MCP definition groups the public server card hides. Groups come from the
+ * subdirectory a definition sits in under `server/mcp/tools`, and
+ * `mcpServerCard.excludeGroups` extends this list rather than replacing it: a
+ * site naming its own private group should not silently start publishing its
+ * admin tools.
+ */
+export const MCP_EXCLUDED_GROUPS = ['admin']
+
+/**
+ * The groups a server card leaves out: the built-in defaults, plus whatever the
+ * resolved config carries.
+ *
+ * The build already merges the two, so `extra` is normally the result of that
+ * merge and the union is a no-op. It is not always: `runtimeConfig` is
+ * env-overridable, and `NUXT_AGENT_DISCOVERY_MCP_EXCLUDE_GROUPS` replaces the
+ * array rather than adding to it. A deploy naming its own groups would drop
+ * `admin` off the end of the list and start advertising the admin tools, which
+ * is the one thing this default exists to prevent.
+ */
+export function mcpExcludedGroups(extra?: string[]): Set<string> {
+  return new Set([...MCP_EXCLUDED_GROUPS, ...(extra || [])])
+}

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -341,7 +341,7 @@ export function isAgentUserAgent(config: NegotiationConfig, userAgent?: string |
 export function negotiatedRawPath(config: NegotiationConfig, path: string, options: { accept?: string | null, userAgent?: string | null } = {}): string | undefined {
   const pathname = normalizePathname(path)
 
-  if (pathname === config.rawPrefix || pathname.startsWith(`${config.rawPrefix}/`)) {
+  if (isRawPath(config, pathname)) {
     return undefined
   }
 
@@ -377,7 +377,7 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
  * configured pattern covers.
  */
 function negotiableRoute(config: NegotiationConfig, pathname: string): AgentRoute | undefined {
-  if (pathname === config.rawPrefix || pathname.startsWith(`${config.rawPrefix}/`)) {
+  if (isRawPath(config, pathname)) {
     return undefined
   }
   if (isExcluded(pathname, config)) {
@@ -387,6 +387,15 @@ function negotiableRoute(config: NegotiationConfig, pathname: string): AgentRout
     return undefined
   }
   return matchRoute(config.routes, pathname)
+}
+
+/**
+ * Whether a normalized pathname is the raw prefix itself or sits under it.
+ * The one definition of "this URL is a raw markdown twin", shared with the
+ * sitemap plugin so every consumer agrees on it.
+ */
+export function isRawPath(config: Pick<NegotiationConfig, 'rawPrefix'>, pathname: string): boolean {
+  return isUnder(pathname, config.rawPrefix)
 }
 
 /**
@@ -506,7 +515,7 @@ export function prefersMarkdownError(config: NegotiationConfig, options: {
 
   const pathname = normalizePathname(options.path)
 
-  if (pathname === config.rawPrefix || pathname.startsWith(`${config.rawPrefix}/`)) {
+  if (isRawPath(config, pathname)) {
     return true
   }
 
@@ -625,6 +634,15 @@ export function absolutizeMarkdownLinks(markdown: string, siteUrl: string): stri
   }).join('\n')
 }
 
+/**
+ * Prefixes a site-relative href with the site origin, leaving absolute and
+ * protocol-relative ones alone. Every discovery surface renders its links
+ * through this so they all agree on what "absolute" means.
+ */
+export function absolutizeHref(href: string, siteUrl: string): string {
+  return href.startsWith('/') && !href.startsWith('//') ? `${siteUrl}${href}` : href
+}
+
 const LINK_PROPS = ['href', 'src', 'to']
 
 /**
@@ -723,10 +741,7 @@ export function errorMarkdown(config: NegotiationConfig, options: { path: string
 
   const links = config.links
     .filter(link => link.title)
-    .map((link) => {
-      const href = link.href.startsWith('/') ? `${siteUrl}${link.href}` : link.href
-      return `- [${link.title}](${href})`
-    })
+    .map(link => `- [${link.title}](${absolutizeHref(link.href, siteUrl)})`)
 
   return [
     '---',

--- a/src/runtime/shared/paths.ts
+++ b/src/runtime/shared/paths.ts
@@ -1,0 +1,9 @@
+/**
+ * The Agent Skills well-known prefix. One constant, because the route
+ * registration, the prerender list, the discovery links, the OpenAPI document
+ * and the file route all have to agree on it.
+ */
+export const SKILLS_PREFIX = '/.well-known/skills/'
+
+/** The generated skills index document. */
+export const SKILLS_INDEX = `${SKILLS_PREFIX}index.json`

--- a/test/unit/defaults.test.ts
+++ b/test/unit/defaults.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { MCP_EXCLUDED_GROUPS, mcpExcludedGroups } from '../../src/runtime/shared/defaults'
+
+// The build merges `MCP_EXCLUDED_GROUPS` into `runtimeConfig`, and
+// `NUXT_AGENT_DISCOVERY_MCP_EXCLUDE_GROUPS` replaces that array wholesale. The
+// card route applies the defaults again so a deploy setting its own list does
+// not start publishing the admin tools.
+describe('mcpExcludedGroups', () => {
+  it('excludes the defaults with nothing configured', () => {
+    expect(mcpExcludedGroups()).toEqual(new Set(MCP_EXCLUDED_GROUPS))
+    expect(mcpExcludedGroups([])).toEqual(new Set(MCP_EXCLUDED_GROUPS))
+  })
+
+  it('keeps `admin` when the configured list drops it', () => {
+    expect(mcpExcludedGroups(['internal'])).toEqual(new Set(['admin', 'internal']))
+  })
+
+  it('adds to the defaults rather than repeating them', () => {
+    expect(mcpExcludedGroups(['admin', 'internal'])).toEqual(new Set(['admin', 'internal']))
+  })
+
+  it('returns a set of its own, so a caller cannot edit the defaults', () => {
+    mcpExcludedGroups().add('internal')
+
+    expect(MCP_EXCLUDED_GROUPS).toEqual(['admin'])
+    expect(mcpExcludedGroups().has('internal')).toBe(false)
+  })
+})

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -426,6 +426,15 @@ describe('module setup: companion modules', () => {
     expect(nuxt.options.nitro.alias?.['#agent-discovery/mcp']).toContain('mcp/none')
   })
 
+  it('merges the default excluded MCP group into the card config', async () => {
+    // `excludeGroups` extends the `admin` default rather than replacing it: a
+    // site naming its own private group should not silently start publishing
+    // its admin tools.
+    const nuxt = await runModule({ discovery: { mcpServerCard: { endpoint: '/mcp', name: 'Basic', excludeGroups: ['internal'] } } })
+
+    expect((nuxt.options.runtimeConfig.agentDiscoveryMcp as { excludeGroups?: string[] }).excludeGroups).toEqual(['admin', 'internal'])
+  })
+
   it('keeps the MCP stub when the toolkit is installed but disabled', async () => {
     // It registers none of the virtual modules the definitions re-export
     // imports in that state, so aliasing them would fail the Nitro build.

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -173,3 +173,39 @@ describe('agentDiscoveryOpenApi: dedupes against itself', () => {
     expect(result).not.toHaveProperty('/.well-known/skills/index.json')
   })
 })
+
+/** A discovery document path item, of what the mutation test reaches into. */
+interface DocumentPath {
+  get: { responses: Record<number, { description: string, content: Record<string, { schema: Record<string, unknown> }> }> }
+}
+
+// The table behind the discovery documents stored each row's response as one
+// object and handed that same reference to every document it emitted. A site
+// editing the fragment it had just merged in was editing what the next request
+// would return.
+describe('agentDiscoveryOpenApi: builds a fresh document every call', () => {
+  function emit() {
+    state.config = createConfig()
+    setRuntimeConfig({ agentDiscoveryMcp: { endpoint: '/mcp' } })
+    return agentDiscoveryOpenApi(event)
+  }
+
+  // One document either side of the split the MCP endpoint is inserted at,
+  // since the two are built by separate passes.
+  it.each([
+    ['/sitemap.md', 'Markdown index of every page.', 'text/markdown'],
+    ['/.well-known/skills/index.json', 'Skills index.', 'application/json']
+  ])('leaves a mutated %s out of the next one', (href, description, type) => {
+    const response = (emit().paths[href] as DocumentPath).get.responses[200]!
+    response.description = 'mutated'
+    response.content['text/plain'] = { schema: { type: 'string' } }
+    // Down to the nested schema, since a shallow copy of the row would still
+    // hand the same one out twice.
+    response.content[type]!.schema.deprecated = true
+
+    const next = (emit().paths[href] as DocumentPath).get.responses[200]!
+    expect(next.description).toBe(description)
+    expect(next.content).not.toHaveProperty('text/plain')
+    expect(next.content[type]!.schema).not.toHaveProperty('deprecated')
+  })
+})

--- a/test/unit/pipeline.test.ts
+++ b/test/unit/pipeline.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { prepareDocumentTree } from '../../src/runtime/server/sources/pipeline'
+import type { DocNode } from '../../src/runtime/server/sources/pipeline'
+
+describe('prepareDocumentTree: related links', () => {
+  it('skips malformed entries instead of throwing', () => {
+    // Frontmatter is user content, so `links: [null]` and half-filled entries
+    // have to be survivable.
+    const nodes: DocNode[] = [['h1', {}, 'Title']]
+    prepareDocumentTree(nodes, {
+      title: 'Title',
+      links: [null, 42, 'x', { label: 'No target' }, { to: '/only-target' }, { label: '', to: '/empty' }, { label: 'Docs', to: '/docs' }],
+      siteUrl: 'https://example.com'
+    })
+
+    const list = nodes.find(node => node[0] === 'ul')
+    expect(list).toBeDefined()
+    expect(list!.slice(2)).toHaveLength(1)
+  })
+
+  it('appends nothing when no entry survives', () => {
+    const nodes: DocNode[] = [['h1', {}, 'Title']]
+    prepareDocumentTree(nodes, { title: 'Title', links: [null], siteUrl: 'https://example.com' })
+
+    expect(nodes.some(node => node[0] === 'ul' || node[0] === 'hr')).toBe(false)
+  })
+})

--- a/test/unit/pipeline.test.ts
+++ b/test/unit/pipeline.test.ts
@@ -18,6 +18,21 @@ describe('prepareDocumentTree: related links', () => {
     expect(list!.slice(2)).toHaveLength(1)
   })
 
+  it('renders a numeric label as text', () => {
+    // YAML reads `label: 2024` as a number, and both adapters rendered it
+    // before the malformed-entry guard landed.
+    const nodes: DocNode[] = [['h1', {}, 'Title']]
+    prepareDocumentTree(nodes, {
+      title: 'Title',
+      links: [{ label: 2024, to: '/releases/2024' }],
+      siteUrl: 'https://example.com'
+    })
+
+    const list = nodes.find(node => node[0] === 'ul')
+    expect(list).toBeDefined()
+    expect(list!.slice(2)).toEqual([['li', {}, ['a', { href: 'https://example.com/releases/2024' }, '2024']]])
+  })
+
   it('appends nothing when no entry survives', () => {
     const nodes: DocNode[] = [['h1', {}, 'Title']]
     prepareDocumentTree(nodes, { title: 'Title', links: [null], siteUrl: 'https://example.com' })


### PR DESCRIPTION
consolidation, no behavior change except two deliberate ones called out below:

- the `@nuxt/content` and comark adapters ran the same four-step document pipeline (strip trailing style nodes, prepend the h1/description lead, append related links, absolutize), kept in sync only by the byte-identical e2e suite. one shared helper in `sources/pipeline.ts` now, both adapters call it, output pinned unchanged by the same suite.
- `absolutizeHref` replaces five inline copies of the same ternary, and `isRawPath` replaces three spellings of the raw-prefix check. deliberate change: the sitemap plugin's own spelling was missing the exact-match case, so it gains it.
- the seven copy-pasted discovery-document blocks in `openapi.ts` fold into a table, mirroring the `DISCOVERY_OPERATIONS` map above them. emitted document unchanged.
- `/.well-known/skills/` was a bare literal in four files; one shared constant now.
- the MCP card's `admin` exclude default was hardcoded inline in the route handler where nobody auditing `defaults.ts` would find it. it lives there now, merged into `excludeGroups` at build time, and the option's JSDoc documents the extend semantics. behavior identical.
- `error.ts` reuses `getAgentSiteUrl` instead of inlining it, and the content adapter's per-collection queries run through `Promise.all` (declaration order preserved for `firstLeaf`).

stacked on the llms PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * MCP server cards consistently hide built-in administrative groups while preserving configured exclusions.
  * Documentation, API catalogs, agent resources, and generated links now use reliable absolute URLs.
  * Agent Skills and OpenAPI discovery paths are standardized.
  * Markdown error pages now display the correct site URL.
  * Content pages automatically include titles, descriptions, related links, and cleaned formatting.
  * Static builds better include custom content routes and sitemap entries.
  * Sitemap generation more accurately excludes raw content paths.

* **Bug Fixes**
  * Invalid self-referential routes are now rejected.

* **Tests**
  * Expanded coverage for routing, prerendering, MCP exclusions, and discovery documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->