### PR TITLE
fix: follow-up correctness pass from the stack review

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,7 @@ import { isValidRel } from './rels'
 import { scanSkills } from './skills'
 import { disableContentRawMarkdown, dropContentLlmsFeature, resolveContentSource } from './build/content'
 import { setupVercelPreset } from './presets/vercel'
-import { formatLinkHeader, hasFileExtension, matchRoute, normalizePathname, patternsOverlap, rawDestination, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
+import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
 import type { AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
 export type { AgentContentSource, AgentIndex, AgentListEntry, AgentPage, AgentRoute, AgentSectionSelector, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
@@ -260,27 +260,40 @@ export default defineNuxtModule<ModuleOptions>({
       ? options.excludePrefixes.replace
       : [...EXCLUDE_PREFIXES, ...(options.excludePrefixes?.extend || [])])]
 
-    // An exact route whose `raw` destination negotiates back to itself makes
-    // the middleware proxy itself forever. Only that fixpoint is refused: a
-    // destination under `rawPrefix` or an excluded prefix never re-enters
-    // negotiation, a wildcard pattern never reads `raw` at all, and a
-    // destination no pattern matches terminates after one hop. The checks run
-    // on the normalized pathname, the spelling the inner request re-enters
-    // with, so a query string or trailing slash cannot hide the fixpoint.
+    // An exact route whose `raw` destination negotiates back into the
+    // middleware makes it proxy itself forever, in one hop (`/about` →
+    // `/about.md`) or through other routes (`/a` → `/b.md` → `/a.md` → …).
+    // The walk mirrors the runtime chain on normalized pathnames, the
+    // spelling the inner request re-enters with: a destination under
+    // `rawPrefix` or an excluded prefix never re-enters negotiation, a
+    // wildcard destination always lands under `rawPrefix`, a dotted
+    // non-`.md` path reads as an asset, and a path no pattern matches
+    // terminates after one hop. Revisiting a pathname is the loop.
+    const negotiationConfig = { rawPrefix } as NegotiationConfig
+    const nextHop = (pathname: string): string | undefined => {
+      if (isRawPath(negotiationConfig, pathname)
+        || excludePrefixes.some(prefix => pathname.startsWith(prefix))) {
+        return undefined
+      }
+      const base = pathname.endsWith('.md') ? pathname.slice(0, -3) : pathname
+      if (base.length <= 1 || (base === pathname && hasFileExtension(base))) {
+        return undefined
+      }
+      const matched = matchRoute(routes, base)
+      return matched ? normalizePathname(rawDestination(negotiationConfig, matched, base)) : undefined
+    }
     for (const route of routes) {
       if (!route.raw || route.path.includes('*')) {
         continue
       }
-      const raw = normalizePathname(route.raw)
-      if (!raw.endsWith('.md')
-        || raw === rawPrefix || raw.startsWith(`${rawPrefix}/`)
-        || excludePrefixes.some(prefix => raw.startsWith(prefix))) {
-        continue
-      }
-      const base = raw.slice(0, -3)
-      const matched = matchRoute(routes, base)
-      if (matched && normalizePathname(rawDestination({ rawPrefix } as NegotiationConfig, matched, base)) === raw) {
-        throw new Error(`[nuxt-agent-discovery] \`routes\`: the \`raw\` destination \`${route.raw}\` for \`${route.path}\` negotiates back to itself. Point it under \`${rawPrefix}\`, or exclude it through \`excludePrefixes\`.`)
+      const visited = new Set<string>()
+      let hop = nextHop(normalizePathname(route.raw))
+      while (hop) {
+        if (visited.has(hop)) {
+          throw new Error(`[nuxt-agent-discovery] \`routes\`: the \`raw\` destination \`${route.raw}\` for \`${route.path}\` negotiates back to itself. Point it under \`${rawPrefix}\`, or exclude it through \`excludePrefixes\`.`)
+        }
+        visited.add(hop)
+        hop = nextHop(hop)
       }
     }
 

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'pathe'
 import { readFile, writeFile } from 'node:fs/promises'
 import type { Nitro } from 'nitropack'
-import { compilePattern, formatLinkHeader, matchRoute, patternsOverlap, rawDestination, ruleCoversPattern, MARKDOWN_VARY } from '../runtime/shared/negotiation'
+import { compilePattern, formatLinkHeader, isRawPath, matchRoute, patternsOverlap, rawDestination, ruleCoversPattern, MARKDOWN_VARY } from '../runtime/shared/negotiation'
 import type { NegotiationConfig } from '../runtime/shared/types'
 
 export interface VercelRoute {
@@ -94,9 +94,16 @@ const ACCEPTS_A_REPRESENTATION = String.raw`(([^"]|"[^"]*")*,)?\s*(text/(html|ma
  */
 const ANY_MEDIA_RANGE = String.raw`(.*,)?\s*${TOKEN}/${TOKEN}\s*([;,].*)?`
 
-/** `has` matcher for the Vercel Build Output API, which anchors the value. */
+/**
+ * `has` matcher for the Vercel Build Output API, which anchors the value.
+ *
+ * Case-folded letter by letter, the way `REFUSES_MARKDOWN` spells `[qQ]`: the
+ * origin matches user agents case-insensitively, an observed edge does too,
+ * and nothing here may depend on the observation.
+ */
 function agentUserAgentPattern(config: NegotiationConfig): string {
-  return `.*(${config.userAgents.map(escapeRegExp).join('|')}).*`
+  const fold = (value: string) => value.replace(/[a-z]/gi, letter => `[${letter.toLowerCase()}${letter.toUpperCase()}]`)
+  return `.*(${config.userAgents.map(agent => fold(escapeRegExp(agent))).join('|')}).*`
 }
 
 /** Pattern wildcards replaced by their capture references: `/docs/**` → `/docs/$1`. */
@@ -258,7 +265,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     // wildcard covers `/`, whose capture would otherwise mis-derive the page
     // as `/index`. An exact destination under an excluded prefix is the
     // site's own document and gets no entry at all.
-    const isRaw = (raw: string) => raw === config.rawPrefix || raw.startsWith(`${config.rawPrefix}/`)
+    const isRaw = (raw: string) => isRawPath(config, raw)
     const rootTwin = `${config.rawPrefix}/index.md`
     const statics: { raw: string, href: string }[] = []
     for (const route of config.routes) {

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -6,8 +6,8 @@ import { defineNitroPlugin } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
 import type { AgentListEntry, NegotiationConfig } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
-import { getSourcePage } from '../utils/document'
-import { hasFileExtension, isNegotiablePath, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
+import { generatedIndexPage, getSourcePage } from '../utils/document'
+import { hasFileExtension, isExcluded, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 interface LlmsSection {
   title: string
@@ -35,11 +35,13 @@ function toLocalUrl(href: string, domain: string): { pathname: string, suffix: s
 /**
  * The page route a link points at, or `undefined` when it names something with
  * no markdown representation: another origin, `llms-full.txt`, an asset, an
- * endpoint under an excluded prefix, a path no configured route covers.
+ * endpoint under an excluded prefix.
  *
- * The same predicate the negotiation itself runs, so a link counts as a page
- * here exactly when the site serves markdown for it. Reading the extension
- * alone counted `/openapi` and `/api/v1/tools` as documentation.
+ * Judged by exclusion and extension alone, not by `routes`: a curated section
+ * may name pages outside the negotiated patterns, and listing them is its
+ * call, so a site narrowing `routes` must not get its curation duplicated by
+ * the whole-site fallback. What has to stay out is data, `/openapi.json` by
+ * its extension and `/api/v1/tools` by its prefix.
  */
 function pageRoute(config: NegotiationConfig, href: string, domain: string): string | undefined {
   const local = toLocalUrl(href, domain)
@@ -50,7 +52,7 @@ function pageRoute(config: NegotiationConfig, href: string, domain: string): str
   // decoded paths, so the route is decoded the same way the raw handler
   // decodes its slug, or a curated link to `/docs/café` resolves no page.
   const route = normalizeAgentRoute(local.pathname)
-  return isNegotiablePath(config, route) ? route : undefined
+  return !isExcluded(route, config) && (route === '/' || !hasFileExtension(route)) ? route : undefined
 }
 
 /** At most this many adapter calls in flight, per fan-out. */
@@ -155,7 +157,9 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       // its API endpoints has named no documentation either.
       const hasPageLinks = options.sections.some(section => section.links?.some(link => pageRoute(config, link.href, domain)))
       if (!hasPageLinks) {
-        const entries = (await adapter.list?.(undefined, event)) || []
+        // The same filter `listAgentPages` applies, so the fallback cannot
+        // advertise pages `sitemap.md` deliberately hides.
+        const entries = ((await adapter.list?.(undefined, event)) || []).filter(entry => !isExcluded(entry.route, config))
         for (const [title, group] of groupBySection(entries)) {
           options.sections.push({
             title,
@@ -192,8 +196,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
 
         // Off-site links keep whatever they were written as, but a same-origin
         // one has to come out absolute: `llms.txt` is read detached from the
-        // site, so a relative href in it points nowhere.
-        const route = pathname === '/' || !hasFileExtension(pathname)
+        // site, so a relative href in it points nowhere. An excluded path is
+        // the site's own document, not a page with a raw twin: rewriting it
+        // would mint a URL that 404s.
+        const route = (pathname === '/' || !hasFileExtension(pathname)) && !isExcluded(pathname, config)
           ? matchRoute(config.routes, pathname)
           : undefined
         if (!route) {
@@ -261,13 +267,26 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // no sections at all.
     if (!routes.length) {
       for (const entry of (await adapter.list?.(undefined, event)) || []) {
-        add(entry.route)
+        // The same filter `listAgentPages` applies, matching the index hook.
+        if (!isExcluded(entry.route, config)) {
+          add(entry.route)
+        }
       }
     }
 
-    // The same `get()` the raw route calls, so a page reads identically whether
-    // an agent fetches `/raw/**.md` or the single full document.
-    const pages = await mapLimit(routes, route => getSourcePage(route, event))
+    // The landing page, mirroring the index hook: `llms.txt` links `/` (or
+    // its generated `/raw/index.md`) whenever no section names it, so the
+    // full document has to hold the page it advertises.
+    if (!seen.has('/') && matchRoute(config.routes, '/')) {
+      routes.unshift('/')
+    }
+
+    // The same `get()` the raw route calls, so a page reads identically
+    // whether an agent fetches `/raw/**.md` or the single full document. `/`
+    // is the one route with a fallback: an adapter with no `/` entry still
+    // has the generated index behind `/raw/index.md`.
+    const pages = await mapLimit(routes, async route =>
+      await getSourcePage(route, event) ?? (route === '/' ? await generatedIndexPage(event) : null))
     for (const page of pages) {
       if (page?.markdown) {
         contents.push(page.markdown)

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -175,7 +175,9 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // `/raw/index.md` for it, so without this nothing links the document an
     // agent is most likely to want first.
     const linked = options.sections.some(section => section.links?.some(link => toLocalUrl(link.href, domain)?.pathname === '/'))
-    if (source && !linked && matchRoute(config.routes, '/')) {
+    // The exclusion guard is for symmetry with the fallback listings: a site
+    // excluding `/` has said the landing page is not agent surface.
+    if (source && !linked && !isExcluded('/', config) && matchRoute(config.routes, '/')) {
       options.sections.unshift({
         title: 'Overview',
         links: [{ title: config.siteName || 'Landing page', href: withBase('/', domain) }]
@@ -277,7 +279,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // The landing page, mirroring the index hook: `llms.txt` links `/` (or
     // its generated `/raw/index.md`) whenever no section names it, so the
     // full document has to hold the page it advertises.
-    if (!seen.has('/') && matchRoute(config.routes, '/')) {
+    if (!seen.has('/') && !isExcluded('/', config) && matchRoute(config.routes, '/')) {
       routes.unshift('/')
     }
 

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -139,6 +139,12 @@ const source: AgentContentSource = {
       return null
     }
 
+    // Copied before anything touches it, the way the comark adapter does:
+    // whether `queryCollection` hands back a shared object is its business,
+    // and both the hook below and the pipeline mutate the tree in place.
+    // `appendRelatedLinks` in particular is not idempotent.
+    page = { ...page, body: { ...page.body, value: structuredClone(page.body.value) } }
+
     // Lets sites transform the minimark tree (MDC components → plain
     // markdown) without replacing the whole source.
     await useNitroApp().hooks.callHook('agent-discovery:document', event, page)

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import type { AgentContentSource, NegotiationConfig } from '../../shared/types'
-import { absolutizeHref, hasFileExtension, matchRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
+import { absolutizeHref, encodeAgentRoute, hasFileExtension, matchRoute, normalizeAgentRoute, rawDestination } from '../../shared/negotiation'
 
 export function useAgentDiscoveryConfig(event?: H3Event): NegotiationConfig {
   // Through `unknown`: a site's generated `runtimeConfig` type narrows the
@@ -46,10 +46,13 @@ export function rawUrl(event: H3Event, path: string): string {
     }
   }
 
-  pathname = normalizePathname(pathname)
+  // Decoded like the raw handler decodes its slug, then re-encoded on the way
+  // out, so a non-ASCII route is spelled here exactly as the `Link` header
+  // and `canonical_url` frontmatter spell it.
+  pathname = normalizeAgentRoute(pathname)
   const route = pathname === '/' || !hasFileExtension(pathname) ? matchRoute(config.routes, pathname) : undefined
 
-  return `${siteUrl}${route ? rawDestination(config, route, pathname) : pathname}${suffix}`
+  return `${siteUrl}${encodeAgentRoute(route ? rawDestination(config, route, pathname) : pathname)}${suffix}`
 }
 
 /**

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -85,6 +85,16 @@ export async function getSourcePage(route: string, event: H3Event): Promise<Agen
 }
 
 /**
+ * The generated landing page, in the same shape `getSourcePage` returns, for
+ * a consumer rendering `/` on an adapter with no `/` entry. The raw route
+ * reaches the same document through `getAgentDocument`'s own fallback.
+ */
+export async function generatedIndexPage(event: H3Event): Promise<AgentPage> {
+  const index = await generatedIndex(event, getAgentSiteUrl(event))
+  return { title: index.title, description: index.description, markdown: index.markdown }
+}
+
+/**
  * Resolves a page route to the exact document `/raw/<path>.md` serves.
  *
  * The HTTP route is a thin shell over this so that anything else reaching for

--- a/src/runtime/server/utils/pages.ts
+++ b/src/runtime/server/utils/pages.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 import source from '#agent-discovery/source'
 import { getAgentSiteUrl, rawUrl, useAgentDiscoveryConfig } from './agent-discovery'
+import { encodeAgentRoute } from '../../shared/negotiation'
 
 /** One page in a listing, with both URLs an agent might want. */
 export interface AgentPageListing {
@@ -70,7 +71,9 @@ export async function listAgentPages(event: H3Event, options: AgentPageListOptio
       title: entry.title,
       description: entry.description,
       section: entry.section,
-      url: `${siteUrl}${entry.route === '/' ? '' : entry.route}` || siteUrl,
+      // Encoded like `canonical_url`, so the two spellings of a non-ASCII
+      // page cannot diverge between the listing and the document itself.
+      url: `${siteUrl}${entry.route === '/' ? '' : encodeAgentRoute(entry.route)}` || siteUrl,
       rawUrl: rawUrl(event, entry.route)
     }))
 }

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -66,7 +66,7 @@ export function hasFileExtension(pathname: string): boolean {
 }
 
 /** Plain prefix match, so `/_` covers `/_nuxt` and `/api/` covers `/api/x`. */
-function isExcluded(pathname: string, config: NegotiationConfig): boolean {
+export function isExcluded(pathname: string, config: NegotiationConfig): boolean {
   return config.excludePrefixes.some(prefix => pathname.startsWith(prefix))
 }
 

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -138,7 +138,7 @@ describe('O(1) route table', () => {
     expect(localeRewrites).toHaveLength(3)
     expect(localeRewrites.every(route => route.dest === '/raw/$1/docs/$2.md')).toBe(true)
     expect(localeRewrites.some(route => route.has?.some(has => has.key === 'accept'))).toBe(true)
-    expect(localeRewrites.some(route => route.has?.some(has => has.key === 'user-agent' && has.value.includes('ClaudeBot')))).toBe(true)
+    expect(localeRewrites.some(route => route.has?.some(has => has.key === 'user-agent' && new RegExp(has.value).test('ClaudeBot/1.0')))).toBe(true)
 
     // The homepage keeps its explicit `raw` destination.
     expect(routes.filter(route => route.dest === '/raw/index.md')).toHaveLength(2)

--- a/test/e2e/llms-handwritten.test.ts
+++ b/test/e2e/llms-handwritten.test.ts
@@ -78,6 +78,9 @@ describe('llms-full.txt', () => {
     expect(body.trim()).not.toBe('')
     expect(body).toContain('# Alpha')
     expect(body).toContain('The one page the hand-written section links.')
+    // The landing page `llms.txt` advertises as its first link: the full
+    // document has to hold the page behind it, mirroring the index hook.
+    expect(body).toContain('# Handwritten')
     // The link arrives percent-encoded through `URL.pathname` while the
     // adapter stores the decoded slug, so the route has to be decoded on the
     // way to `get()` or the page silently drops out of the full document.

--- a/test/e2e/llms-narrow.test.ts
+++ b/test/e2e/llms-narrow.test.ts
@@ -1,0 +1,40 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { fetch, setup } from '@nuxt/test-utils/e2e'
+
+/**
+ * Narrowed `routes` under a curated section. The section names a page outside
+ * the negotiated patterns, which is its call: `llms.txt` used to read that
+ * link as "not a page", decide no section named documentation, and append the
+ * whole site after the curation, while `llms-full.txt` rendered only the
+ * curated page, so the two documents disagreed. A page counts as a page by
+ * exclusion and extension now, not by `routes`.
+ */
+const SITE_URL = 'https://narrow.example.com'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../fixtures/llms-narrow', import.meta.url)),
+  build: true,
+  server: true,
+  setupTimeout: 300000
+})
+
+describe('llms.txt', () => {
+  it('keeps the curated section and skips the whole-site fallback', async () => {
+    const body = await (await fetch('/llms.txt')).text()
+
+    // The curated link stays a plain page URL: `/guide/**` is not negotiated,
+    // so it has no raw twin to rewrite to.
+    expect(body).toContain(`- [Intro](${SITE_URL}/guide/intro): A page outside \`routes\`.`)
+    expect(body).not.toContain('Alpha')
+  })
+})
+
+describe('llms-full.txt', () => {
+  it('renders the page the curated link names, and nothing else', async () => {
+    const body = await (await fetch('/llms-full.txt')).text()
+
+    expect(body).toContain('# Intro')
+    expect(body).not.toContain('# Alpha')
+  })
+})

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -155,10 +155,10 @@ describe('vercel build output', () => {
       expect(route.dest ? route.check : route.status).toBeTruthy()
 
       const pattern = route.has!.find(has => has.key === 'user-agent')!.value
-      expect(pattern).toContain('ClaudeBot')
-      expect(pattern).toContain('GPTBot')
-      // The bot list must be the shared one, not a `curl`-only match.
+      // The bot list must be the shared one, not a `curl`-only match, and it
+      // matches case-insensitively like the origin does.
       expect(new RegExp(pattern).test('Mozilla/5.0 (compatible; ClaudeBot/1.0)')).toBe(true)
+      expect(new RegExp(pattern).test('gptbot/1.0')).toBe(true)
     }
   })
 

--- a/test/fixtures/llms-narrow/app.vue
+++ b/test/fixtures/llms-narrow/app.vue
@@ -1,0 +1,6 @@
+<template>
+  <main>
+    <h1>Narrow</h1>
+    <p>Fixture site whose routes cover less than its curation.</p>
+  </main>
+</template>

--- a/test/fixtures/llms-narrow/nuxt.config.ts
+++ b/test/fixtures/llms-narrow/nuxt.config.ts
@@ -1,0 +1,27 @@
+export default defineNuxtConfig({
+  modules: ['../../../src/module', 'nuxt-llms'],
+  devtools: { enabled: false },
+  compatibilityDate: '2026-01-01',
+  agentDiscovery: {
+    siteName: 'Narrow',
+    source: '~~/server/agent-source',
+    // Only `/docs/**` negotiates markdown. The curated section still names a
+    // page outside it, which is the section's call: listing a page and
+    // negotiating it are two different promises.
+    routes: ['/docs/**']
+  },
+  llms: {
+    domain: 'https://narrow.example.com',
+    title: 'Narrow',
+    description: 'Fixture site whose routes cover less than its curation.',
+    full: {
+      title: 'Narrow',
+      description: 'The curated documentation.'
+    },
+    sections: [{
+      title: 'Guide',
+      description: 'Curated by hand, partly outside the negotiated routes.',
+      links: [{ title: 'Intro', href: '/guide/intro', description: 'A page outside `routes`.' }]
+    }]
+  }
+})

--- a/test/fixtures/llms-narrow/server/agent-source.ts
+++ b/test/fixtures/llms-narrow/server/agent-source.ts
@@ -1,0 +1,41 @@
+import { defineAgentContentSource } from '#agent-discovery'
+
+/**
+ * In-memory adapter for a site whose `routes` cover less than its curation:
+ * `/docs/**` negotiates, the curated section links `/guide/intro` anyway.
+ */
+const pages: Record<string, { title: string, description: string, markdown: string }> = {
+  '/docs/alpha': {
+    title: 'Alpha',
+    description: 'A docs page the section leaves out.',
+    markdown: `# Alpha
+
+> A docs page the section leaves out.
+
+Negotiable, listed by the adapter, absent from the curated documents.
+`
+  },
+  '/guide/intro': {
+    title: 'Intro',
+    description: 'A page outside `routes`.',
+    markdown: `# Intro
+
+> A page outside \`routes\`.
+
+Curated by hand while sitting outside the negotiated patterns.
+`
+  }
+}
+
+export default defineAgentContentSource({
+  async list(selector) {
+    if (selector) {
+      return null
+    }
+    return Object.entries(pages).map(([route, page]) => ({ route, title: page.title, description: page.description }))
+  },
+
+  async get(route: string) {
+    return pages[route] || null
+  }
+})

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -469,6 +469,28 @@ describe('module setup: routes', () => {
       .rejects.toThrow('negotiates back to itself')
   })
 
+  it('refuses a raw cycle through another route', async () => {
+    // `/a` proxies to `/b.md`, which negotiates through `/b` back to `/a.md`,
+    // forever, and neither hop is a one-step fixpoint.
+    await expect(runModule({ routes: [{ path: '/a', raw: '/b.md' }, { path: '/b', raw: '/a.md' }] }))
+      .rejects.toThrow('negotiates back to itself')
+  })
+
+  it('refuses a raw destination without an extension', async () => {
+    // `/x` negotiates markdown for itself: the middleware fetches `/x` from
+    // `/x`, forever. The `.md` spelling is not what loops, the negotiation is.
+    await expect(runModule({ routes: [{ path: '/x', raw: '/x' }] }))
+      .rejects.toThrow('negotiates back to itself')
+  })
+
+  it('accepts a chain that terminates', async () => {
+    // `/a.md` negotiates through `/a`, whose own destination sits under the
+    // raw prefix: one extra hop, then done.
+    const config = await setupModule({ routes: [{ path: '/a', raw: '/raw/a.md' }, { path: '/b', raw: '/a.md' }] })
+
+    expect(config.routes[1]).toEqual({ path: '/b', raw: '/a.md' })
+  })
+
   it('accepts a raw destination under an excluded prefix', async () => {
     // `isExcluded` runs before the `.md` branch in `negotiatedRawPath`, so an
     // excluded destination never negotiates and cannot loop. A site serving

--- a/test/unit/pages.test.ts
+++ b/test/unit/pages.test.ts
@@ -62,4 +62,27 @@ describe('listAgentPages: an adapter without `list()`', () => {
       rawUrl: 'https://example.com/raw/docs/getting-started.md'
     }])
   })
+
+  it('spells a non-ASCII route like the canonical URL', async () => {
+    // The raw route's `Link` header and `canonical_url` frontmatter encode
+    // the path, so the listing has to spell it the same way or an agent sees
+    // two names for one page.
+    setAgentContentSource({
+      async list() {
+        return [{ route: '/guide/文档', title: '文档' }]
+      },
+      async get() {
+        return { markdown: '# 文档\n' }
+      }
+    })
+
+    await expect(listAgentPages(event)).resolves.toEqual([{
+      route: '/guide/文档',
+      title: '文档',
+      description: undefined,
+      section: undefined,
+      url: 'https://example.com/guide/%E6%96%87%E6%A1%A3',
+      rawUrl: 'https://example.com/raw/guide/%E6%96%87%E6%A1%A3.md'
+    }])
+  })
 })

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -179,7 +179,7 @@ describe('vercelMarkdownRoutes: 406', () => {
     expect(present.test('text/html/extra')).toBe(false)
 
     expect(matcher(refusal, 'sec-fetch-mode', 'missing')).toBe('navigate')
-    expect(matcher(refusal, 'user-agent', 'missing')).toContain('ClaudeBot')
+    expect(new RegExp(matcher(refusal, 'user-agent', 'missing') || '$^').test('ClaudeBot/1.0')).toBe(true)
   })
 
   // A bare substring matched a supported type inside a parameter value, so
@@ -491,8 +491,8 @@ describe('vercelMarkdownRoutes: user-agent matcher', () => {
   const uaRoute = vercelMarkdownRoutes(config).find(route => route.has?.[0]?.key === 'user-agent')
   const value = uaRoute?.has?.[0]?.value || ''
 
-  it('escapes regex specials', () => {
-    expect(value).toBe('.*(ClaudeBot|GPTBot|curl/8\\.4).*')
+  it('escapes regex specials and folds the case', () => {
+    expect(value).toBe('.*([cC][lL][aA][uU][dD][eE][bB][oO][tT]|[gG][pP][tT][bB][oO][tT]|[cC][uU][rR][lL]/8\\.4).*')
     expect(new RegExp(value).test('curl/8x4')).toBe(false)
   })
 
@@ -503,8 +503,12 @@ describe('vercelMarkdownRoutes: user-agent matcher', () => {
     expect(new RegExp(value).test('Mozilla/5.0 (Macintosh) Chrome/131.0')).toBe(false)
   })
 
-  it('stays case-sensitive, like the runtime', () => {
-    expect(new RegExp(value).test('claudebot/1.0')).toBe(false)
+  it('matches case-insensitively, like the runtime', () => {
+    // Spelled into the pattern, `[qQ]`-style: the origin lowercases both
+    // sides, and whether the edge's `has` matching is case-insensitive is an
+    // observation nothing may depend on.
+    expect(new RegExp(value).test('claudebot/1.0')).toBe(true)
+    expect(new RegExp(value).test('GPTBOT')).toBe(true)
   })
 })
 


### PR DESCRIPTION
follow-up to the #9 → #16 stack: everything actionable the deep review of the combined diff surfaced but the stack merged without, one commit per area.

- `llms.txt`/`llms-full.txt` and narrowed `routes` no longer disagree: a link counted as a page only when it matched `routes`, so a site narrowing the patterns got its curated section listed twice in `llms.txt` (the curation, then the whole-site fallback on top) while `llms-full.txt` rendered only the curated pages. page-ness is judged by exclusion and extension alone now, the docstring's actual intent (`/openapi.json` out by extension, `/api/v1/tools` out by prefix), and a curated link outside `routes` stays a plain page URL instead of being rewritten to a raw twin that 404s. new `llms-narrow` fixture pins both documents.
- `llms-full.txt` now holds the landing page `llms.txt` advertises as its first link: the full hook mirrors the index hook's condition and falls back to the same generated index `/raw/index.md` serves when the adapter has no `/` entry.
- both fallback listings apply the `excludePrefixes` filter `listAgentPages` already applied, so `llms.txt` cannot advertise pages `sitemap.md` deliberately hides.
- the raw-cycle guard walks the negotiation chain instead of testing the one-hop fixpoint: `{ '/a' → '/b.md', '/b' → '/a.md' }` and an extensionless `raw: '/x'` built fine and hung the middleware in unbounded `localFetch` recursion; both are refused at build now, and a chain that terminates stays accepted.
- the Vercel agent `has` matcher is case-folded letter by letter, `[qQ]`-style: the origin matches user agents case-insensitively since #10, and whether the edge does is an observed behaviour nothing may depend on.
- `listAgentPages()` and `/sitemap.md` spell non-ASCII routes percent-encoded, the same spelling the raw route's `Link` header and `canonical_url` frontmatter use, so an agent no longer sees two names for one page.
- the `@nuxt/content` adapter clones the queried tree before the document hook and the pipeline mutate it, the way the comark adapter already did: `appendRelatedLinks` is not idempotent if the query layer ever hands back a shared object.
- build-time raw-prefix checks go through `isRawPath` instead of two more inlined spellings.

`pnpm test` (437 across 21 files), `typecheck` and `lint` green on this head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved route validation to detect indirect redirect cycles and safely follow multi-step raw routes.
  - Prevented shared page content from being unintentionally modified during document generation.
  - Corrected handling of excluded paths, assets, and unmatched routes in generated LLM content.

- **Improvements**
  - Added landing-page content to full-site LLM documents when available.
  - Standardized URL encoding for non-ASCII agent routes.
  - Made Vercel user-agent matching case-insensitive.
  - Improved support for curated LLM links outside negotiated routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->