### PR TITLE
fix(prerender): hint each page's raw twin from its own response

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default defineNuxtConfig({
 
 `/llms.txt` and `/llms-full.txt` belong to `nuxt-llms`; this module feeds them but never registers them.
 
-With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered, and the `nuxt-llms` bridge hands Nitro's crawler every twin `llms.txt` links. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is skipped by both, so it keeps answering per request instead of being frozen at build.
+With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered, every prerendered page hands Nitro's crawler its own twin, and the `nuxt-llms` bridge hands it every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is skipped by both, so it keeps answering per request instead of being frozen at build.
 
 ### The raw route
 

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -1,7 +1,7 @@
 import { appendResponseHeader, createError, defineEventHandler, getRequestHeader, sendRedirect, setResponseHeader, setResponseStatus } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
-import { isNegotiablePath, negotiatedRawPath, normalizePathname, notAcceptable, ruleMatchesPath, MARKDOWN_VARY } from '../../shared/negotiation'
+import { isNegotiablePath, negotiatedRawPath, normalizePathname, notAcceptable, prerenderTwin, ruleMatchesPath, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
  * Serves markdown through content negotiation on the Nitro server.
@@ -19,6 +19,13 @@ import { isNegotiablePath, negotiatedRawPath, normalizePathname, notAcceptable, 
  */
 export default defineEventHandler(async (event) => {
   if (import.meta.prerender) {
+    // Nothing negotiates at build, but every page rendered here has a twin
+    // the crawler cannot find on its own: `.md` links are not followed, and
+    // the header is only read off HTML responses, so this one is the place.
+    const twin = prerenderTwin(useAgentDiscoveryConfig(event), event.path)
+    if (twin) {
+      appendResponseHeader(event, 'x-nitro-prerender', twin)
+    }
     return
   }
 

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -371,6 +371,28 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
 }
 
 /**
+ * The twin a page hands Nitro's prerender crawler while it is being rendered:
+ * the raw destination of a negotiable path, or `undefined` for a URL with a
+ * single representation and for a twin the site serves with a handler of its
+ * own, which prerendering would freeze at build.
+ *
+ * Emitted from the page's own HTML response, because that is the only kind
+ * Nitro reads `x-nitro-prerender` from: the hint the llms bridge attaches to
+ * `/llms.txt` is dropped with the rest of a `text/plain` response, and `/` is
+ * not prerendered on every site (a locale-prefixed one starts at `/en`). A
+ * twin is prerendered exactly when its page is, whatever the crawl order.
+ */
+export function prerenderTwin(config: NegotiationConfig, path: string): string | undefined {
+  const pathname = normalizePathname(path)
+  const route = negotiableRoute(config, pathname)
+  if (!route) {
+    return undefined
+  }
+  const raw = rawDestination(config, route, pathname)
+  return config.ownRawRoutes?.includes(raw) ? undefined : raw
+}
+
+/**
  * The route a path negotiates through, whatever the client asked for.
  * `undefined` when the URL has a single representation: the raw prefix itself,
  * an excluded prefix, a dotted asset (`_payload.json`, images), or a path no

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -1,6 +1,8 @@
+import { existsSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { fetch, setup } from '@nuxt/test-utils/e2e'
+import { fetch, setup, useTestContext } from '@nuxt/test-utils/e2e'
 import { vercelMarkdownRoutes } from '../../src/presets/vercel'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
 import { CLAUDE_BOT, MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY } from './expected'
@@ -187,5 +189,24 @@ describe('openapi operation ids', () => {
 
     expect(doc.paths).not.toHaveProperty(['/mcp'])
     expect(doc.paths).not.toHaveProperty(['/.well-known/mcp/server-card.json'])
+  })
+})
+
+describe('prerender', () => {
+  // `@nuxt/test-utils` builds under a random `.nuxt/test/<id>/output`.
+  const built = (path: string) => existsSync(join(useTestContext().nuxt!.options.nitro.output!.dir!, 'public', path))
+
+  it('prerenders the twin of every prerendered page', () => {
+    // A locale-prefixed site never renders `/`, and Nitro drops the hint the
+    // llms bridge puts on `/llms.txt` with the rest of a `text/plain`
+    // response, so the page's own HTML response is what carries its twin.
+    expect(built('/en/docs/getting-started/index.html') || built('/en/docs/getting-started.html')).toBe(true)
+    expect(built('/raw/en/docs/getting-started.md')).toBe(true)
+    expect(built('/raw/en/docs/components/button.md')).toBe(true)
+  })
+
+  it('leaves the twin of a request-time page to request time', () => {
+    expect(built('/fr/docs/getting-started/index.html') || built('/fr/docs/getting-started.html')).toBe(false)
+    expect(built('/raw/fr/docs/getting-started.md')).toBe(false)
   })
 })

--- a/test/fixtures/i18n/nuxt.config.ts
+++ b/test/fixtures/i18n/nuxt.config.ts
@@ -2,6 +2,14 @@ export default defineNuxtConfig({
   modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms'],
   devtools: { enabled: false },
   compatibilityDate: '2026-01-01',
+  // Two pages prerendered, the French ones left to request time. `/` is not
+  // prerendered here, so nothing ever flushes the llms bridge's crawler hint:
+  // the twins below reach the build through the pages' own responses.
+  nitro: {
+    prerender: {
+      routes: ['/en/docs/getting-started', '/en/docs/components/button']
+    }
+  },
   agentDiscovery: {
     siteName: 'i18n',
     // One wildcard segment covers every locale, so the generated CDN route

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -11,6 +11,7 @@ import {
   hasCdnLinkPair,
   hasFileExtension,
   isNegotiablePath,
+  prerenderTwin,
   matchRoute,
   negotiatedRawPath,
   normalizeAgentRoute,
@@ -473,6 +474,35 @@ describe('isNegotiablePath', () => {
     expect(isNegotiablePath(config, '/api/x')).toBe(false)
     expect(isNegotiablePath(config, '/_nuxt/entry.js')).toBe(false)
     expect(isNegotiablePath(config, '/blog/post')).toBe(false)
+  })
+})
+
+describe('prerenderTwin', () => {
+  it('hands the crawler the twin of the page being rendered', () => {
+    expect(prerenderTwin(config, '/docs/guide')).toBe('/raw/docs/guide.md')
+    expect(prerenderTwin(config, '/docs/guide/')).toBe('/raw/docs/guide.md')
+    expect(prerenderTwin(config, '/')).toBe('/raw/index.md')
+  })
+
+  it('hints nothing for a single-representation URL', () => {
+    expect(prerenderTwin(config, '/llms.txt')).toBeUndefined()
+    expect(prerenderTwin(config, '/docs/guide.md')).toBeUndefined()
+    expect(prerenderTwin(config, '/raw/docs/guide.md')).toBeUndefined()
+    expect(prerenderTwin(config, '/docs/guide/_payload.json')).toBeUndefined()
+    expect(prerenderTwin(config, '/api/x')).toBeUndefined()
+    expect(prerenderTwin(config, '/blog/post')).toBeUndefined()
+  })
+
+  it('leaves a twin the site serves itself to its handler', () => {
+    // Prerendering it would freeze live data at build: the same skip the
+    // module applies to exact routes and the llms bridge to its own hints.
+    const owned = createConfig({
+      routes: [{ path: '/modules', raw: '/raw/modules.md' }, { path: '/docs/**' }],
+      ownRawRoutes: ['/raw/modules.md']
+    })
+
+    expect(prerenderTwin(owned, '/modules')).toBeUndefined()
+    expect(prerenderTwin(owned, '/docs/guide')).toBe('/raw/docs/guide.md')
   })
 })
 


### PR DESCRIPTION
## Summary

Every page rendered during prerender now hands Nitro's crawler its own raw markdown twin through `x-nitro-prerender`, from the negotiation middleware's prerender branch.

The llms bridge already collected every twin `llms.txt` links and flushed them on `/` and `/llms.txt`. That never reached the crawler on a locale-prefixed site: Nitro only reads `x-nitro-prerender` off HTML responses (`extractLinks` runs for implicit HTML or `.html` routes), so the flush on `/llms.txt` goes out with a `text/plain` response and is dropped, and `/` is not in the prerender queue when the site starts at `/en` and `/fr`. Docus i18n builds ended up with no twin prerendered at all (13 `.md` files instead of 53), which is where this came from.

## Changes

- `prerenderTwin()` in the shared negotiation helpers: the raw destination of a negotiable path, `undefined` for a single-representation URL and for a twin the site serves with its own handler (`ownRawRoutes`), the same skip the exact-route prerender and the llms hints apply
- the middleware appends it to `x-nitro-prerender` during prerender instead of returning straight away, so a twin is prerendered exactly when its page is, whatever the crawl order and whether `llms.txt` exists
- the llms bridge flush stays as is, it still covers the twins of pages that are never rendered as HTML when `/` is prerendered

## Tests

- unit: `prerenderTwin` for pages, single-representation URLs and site-owned twins
- e2e (`i18n`): the fixture prerenders two English pages, the build has to contain their twins and no French one. `/` is not prerendered in that fixture, so nothing flushes the llms hint there and the assertion holds only through the page's own response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Prerendered pages now generate corresponding Markdown “twins” for raw-content access.
  - The prerendering process identifies linked Markdown twins from `llms.txt` when the homepage is prerendered.
  - Pages without prerendering continue to avoid generating HTML or Markdown output during the build.

- **Documentation**
  - Updated deployment guidance to explain prerendered page and Markdown-twin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->