### PR TITLE
feat: append the resources block to a source-backed `/` document

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ canonical_url: "https://example.com/docs/getting-started"
 ---
 ```
 
-Then the page markdown, with every same-origin link absolutized. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
+Then the page markdown, with every same-origin link absolutized. On `/` the discovery registry follows the body as a `## Resources for Agents` block, the same block the generated landing page carries. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
 
-A path naming a section rather than a page redirects 302 to the section's first document when the adapter implements `firstLeaf()`. Anything else missing answers a real 404 with the markdown error body, so an agent can tell an unknown URL from an empty one. `/` is the exception: with no `/` entry in the adapter, `/raw/index.md` falls through to a generated landing page, see [`agent-discovery:index`](#extending).
+A path naming a section rather than a page redirects 302 to the section's first document when the adapter implements `firstLeaf()`. Anything else missing answers a real 404 with the markdown error body, so an agent can tell an unknown URL from an empty one. `/` is the exception: with no `/` entry in the adapter, `/raw/index.md` falls through to a generated landing page, see [`agent-discovery:index`](#extending). The recommended way to author the agent homepage is a `/` document in the content source: the module wraps it with the resources block and the sitemap footer, and the generated page is the fallback for sites that have none.
 
 ## Content sources
 
@@ -213,7 +213,7 @@ export default defineNitroPlugin((nitroApp) => {
 })
 ```
 
-**`renderAgentResources()`** renders the discovery registry as a markdown block, the same list the `Link` header and the api-catalog are built from.
+**`renderAgentResources()`** renders the discovery registry as a markdown block, the same list the `Link` header and the api-catalog are built from. The module appends it to the `/` document itself, so call it only for a page you render by hand.
 
 **`agentDiscoveryOpenApi()`** returns the discovery layer as OpenAPI fragments for sites publishing an `openapi.json`: the negotiated page patterns, their raw twins, and every discovery document the site serves, each with a stable `operationId`. Pass the `paths` you are merging into so your own operation ids are claimed first:
 
@@ -229,7 +229,7 @@ return {
 }
 ```
 
-**`agent-discovery:index`** fills in the generated `/raw/index.md` for sites whose landing page is a Vue page rather than a document:
+**`agent-discovery:index`** fills in the generated `/raw/index.md` for sites whose landing page is a Vue page rather than a document. Keep it to metadata and data-driven blocks: homepage prose belongs in a `/` document in the content source, which the raw route wraps with the same resources block:
 
 ```ts
 // server/plugins/agent-discovery.ts

--- a/skills/migrate-to-nuxt-agent-discovery/SKILL.md
+++ b/skills/migrate-to-nuxt-agent-discovery/SKILL.md
@@ -124,7 +124,7 @@ export default defineNitroPlugin((nitroApp) => {
 
 Three helpers replace hand-written equivalents:
 
-- `renderAgentResources(event)` renders the discovery registry as a markdown block, for a hand-written agent homepage.
+- `renderAgentResources(event)` renders the discovery registry as a markdown block, for a page the site renders by hand. The module appends it to the `/` document itself, so a `/` document must not render it again.
 - `agentDiscoveryOpenApi(event)` returns the discovery layer as OpenAPI fragments. Spread the site's own paths last so they win.
 - `rawUrl(event, href)` resolves a page URL to its markdown twin from the same route config, for links the site builds itself inside `llms:generate` hooks.
 
@@ -152,7 +152,7 @@ Two wrinkles. A tool that deliberately serves excluded content, say a nightly do
 | `server/middleware/markdown.ts` | the module's middleware |
 | `server/error.ts` plus the `nitro:config` errorHandler chaining in `nuxt.config` | `errors: true` |
 | `server/routes/raw/[...slug].md.get.ts` | the module's raw route |
-| `server/routes/raw/index.md.get.ts` | `agent-discovery:index` |
+| `server/routes/raw/index.md.get.ts` | a `/` document in the content source, or `agent-discovery:index` |
 | `server/routes/.well-known/api-catalog.get.ts`, `.well-known/mcp/server-card.json.get.ts` | `discovery.apiCatalog`, `discovery.mcpServerCard` |
 | `server/routes/sitemap.md.get.ts` | `sitemap.markdown` |
 | `public/robots.txt` with its `Disallow` lines, hand-maintained agent lists | `robots.aiPolicy` and `robots.disallow` |
@@ -164,7 +164,7 @@ Two wrinkles. A tool that deliberately serves excluded content, say a nightly do
 
 Two that are easy to miss: the `Vary`/`Link` `routeRules` block, which now conflicts with what the module emits, and the `nitro:config` hook chaining the error handler, which the module does itself.
 
-Keep a hand-written `/raw/index.md` handler only when the site wants full control of that document. Otherwise delete it and use the `agent-discovery:index` hook.
+Keep a hand-written `/raw/index.md` handler only when the site wants full control of that document. Otherwise prefer a `/` document in the content source, which the module wraps with the resources block and the sitemap footer, and keep the `agent-discovery:index` hook for metadata when no `/` document exists.
 
 ## Adopting `@nuxtjs/sitemap` in the same PR
 

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -6,7 +6,7 @@ import { defineNitroPlugin } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
 import type { AgentListEntry, NegotiationConfig } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
-import { generatedIndexPage, getSourcePage } from '../utils/document'
+import { appendAgentResources, generatedIndexPage, getSourcePage } from '../utils/document'
 import { hasFileExtension, isExcluded, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
 
 interface LlmsSection {
@@ -254,8 +254,11 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       ? null
       : (adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null))
     for (const [index, section] of sections.entries()) {
+      // Normalized the way `listAgentPages` does, so an adapter listing its
+      // homepage as `/index` lands on the same `/` the landing-page check
+      // below looks for and the resources append keys on.
       for (const entry of resolved[index] || []) {
-        add(entry.route)
+        add(normalizeAgentRoute(entry.route))
       }
       // A section curating its documentation by hand names it in its links, so
       // the pages behind them are what the full document is. Everything else a
@@ -274,9 +277,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // no sections at all.
     if (!routes.length) {
       for (const entry of (await adapter.list?.(undefined, event)) || []) {
+        const route = normalizeAgentRoute(entry.route)
         // The same filter `listAgentPages` applies, matching the index hook.
-        if (!isExcluded(entry.route, config)) {
-          add(entry.route)
+        if (!isExcluded(route, config)) {
+          add(route)
         }
       }
     }
@@ -291,9 +295,17 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // The same `get()` the raw route calls, so a page reads identically
     // whether an agent fetches `/raw/**.md` or the single full document. `/`
     // is the one route with a fallback: an adapter with no `/` entry still
-    // has the generated index behind `/raw/index.md`.
-    const pages = await mapLimit(routes, async route =>
-      await getSourcePage(route, event) ?? (route === '/' ? await generatedIndexPage(event) : null))
+    // has the generated index behind `/raw/index.md`, and one that does carries
+    // the same resources block the raw route appends.
+    const pages = await mapLimit(routes, async (route) => {
+      const page = await getSourcePage(route, event)
+      if (route !== '/') {
+        return page
+      }
+      return page
+        ? { ...page, markdown: appendAgentResources(event, page.markdown) }
+        : await generatedIndexPage(event)
+    })
     for (const page of pages) {
       if (page?.markdown) {
         contents.push(page.markdown)

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -56,10 +56,11 @@ export function rawUrl(event: H3Event, path: string): string {
 }
 
 /**
- * The discovery registry as a markdown block, for sites that hand-write an
- * agent-facing homepage. Same list the `Link` header and the api-catalog are
- * built from, so a resource can never be advertised in one place and missed
- * in another.
+ * The discovery registry as a markdown block. The module appends it to the
+ * `/` document itself, on the raw route and in `llms-full.txt`, so a site
+ * only calls this for a page it renders by hand. Same list the `Link` header
+ * and the api-catalog are built from, so a resource can never be advertised
+ * in one place and missed in another.
  */
 export function renderAgentResources(event: H3Event, options: { heading?: string } = {}): string {
   const config = useAgentDiscoveryConfig(event)

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -103,6 +103,21 @@ export async function generatedIndexPage(event: H3Event): Promise<AgentPage> {
 }
 
 /**
+ * The `/` body with the discovery resources appended, shared by
+ * `getAgentDocument` and the `llms-full.txt` builder so the homepage reads
+ * identically wherever it is served. An empty body stays empty, so a
+ * placeholder `/` entry keeps contributing nothing to `llms-full.txt`, and a
+ * registry with no titled links leaves the body alone.
+ */
+export function appendAgentResources(event: H3Event, markdown: string): string {
+  if (!markdown.trim()) {
+    return markdown
+  }
+  const resources = renderAgentResources(event)
+  return resources ? `${markdown.replace(/\n*$/, '\n\n')}${resources}` : markdown
+}
+
+/**
  * Resolves a page route to the exact document `/raw/<path>.md` serves.
  *
  * The HTTP route is a thin shell over this so that anything else reaching for
@@ -177,7 +192,9 @@ export async function getAgentDocument(event: H3Event, route: string, options: A
     ? `\n\n## Sitemap\n\nSee the full [sitemap](${siteUrl}/sitemap.md) for all pages.\n`
     : '\n'
 
-  const markdown = frontmatter + page!.markdown + sitemap
+  // `/` mirrors the generated index: body, the discovery resources, footer.
+  const body = path === '/' ? appendAgentResources(event, page!.markdown) : page!.markdown
+  const markdown = frontmatter + body + sitemap
 
   return {
     markdown: options.sections?.length ? extractSections(markdown, options.sections) : markdown,

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -303,6 +303,7 @@ describe('agent tooling helpers', () => {
     entry: { route: string, title: string, description: string, section?: string, url: string, rawUrl: string }
     sectioned: string
     unmatchedSections: string
+    index: string
   }
 
   it('lists every page with both URLs an agent might want', async () => {
@@ -333,6 +334,13 @@ describe('agent tooling helpers', () => {
     // Matching any term would have returned the button page here.
     expect(body.oneTermMisses).toEqual([])
     expect(body.combined).toEqual(['/docs/components/badge'])
+  })
+
+  it('returns the same bytes for `/` as the raw route serves', async () => {
+    const body = await load()
+    const raw = await (await fetch('/raw/index.md')).text()
+
+    expect(body.index).toBe(raw)
   })
 
   it('narrows a document to the sections asked for, and hands back the whole one otherwise', async () => {
@@ -566,6 +574,15 @@ describe('nuxt-llms bridge', () => {
     // The raw route wraps the body in frontmatter and a sitemap footer.
     const body = raw.split('---\n')[2]!.split('\n\n## Sitemap')[0]!
     expect(full).toContain(body.trim())
+  })
+
+  it('carries the homepage with its resources block, matching the raw route', async () => {
+    const raw = await (await fetch('/raw/index.md')).text()
+    const full = await (await fetch('/llms-full.txt')).text()
+
+    const body = raw.split('---\n')[2]!.split('\n\n## Sitemap')[0]!
+    expect(body).toContain('## Resources for Agents')
+    expect(full).toContain(body)
   })
 })
 

--- a/test/e2e/comark.test.ts
+++ b/test/e2e/comark.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { fetch, setup } from '@nuxt/test-utils/e2e'
-import { MARKDOWN_CONTENT_TYPE, SITE_URL } from './expected'
+import { MARKDOWN_CONTENT_TYPE, SITE_URL, SOURCE_INDEX_MARKDOWN } from './expected'
 import { describeSharedDocuments } from './shared'
 
 /**
@@ -20,7 +20,7 @@ await setup({
   setupTimeout: 300000
 })
 
-describeSharedDocuments()
+describeSharedDocuments(SOURCE_INDEX_MARKDOWN)
 
 describe('comark source', () => {
   it('renders a raw document on the request, not off a prerendered file', async () => {
@@ -62,6 +62,15 @@ describe('comark source', () => {
 
     // The body only, since the raw route adds frontmatter of its own.
     const body = page.slice(page.indexOf('# Getting Started'), page.indexOf('## Sitemap')).trim()
+    expect(full).toContain(body)
+  })
+
+  it('carries the homepage with its resources block, matching the raw route', async () => {
+    const full = await (await fetch('/llms-full.txt')).text()
+    const page = await (await fetch('/raw/index.md')).text()
+
+    const body = page.slice(page.indexOf('# Basic'), page.indexOf('## Sitemap')).trim()
+    expect(body).toContain('## Resources for Agents')
     expect(full).toContain(body)
   })
 

--- a/test/e2e/custom-source.test.ts
+++ b/test/e2e/custom-source.test.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { fetch, setup } from '@nuxt/test-utils/e2e'
-import { MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY, SITE_URL } from './expected'
+import { MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY, SITE_URL, SOURCE_INDEX_MARKDOWN } from './expected'
 import { describeSharedDocuments } from './shared'
 
 /**
@@ -21,7 +21,7 @@ await setup({
   setupTimeout: 300000
 })
 
-describeSharedDocuments()
+describeSharedDocuments(SOURCE_INDEX_MARKDOWN)
 
 describe('content negotiation', () => {
   // `notAcceptable` is off here, which is the default. The strict answer would

--- a/test/e2e/expected.ts
+++ b/test/e2e/expected.ts
@@ -16,7 +16,9 @@
  * `test/unit/comark.test.ts` asserts directly with no Nuxt build in the way.
  * The `*_MARKDOWN` half is the document the raw route serves, body plus the
  * frontmatter and `## Sitemap` footer `runtime/server/routes/raw.ts` wraps it
- * in.
+ * in. The homepage twin additionally carries the fixture's discovery registry
+ * as a resources block, so it is the one document pinned per suite rather
+ * than shared.
  */
 
 export const SITE_URL = 'https://basic.example.com'
@@ -86,7 +88,7 @@ const label = 'Badge'
  * so a change to the envelope fails every suite at once, loudly, instead of
  * being copied into four literals.
  */
-function rawDocument(page: { title: string, description: string, path: string }, body: string): string {
+function rawDocument(page: { title: string, description: string, path: string }, body: string, resources: string[] = []): string {
   const frontmatter = [
     '---',
     `title: ${JSON.stringify(page.title)}`,
@@ -96,14 +98,46 @@ function rawDocument(page: { title: string, description: string, path: string },
     ''
   ].join('\n')
 
-  return `${frontmatter}${body}\n\n## Sitemap\n\nSee the full [sitemap](${SITE_URL}/sitemap.md) for all pages.\n`
+  const block = resources.length ? `\n## Resources for Agents\n\n${resources.join('\n')}\n` : ''
+
+  return `${frontmatter}${body}${block}\n\n## Sitemap\n\nSee the full [sitemap](${SITE_URL}/sitemap.md) for all pages.\n`
 }
+
+/**
+ * The discovery registry each fixture advertises on `/`. `basic` runs the
+ * sitemap module, an MCP card and skills; the source fixtures run none of
+ * them, so the two lists differ by module config, not content backend.
+ */
+export const INDEX_RESOURCES = [
+  `- [API catalog: every service document this site publishes](${SITE_URL}/.well-known/api-catalog)`,
+  `- [Sitemap (XML)](${SITE_URL}/sitemap.xml)`,
+  `- [Sitemap (Markdown): every page on the site](${SITE_URL}/sitemap.md)`,
+  `- [MCP server card: MCP endpoint at ${SITE_URL}/mcp](${SITE_URL}/.well-known/mcp/server-card.json)`,
+  `- [MCP endpoint (streamable HTTP)](${SITE_URL}/mcp)`,
+  `- [llms.txt: index of the documentation for LLMs](${SITE_URL}/llms.txt)`,
+  `- [llms-full.txt: the full documentation as a single file](${SITE_URL}/llms-full.txt)`,
+  `- [Agent skills index: every skill published by this site](${SITE_URL}/.well-known/skills/index.json)`,
+  `- [Agent skill: basic-site](${SITE_URL}/.well-known/skills/basic-site/SKILL.md)`
+]
+
+export const SOURCE_INDEX_RESOURCES = [
+  `- [API catalog: every service document this site publishes](${SITE_URL}/.well-known/api-catalog)`,
+  `- [Sitemap (Markdown): every page on the site](${SITE_URL}/sitemap.md)`,
+  `- [llms.txt: index of the documentation for LLMs](${SITE_URL}/llms.txt)`,
+  `- [llms-full.txt: the full documentation as a single file](${SITE_URL}/llms-full.txt)`
+]
 
 export const INDEX_MARKDOWN = rawDocument({
   title: 'Basic',
   description: 'Fixture site for the nuxt-agent-discovery e2e tests.',
   path: ''
-}, INDEX_BODY)
+}, INDEX_BODY, INDEX_RESOURCES)
+
+export const SOURCE_INDEX_MARKDOWN = rawDocument({
+  title: 'Basic',
+  description: 'Fixture site for the nuxt-agent-discovery e2e tests.',
+  path: ''
+}, INDEX_BODY, SOURCE_INDEX_RESOURCES)
 
 export const GETTING_STARTED_MARKDOWN = rawDocument({
   title: 'Getting Started',

--- a/test/e2e/landing.test.ts
+++ b/test/e2e/landing.test.ts
@@ -68,6 +68,33 @@ describe('generated /raw/index.md', () => {
     expect(link).toContain(`<${SITE_URL}>; rel="alternate"; type="text/html"`)
   })
 
+  it('serves the whole generated document, byte for byte', async () => {
+    // Pinned exactly: the adapter-served `/` carries a resources block of its
+    // own, and this branch must not move with it.
+    const body = await (await fetch('/raw/index.md')).text()
+
+    expect(body).toBe(`---
+title: "Landing: A Vue Landing Page"
+description: "Metadata that lives in the app, not in a document."
+canonical_url: "${SITE_URL}"
+---
+# Landing: A Vue Landing Page
+
+> Metadata that lives in the app, not in a document.
+
+A Vue landing page, with no content document behind it.
+
+## Resources for Agents
+
+- [API catalog: every service document this site publishes](${SITE_URL}/.well-known/api-catalog)
+- [Sitemap (Markdown): every page on the site](${SITE_URL}/sitemap.md)
+- [llms.txt: index of the documentation for LLMs](${SITE_URL}/llms.txt)
+
+Every page on this site is available as raw markdown: append \`.md\` to its
+URL or send \`Accept: text/markdown\`.
+`)
+  })
+
   it('is what `llms.txt` links to for the homepage', async () => {
     const body = await (await fetch('/llms.txt')).text()
 

--- a/test/e2e/shared.ts
+++ b/test/e2e/shared.ts
@@ -30,8 +30,12 @@ import {
  * `robots.txt` handoff (which differs by design depending on whether
  * `@nuxtjs/robots` is installed), and the highlighter `<style>` stripping
  * (only `@nuxt/content` produces that node).
+ *
+ * `indexMarkdown` is the one parameterized document: the homepage twin renders
+ * the fixture's own discovery registry as a resources block, and the suites
+ * run different module sets.
  */
-export function describeSharedDocuments(): void {
+export function describeSharedDocuments(indexMarkdown: string = INDEX_MARKDOWN): void {
   describe('content negotiation', () => {
     it('serves markdown for an explicit `Accept: text/markdown`', async () => {
       const response = await fetch('/docs/getting-started', { headers: { Accept: 'text/markdown' } })
@@ -85,7 +89,7 @@ export function describeSharedDocuments(): void {
 
       expect(response.status).toBe(200)
       expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
-      expect(await response.text()).toBe(INDEX_MARKDOWN)
+      expect(await response.text()).toBe(indexMarkdown)
     })
 
     it('appends the related links a page declares in frontmatter', async () => {

--- a/test/fixtures/basic/server/routes/agent-pages.json.get.ts
+++ b/test/fixtures/basic/server/routes/agent-pages.json.get.ts
@@ -9,6 +9,8 @@ import { getAgentDocument, listAgentPages } from '#agent-discovery'
 export default defineEventHandler(async (event) => {
   const sectioned = await getAgentDocument(event, '/docs/components/badge', { sections: ['Usage'] })
   const missing = await getAgentDocument(event, '/docs/components/badge', { sections: ['Nowhere'] })
+  // `/` through the helper, compared byte for byte against the raw route.
+  const index = await getAgentDocument(event, '/')
 
   return {
     all: (await listAgentPages(event)).map(page => page.route),
@@ -20,6 +22,7 @@ export default defineEventHandler(async (event) => {
     combined: (await listAgentPages(event, { prefix: '/docs/', search: 'badge' })).map(page => page.route),
     entry: (await listAgentPages(event, { search: 'badge' }))[0],
     sectioned: sectioned && 'markdown' in sectioned ? sectioned.markdown : null,
-    unmatchedSections: missing && 'markdown' in missing ? missing.markdown : null
+    unmatchedSections: missing && 'markdown' in missing ? missing.markdown : null,
+    index: index && 'markdown' in index ? index.markdown : null
   }
 })

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -60,3 +60,116 @@ describe('getAgentDocument: excluded prefixes', () => {
     await expect(getAgentDocument(event, '/docs/5%2Ex/foo')).resolves.toBeNull()
   })
 })
+
+describe('getAgentDocument: homepage', () => {
+  const configure = (links: { href: string, rel: string, title?: string }[]) => setRuntimeConfig({
+    agentDiscovery: {
+      siteUrl: 'https://example.com',
+      rawPrefix: '/raw',
+      routes: [{ path: '/', raw: '/raw/index.md' }, { path: '/**' }],
+      excludePrefixes: [],
+      links
+    }
+  })
+
+  beforeEach(() => {
+    configure([
+      { href: '/sitemap.md', rel: 'sitemap', title: 'Sitemap (Markdown): every page on the site' },
+      { href: '/llms.txt', rel: 'describedby', title: 'llms.txt: index of the documentation for LLMs' },
+      { href: '/', rel: 'alternate' }
+    ])
+  })
+
+  it('appends the resources block between the body and the sitemap footer', async () => {
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '# Home\n\nWelcome.\n' } : null
+      }
+    })
+
+    await expect(getAgentDocument(event, '/')).resolves.toMatchObject({
+      markdown: `---
+title: "Home"
+canonical_url: "https://example.com"
+---
+# Home
+
+Welcome.
+
+## Resources for Agents
+
+- [Sitemap (Markdown): every page on the site](https://example.com/sitemap.md)
+- [llms.txt: index of the documentation for LLMs](https://example.com/llms.txt)
+
+
+## Sitemap
+
+See the full [sitemap](https://example.com/sitemap.md) for all pages.
+`
+    })
+  })
+
+  it('leaves every other page without the block', async () => {
+    setAgentContentSource({
+      async get(route) {
+        return { title: route.slice(1), markdown: `# ${route.slice(1)}\n` }
+      }
+    })
+
+    const document = await getAgentDocument(event, '/docs/foo') as { markdown: string }
+
+    expect(document.markdown).not.toContain('Resources for Agents')
+  })
+
+  it('leaves an empty body empty rather than serving a headless block', async () => {
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '' } : null
+      }
+    })
+
+    await expect(getAgentDocument(event, '/')).resolves.toMatchObject({
+      markdown: '---\ntitle: "Home"\ncanonical_url: "https://example.com"\n---\n\n\n## Sitemap\n\nSee the full [sitemap](https://example.com/sitemap.md) for all pages.\n'
+    })
+  })
+
+  it('leaves the document alone when the registry has no titled links', async () => {
+    configure([{ href: '/', rel: 'alternate' }])
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '# Home\n\nWelcome.\n' } : null
+      }
+    })
+
+    await expect(getAgentDocument(event, '/')).resolves.toMatchObject({
+      markdown: '---\ntitle: "Home"\ncanonical_url: "https://example.com"\n---\n# Home\n\nWelcome.\n\n'
+    })
+  })
+
+  it('generates the landing page when the adapter has no `/` entry, byte for byte', async () => {
+    // Pinned exactly: the adapter-served `/` carries a resources block of its
+    // own, and this branch must not move with it.
+    setAgentContentSource({
+      async get() {
+        return null
+      }
+    })
+
+    await expect(getAgentDocument(event, '/')).resolves.toMatchObject({
+      markdown: `---
+title: "example.com"
+canonical_url: "https://example.com"
+---
+# example.com
+
+## Resources for Agents
+
+- [Sitemap (Markdown): every page on the site](https://example.com/sitemap.md)
+- [llms.txt: index of the documentation for LLMs](https://example.com/llms.txt)
+
+Every page on this site is available as raw markdown: append \`.md\` to its
+URL or send \`Accept: text/markdown\`.
+`
+    })
+  })
+})


### PR DESCRIPTION
A site with a real `/` document in its content source now gets the same `## Resources for Agents` block on `/raw/index.md` and inside `llms-full.txt` that the generated landing page already carries. Until now only the hook path had it, so a Docus-style site with a `content/index.md` served a homepage twin with no discovery links.

- `appendAgentResources()` in `document.ts`, shared by `getAgentDocument` and the `llms:generate:full` builder so the two stay byte for byte identical. An empty body stays empty so a placeholder `/` entry keeps contributing nothing to `llms-full.txt`.
- adapter routes in the `llms-full.txt` builder go through `normalizeAgentRoute` like `listAgentPages` does, so a source listing its homepage as `/index` lands on the same `/` the landing-page check and the append key on.
- README and the migration skill now recommend a `/` document over the `agent-discovery:index` hook for homepage prose, and say the module appends the block itself so `renderAgentResources()` is for pages rendered by hand.

Neither nuxt.com nor the nuxt/ui docs change bytes: both sit behind an `index.yml` and keep taking the generated path.

Tests pin the homepage twin per fixture (`basic`, `comark`, `custom-source`, `landing`) and compare `/raw/index.md`, `getAgentDocument(event, '/')` and the `llms-full.txt` entry against each other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Homepage and full-document outputs now include an **“Resources for Agents”** section alongside sitemap content.
  - Homepage content retrieved from configured sources is preserved and enriched with agent resources.
  - Raw homepage responses and agent tooling responses now consistently expose the complete homepage document.

- **Documentation**
  - Clarified homepage rendering behavior and guidance for manually rendered pages, content documents, and discovery metadata hooks.

- **Tests**
  - Added coverage for homepage content, resource sections, raw documents, and full-document output across supported content sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->