### PR TITLE
fix: treat disabled companion modules as absent and type their hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export default defineNuxtConfig({
     discovery: {
       link: true,
       apiCatalog: true,
-      sitemapXml: true,               // only when `@nuxtjs/sitemap` is installed
+      sitemapXml: true,               // only when `@nuxtjs/sitemap` is installed and enabled
       mcpServerCard: false,
       links: []
     },
@@ -93,7 +93,7 @@ export default defineNuxtConfig({
 - **`userAgents.extend`** Extra user agents on top of the defaults (18 agents from `ai.robots.txt`, see `src/defaults.ts`). **`.replace`** replaces the list.
 - **`discovery.link`** Emit the discovery `Link` header on `/`.
 - **`discovery.apiCatalog`** Serve `/.well-known/api-catalog` (RFC 9727).
-- **`discovery.sitemapXml`** Advertise `/sitemap.xml`, only when `@nuxtjs/sitemap` is installed.
+- **`discovery.sitemapXml`** Advertise `/sitemap.xml`, only when `@nuxtjs/sitemap` is installed and enabled. A disabled companion counts as absent everywhere: the module then serves `/robots.txt` itself and registers no sitemap filter.
 - **`discovery.mcpServerCard`** Given an `McpServerCardOptions` object, serves `/.well-known/mcp/server-card.json`.
 - **`discovery.links`** Site-specific discovery links. Rels are validated against the IANA registry, an invented one fails the build.
 - **`errors`** Answer errors with a markdown body carrying recovery links when the request prefers it.

--- a/src/module.ts
+++ b/src/module.ts
@@ -23,6 +23,7 @@ import { disableContentRawMarkdown, dropContentLlmsFeature, resolveContentSource
 import { setupVercelPreset } from './presets/vercel'
 import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
 import type { Nuxt } from '@nuxt/schema'
+import type { ModuleHooks as RobotsModuleHooks } from '@nuxtjs/robots'
 import type { AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
 export type { AgentContentSource, AgentIndex, AgentListEntry, AgentPage, AgentRoute, AgentSectionSelector, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
@@ -512,9 +513,13 @@ export {}
       // options during its own setup, so a site listing it first (which
       // `@nuxtjs/sitemap` asks for) would silently get none of this.
       const contentSignal = options.robots.contentSignal
+      // Typed with the hook signature `@nuxtjs/robots` exports, so a group
+      // shape change in a robots major fails this build instead of silently
+      // pushing groups it no longer reads. The cast is only for the hook name,
+      // which that module declares through no global augmentation.
       const onRobotsConfig = nuxt.hook as unknown as (
         name: 'robots:config',
-        cb: (config: { groups: { userAgent: string[], allow: string[], disallow: string[], comment: string[], contentSignal?: string[] }[] }) => void | Promise<void>
+        cb: RobotsModuleHooks['robots:config']
       ) => void
       onRobotsConfig('robots:config', async (robotsConfig) => {
         // The groups below snapshot the user-agent list, so anything a site
@@ -522,10 +527,13 @@ export {}
         await extendRegistry()
         // `Content-Signal` belongs on the wildcard group, which this module's
         // own `robots.txt` route emits too. Without it the directive would be
-        // lost the moment a site adds `@nuxtjs/robots`.
+        // lost the moment a site adds `@nuxtjs/robots`. The groups are
+        // normalized before the hook fires, but the declared type still
+        // carries the `Arrayable` input shape.
         if (contentSignal) {
           for (const group of robotsConfig.groups) {
-            if (group.userAgent.includes('*')) {
+            const groupAgents = Array.isArray(group.userAgent) ? group.userAgent : [group.userAgent]
+            if (groupAgents.includes('*')) {
               group.contentSignal = [contentSignal]
             }
           }

--- a/src/module.ts
+++ b/src/module.ts
@@ -22,6 +22,7 @@ import { scanSkills } from './skills'
 import { disableContentRawMarkdown, dropContentLlmsFeature, resolveContentSource } from './build/content'
 import { setupVercelPreset } from './presets/vercel'
 import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
+import type { Nuxt } from '@nuxt/schema'
 import type { AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
 export type { AgentContentSource, AgentIndex, AgentListEntry, AgentPage, AgentRoute, AgentSectionSelector, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
@@ -166,6 +167,23 @@ declare module '@nuxt/schema' {
   }
   interface RuntimeConfig extends AgentDiscoveryRuntimeConfig {}
   interface PublicRuntimeConfig extends AgentDiscoveryPublicRuntimeConfig {}
+}
+
+/**
+ * Whether a companion module is installed and will actually run. `hasNuxtModule`
+ * alone is not enough: `@nuxtjs/robots`, `@nuxtjs/sitemap` and
+ * `@nuxtjs/mcp-toolkit` all return early from their own `setup()` on
+ * `{ enabled: false }`, staying installed while registering nothing. And
+ * `<configKey>: false` is how Nuxt disables a module by its config key, which
+ * is not the same as `{ enabled: false }`: optional chaining alone reads it as
+ * `undefined !== false` and counts the module as active.
+ */
+function hasActiveNuxtModule(nuxt: Nuxt, name: string, configKey: string): boolean {
+  if (!hasNuxtModule(name, nuxt)) {
+    return false
+  }
+  const moduleOptions = (nuxt.options as unknown as Record<string, false | { enabled?: boolean } | undefined>)[configKey]
+  return moduleOptions !== false && moduleOptions?.enabled !== false
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -373,20 +391,12 @@ export default defineNuxtModule<ModuleOptions>({
     // tools at all, silently. Nitro resolves the alias table well after this
     // hook, so swapping the entry now still lands.
     nuxt.hook('modules:done', () => {
-      // `hasNuxtModule` alone is not enough: the toolkit's own setup returns
-      // early when it is disabled or running under `nuxt generate`, registering
-      // none of the `#nuxt-mcp-toolkit/*` virtual modules its listing API
-      // imports. Aliasing the real re-export in that state fails the Nitro
-      // build on an unresolvable id, so the same three conditions are mirrored
-      // here.
-      // `mcp: false` is how Nuxt disables a module by its config key, and it is
-      // not the same as `mcp: { enabled: false }`: optional chaining reads the
-      // first as `undefined !== false`, which passed this guard and left the
-      // card aliased to a toolkit that registered nothing.
-      const mcpOptions = (nuxt.options as { mcp?: false | { enabled?: boolean } }).mcp
-      const mcpToolkit = hasNuxtModule('@nuxtjs/mcp-toolkit')
-        && mcpOptions !== false
-        && mcpOptions?.enabled !== false
+      // Active, not merely installed: the toolkit's setup also returns early
+      // under `nuxt generate`, registering none of the `#nuxt-mcp-toolkit/*`
+      // virtual modules its listing API imports. Aliasing the real re-export
+      // in that state fails the Nitro build on an unresolvable id, so the two
+      // build conditions are mirrored here on top of the shared check.
+      const mcpToolkit = hasActiveNuxtModule(nuxt, '@nuxtjs/mcp-toolkit', 'mcp')
         && !nuxt.options.nitro?.static
         && (nuxt.options as { _generate?: boolean })._generate !== true
       if (!mcpToolkit) {
@@ -534,7 +544,10 @@ export {}
       // `setup()` runs. `hasNuxtModule` says no at this point, and the handler
       // we would register is dead code behind theirs.
       nuxt.hook('modules:done', () => {
-        if (hasNuxtModule('@nuxtjs/robots')) {
+        // Active, not merely installed: a robots module disabled through its
+        // own options registers no `/robots.txt` route, so deferring to it
+        // served nobody the agent policy.
+        if (hasActiveNuxtModule(nuxt, '@nuxtjs/robots', 'robots')) {
           return
         }
         // The name check above covers the modules we know. Anything else
@@ -568,7 +581,7 @@ export {}
     // does nothing unless the site happens to list this module first. Detection
     // waits for `modules:done` for the `moduleDependencies` reason above.
     nuxt.hook('modules:done', () => {
-      if (hasNuxtModule('@nuxtjs/sitemap')) {
+      if (hasActiveNuxtModule(nuxt, '@nuxtjs/sitemap', 'sitemap')) {
         addServerPlugin(resolve('./runtime/server/plugins/sitemap'))
       }
     })
@@ -730,9 +743,10 @@ export {}
 
       // Advertised only when something serves it. This module does not generate
       // `sitemap.xml`, so keying on the option alone meant a zero-config site
-      // pointed agents, the api-catalog and `robots.txt` at a 404. A site that
-      // serves its own can register it through `discovery.links`.
-      if (options.discovery?.sitemapXml !== false && hasNuxtModule('@nuxtjs/sitemap')) {
+      // pointed agents, the api-catalog and `robots.txt` at a 404, and so does
+      // a sitemap module a site installed but disabled. A site that serves its
+      // own can register it through `discovery.links`.
+      if (options.discovery?.sitemapXml !== false && hasActiveNuxtModule(nuxt, '@nuxtjs/sitemap', 'sitemap')) {
         links.push({ href: '/sitemap.xml', rel: 'sitemap', type: 'application/xml', title: 'Sitemap (XML)' })
       }
       if (sourcePath && options.sitemap?.markdown) {

--- a/src/runtime/server/plugins/sitemap.ts
+++ b/src/runtime/server/plugins/sitemap.ts
@@ -2,13 +2,7 @@ import { parseURL } from 'ufo'
 import { defineNitroPlugin } from 'nitropack/runtime'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { isRawPath } from '../../shared/negotiation'
-
-/** A sitemap URL as the sources hand it over, before `@nuxtjs/sitemap` normalizes it. */
-type SitemapUrlInput = string | { loc?: string }
-
-interface SitemapInputContext {
-  urls: SitemapUrlInput[]
-}
+import type { SitemapInputCtx } from '@nuxtjs/sitemap'
 
 /**
  * Drops the raw markdown twins from every sitemap `@nuxtjs/sitemap` builds.
@@ -27,9 +21,13 @@ interface SitemapInputContext {
 export default defineNitroPlugin((nitroApp) => {
   const { rawPrefix } = useAgentDiscoveryConfig()
 
+  // Typed with the context `@nuxtjs/sitemap` exports, so a shape change in a
+  // sitemap major fails this build instead of silently filtering nothing. The
+  // cast is only for the hook name, which that module declares through no
+  // global augmentation.
   const onSitemapInput = nitroApp.hooks.hook as unknown as (
     name: 'sitemap:input',
-    cb: (ctx: SitemapInputContext) => void
+    cb: (ctx: SitemapInputCtx) => void
   ) => void
 
   onSitemapInput('sitemap:input', (ctx) => {

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -349,6 +349,17 @@ describe('module setup: companion modules', () => {
     expect(nuxt.options.serverHandlers.some(handler => handler.route === '/robots.txt')).toBe(false)
   })
 
+  it('serves `/robots.txt` itself when the companion is installed but disabled', async () => {
+    // `@nuxtjs/robots` returns early from its own setup on `enabled: false`,
+    // registering no route, so deferring to it would serve nobody the policy.
+    const nuxt = await runModule(robots, {}, (nuxt) => {
+      installLate('@nuxtjs/robots')(nuxt)
+      Object.assign(nuxt.options, { robots: { enabled: false } })
+    })
+
+    expect(nuxt.options.serverHandlers.some(handler => handler.route === '/robots.txt')).toBe(true)
+  })
+
   it('extends the user agents before an earlier robots module snapshots them', async () => {
     // `@nuxtjs/robots` listed first registers its `modules:done` before this
     // module's and fires `robots:config` from it, so the groups it builds
@@ -408,6 +419,26 @@ describe('module setup: companion modules', () => {
     const nuxt = await runModule()
 
     expect((nuxt.options.nitro.plugins || []).some(plugin => String(plugin).includes('plugins/sitemap'))).toBe(false)
+  })
+
+  it('treats a sitemap module installed but disabled as absent', async () => {
+    // The same early return as the robots and MCP companions: `enabled: false`
+    // leaves the module installed while it serves nothing, so the plugin would
+    // filter a sitemap that never builds and the advertised `/sitemap.xml`
+    // would 404.
+    const enabled = await runModule({}, {}, installLate('@nuxtjs/sitemap'))
+    const enabledLinks = (enabled.options.runtimeConfig.agentDiscovery as NegotiationConfig).links
+
+    expect(enabledLinks.some(link => link.href === '/sitemap.xml')).toBe(true)
+
+    const disabled = await runModule({}, {}, (nuxt) => {
+      installLate('@nuxtjs/sitemap')(nuxt)
+      Object.assign(nuxt.options, { sitemap: { enabled: false } })
+    })
+    const disabledLinks = (disabled.options.runtimeConfig.agentDiscovery as NegotiationConfig).links
+
+    expect((disabled.options.nitro.plugins || []).some(plugin => String(plugin).includes('plugins/sitemap'))).toBe(false)
+    expect(disabledLinks.some(link => link.href === '/sitemap.xml')).toBe(false)
   })
 
   it('resolves the MCP definitions for a toolkit installed after `setup()`', async () => {


### PR DESCRIPTION
two gaps in how the module integrates with its optional companions (`@nuxtjs/robots`, `@nuxtjs/sitemap`, `@nuxtjs/mcp-toolkit`), one commit each.

- **installed-but-disabled companions were treated as active.** all three return early from their own `setup()` on `{ enabled: false }`, and Nuxt disables a module outright when its config key is `false` (`sitemap: false`), but `hasNuxtModule()` still reports them installed. so a disabled `@nuxtjs/robots` made the module defer and skip its own `/robots.txt` (nobody served the agent allow list), and a disabled `@nuxtjs/sitemap` still got the `sitemap:input` filter plugin and a `/sitemap.xml` discovery link pointing agents at a 404. a shared `hasActiveNuxtModule()` helper now treats a companion as absent unless it is installed, its config key is not `false`, and `enabled` is not `false`. applied at the robots fallback decision, the sitemap plugin registration, the `/sitemap.xml` link, and the MCP alias swap (which had these checks inline before).
- **hand-declared hook shapes replaced with the peers' exported types.** the `robots:config` and `sitemap:input` callbacks were typed with locally written shapes behind `as unknown as` casts, so a breaking shape change in a future major of either peer would have failed silently. they now use `ModuleHooks['robots:config']` from `@nuxtjs/robots` and `SitemapInputCtx` from `@nuxtjs/sitemap`; the casts remain only for the hook names, which neither peer declares globally. the real type surfaced that `group.userAgent` is `Arrayable<string>`, hence the `Array.isArray` guard. both imports are type-only and elided from the published `dist` declarations (verified by building), so the peers stay optional.

`pnpm test` (439 across 24 files), `typecheck` and `lint` green on this head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of disabled companion modules, ensuring integrations only activate when those modules are enabled.
  - The application now provides its own `/robots.txt` when the robots integration is disabled.
  - Sitemap functionality and sitemap links are omitted when the sitemap integration is disabled.
  - Improved robot group matching by normalizing user-agent values.

- **Documentation**
  - Clarified sitemap XML integration requirements and behavior when the companion integration is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->