### PR TITLE
fix(prerender): skip site-owned, redirecting and missing twins

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default defineNuxtConfig({
 
 `/llms.txt` and `/llms-full.txt` belong to `nuxt-llms`; this module feeds them but never registers them.
 
-With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered, every prerendered page hands Nitro's crawler its own twin, and the `nuxt-llms` bridge hands it every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is skipped by both, so it keeps answering per request instead of being frozen at build.
+With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered, and the `nuxt-llms` bridge hands Nitro's crawler every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. Whatever the source, every prerendered page hands the crawler its own twin, so a twin is frozen exactly when its page is. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is never prerendered, so it keeps answering per request instead of being frozen at build. A hinted twin the raw route cannot answer as markdown, a section redirecting to its first document or a page with no document behind it, is skipped rather than written or reported as a failed route.
 
 ### The raw route
 
@@ -129,7 +129,7 @@ canonical_url: "https://example.com/docs/getting-started"
 ---
 ```
 
-Then the page markdown, with every same-origin link absolutized. On `/` the discovery registry follows the body as a `## Resources for Agents` block, the same block the generated landing page carries. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
+Then the page markdown, with every same-origin link absolutized. On `/` the discovery registry follows the body as a `## Resources for Agents` block, the same block the generated landing page carries, unless the body already has that heading. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
 
 A path naming a section rather than a page redirects 302 to the section's first document when the adapter implements `firstLeaf()`. Anything else missing answers a real 404 with the markdown error body, so an agent can tell an unknown URL from an empty one. `/` is the exception: with no `/` entry in the adapter, `/raw/index.md` falls through to a generated landing page, see [`agent-discovery:index`](#extending). The recommended way to author the agent homepage is a `/` document in the content source: the module wraps it with the resources block and the sitemap footer, and the generated page is the fallback for sites that have none.
 

--- a/skills/migrate-to-nuxt-agent-discovery/SKILL.md
+++ b/skills/migrate-to-nuxt-agent-discovery/SKILL.md
@@ -124,7 +124,7 @@ export default defineNitroPlugin((nitroApp) => {
 
 Three helpers replace hand-written equivalents:
 
-- `renderAgentResources(event)` renders the discovery registry as a markdown block, for a page the site renders by hand. The module appends it to the `/` document itself, so a `/` document must not render it again.
+- `renderAgentResources(event)` renders the discovery registry as a markdown block, for a page the site renders by hand. The module appends it to the `/` document itself and leaves a body that already carries the heading alone, so a `/` document has no reason to render it.
 - `agentDiscoveryOpenApi(event)` returns the discovery layer as OpenAPI fragments. Spread the site's own paths last so they win.
 - `rawUrl(event, href)` resolves a page URL to its markdown twin from the same route config, for links the site builds itself inside `llms:generate` hooks.
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, statSync } from 'node:fs'
 import {
   addImports,
   addTypeTemplate,
@@ -21,7 +21,7 @@ import { isValidRel } from './rels'
 import { scanSkills } from './skills'
 import { disableContentRawMarkdown, dropContentLlmsFeature, resolveContentSource } from './build/content'
 import { setupVercelPreset } from './presets/vercel'
-import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
+import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, siteServesRaw, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleHooks as RobotsModuleHooks } from '@nuxtjs/robots'
 import type { AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
@@ -917,52 +917,75 @@ export {}
 
     /* ------------------------------ prerender ------------------------------ */
 
-    // Whether a registered handler's route pattern covers a path, the way
-    // Nitro's router reads it: `:name` and `*` match one segment, `**` the
-    // rest. An exact string compare read `/raw/:name` as not owning the twin
-    // it serves, and the prerender froze it anyway.
-    const handlerRouteMatches = (pattern: string, path: string): boolean => {
-      if (!/[:*]/.test(pattern)) {
-        return pattern === path
+    // The route patterns of every handler the site serves under the raw
+    // prefix, read the way Nitro registers them: one a module registered
+    // (this module's own `${rawPrefix}/**` handler excepted, or every twin
+    // would read as site-owned and nothing would prerender), or a scanned
+    // `server/routes` file, which never reaches `serverHandlers` and is mapped
+    // from its filename the way Nitro maps it (`raw/[...slug].md.get.ts` →
+    // `/raw/**:slug.md`) in every layer's server dir, since a layer's routes
+    // are scanned like the root's. Patterns rather than paths, because a page
+    // matched by a wildcard route has no build-time list of twins: the
+    // runtime asks `siteServesRaw()` per path instead.
+    const rawSegments = rawPrefix.split('/').filter(Boolean)
+    const coversRawPrefix = (pattern: string): boolean => {
+      const segments: string[] = []
+      for (const segment of pattern.split('/').filter(Boolean)) {
+        if (/[:*]/.test(segment)) {
+          break
+        }
+        segments.push(segment)
       }
-      const patternSegments = pattern.split('/').filter(Boolean)
-      const pathSegments = path.split('/').filter(Boolean)
-      for (const [index, segment] of patternSegments.entries()) {
-        if (segment.startsWith('**')) {
-          return true
-        }
-        if (index >= pathSegments.length) {
-          return false
-        }
-        if (segment !== '*' && !segment.startsWith(':') && segment !== pathSegments[index]) {
-          return false
-        }
-      }
-      return patternSegments.length === pathSegments.length
+      return segments.slice(0, rawSegments.length).every((segment, index) => segment === rawSegments[index])
     }
-
-    // Whether the site answers a route with a handler of its own: one a
-    // module registered (this module's own `${rawPrefix}/**` handler excepted,
-    // or every twin would read as site-owned and nothing would prerender), or
-    // a scanned `server/routes` file, which never reaches `serverHandlers`
-    // and is looked up on disk the way Nitro maps it (`/raw/modules.md` →
-    // `server/routes/raw/modules.md.get.ts`) in every layer's server dir,
-    // since a layer's routes are scanned like the root's.
-    const siteServesRoute = (route: string): boolean => {
-      if (nuxt.options.serverHandlers.some(handler =>
-        handler.handler !== rawHandler && handler.route && handlerRouteMatches(handler.route, route))) {
-        return true
+    const scannedRawRoutes = (serverDir: string): string[] => {
+      const dir = join(serverDir, 'routes', ...rawSegments)
+      if (!existsSync(dir)) {
+        return []
+      }
+      const patterns: string[] = []
+      for (const file of readdirSync(dir, { recursive: true }) as string[]) {
+        if (!/\.(?:js|mjs|cjs|ts|mts|cts|tsx|jsx)$/.test(file) || !statSync(join(dir, file)).isFile()) {
+          continue
+        }
+        let route = file
+          .replace(/\\/g, '/')
+          .replace(/\.[a-z]+$/i, '')
+          .replace(/\(([^(/]+)\)\//g, '')
+          .replace(/\[\.{3}\]/g, '**')
+          .replace(/\[\.{3}(\w+)\]/g, '**:$1')
+          .replace(/\[([^/\]]+)\]/g, ':$1')
+        const suffix = route.match(/(\.(?<method>connect|delete|get|head|options|patch|post|put|trace))?(\.(?<env>dev|prod|prerender))?$/)
+        if (suffix?.index !== undefined && suffix[0]) {
+          route = route.slice(0, suffix.index)
+        }
+        const method = suffix?.groups?.method
+        if (method && method !== 'get' && method !== 'head') {
+          continue
+        }
+        route = route.replace(/\/index$/, '')
+        patterns.push(withoutTrailingSlash(`${rawPrefix}/${route}`))
+      }
+      return patterns
+    }
+    const siteRawRoutes = (): string[] => {
+      const patterns = new Set<string>()
+      for (const handler of nuxt.options.serverHandlers) {
+        if (handler.handler !== rawHandler && handler.route && coversRawPrefix(handler.route)) {
+          patterns.add(handler.route)
+        }
       }
       const layers = nuxt.options._layers || []
       const serverDirs = new Set([
         (nuxt.options as { serverDir?: string }).serverDir || join(nuxt.options.srcDir, 'server'),
         ...layers.map(layer => layer.config?.serverDir || join(layer.cwd, 'server'))
       ])
-      return [...serverDirs].some((dir) => {
-        const base = join(dir, 'routes', ...route.slice(1).split('/'))
-        return ['', '.get', '.head'].some(method =>
-          ['.ts', '.js', '.mjs', '.cjs'].some(extension => existsSync(`${base}${method}${extension}`)))
-      })
+      for (const serverDir of serverDirs) {
+        for (const pattern of scannedRawRoutes(serverDir)) {
+          patterns.add(pattern)
+        }
+      }
+      return [...patterns]
     }
 
     // With a server behind the site, only the built-in source prerenders: a
@@ -973,22 +996,23 @@ export {}
     // At `modules:done`, not here: a twin the site backs with its own handler
     // (an swr route reading a live API) must be left alone, or prerendering
     // freezes it at build, and handlers registered by modules listed later
-    // are not visible yet. The same twins go into `ownRawRoutes` so the llms
-    // bridge skips its crawler hints for them too.
+    // are not visible yet. The same patterns go into `ownRawRoutes` so the
+    // llms bridge and the negotiation middleware skip their crawler hints for
+    // them too.
     const staticBuild = Boolean(nuxt.options.nitro?.static) || (nuxt.options as { _generate?: boolean })._generate === true
+    // The twins this pass queued, which stay build errors when they 404: the
+    // site named those patterns, so a missing document there is a mistake.
+    const queuedRawRoutes = new Set<string>()
     nuxt.hook('modules:done', () => {
-      const ownRawRoutes = routes
-        .filter(route => !route.path.includes('*'))
-        .map(route => rawDestination(config, route, route.path))
-        .filter(raw => siteServesRoute(raw))
-      config.ownRawRoutes = ownRawRoutes
+      config.ownRawRoutes = siteRawRoutes()
 
       if (sourcePath && (builtinContentSource || staticBuild)) {
         for (const route of routes) {
           if (!route.path.includes('*')) {
             const raw = rawDestination(config, route, route.path)
-            if (!ownRawRoutes.includes(raw)) {
+            if (!siteServesRaw(config, raw)) {
               addPrerenderRoutes(raw)
+              queuedRawRoutes.add(raw)
             }
           }
         }
@@ -1018,6 +1042,36 @@ export {}
         // build, after both passes above, and the CDN table is the one output
         // late enough to honour it.
         setupVercelPreset(nitro, config, collectCachedRoutes)
+
+        // Every queued twin passes here before Nitro writes it, whichever of
+        // the exact-route pass, the llms bridge or a page's own hint queued
+        // it. One the site serves itself is never frozen, whatever listed it.
+        // One the raw route could not answer as markdown is dropped rather
+        // than written or reported: a section answers a redirect, whose HTML
+        // body Nitro would otherwise store in place of the 302, and a page
+        // with no document behind it answers 404, which is that page's answer
+        // at runtime too and no reason to fail the build. The twins queued for
+        // exact patterns keep their errors: the site named those.
+        nitro.hooks.hook('prerender:generate', (route) => {
+          if (!isRawPath(config, route.route)) {
+            return
+          }
+          if (siteServesRaw(config, route.route)) {
+            route.skip = true
+            route.error = undefined
+            return
+          }
+          if (route.error) {
+            if (route.error.statusCode === 404 && !queuedRawRoutes.has(route.route)) {
+              route.skip = true
+              route.error = undefined
+            }
+            return
+          }
+          if (!route.contentType?.includes('markdown')) {
+            route.skip = true
+          }
+        })
       })
     }
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -959,8 +959,10 @@ export {}
         if (suffix?.index !== undefined && suffix[0]) {
           route = route.slice(0, suffix.index)
         }
+        // A handler that answers no GET serves no twin, and a `.dev` one does
+        // not exist in the build at all.
         const method = suffix?.groups?.method
-        if (method && method !== 'get' && method !== 'head') {
+        if ((method && method !== 'get' && method !== 'head') || suffix?.groups?.env === 'dev') {
           continue
         }
         route = route.replace(/\/index$/, '')
@@ -971,7 +973,8 @@ export {}
     const siteRawRoutes = (): string[] => {
       const patterns = new Set<string>()
       for (const handler of nuxt.options.serverHandlers) {
-        if (handler.handler !== rawHandler && handler.route && coversRawPrefix(handler.route)) {
+        const answersGet = !handler.method || handler.method === 'get' || handler.method === 'head'
+        if (handler.handler !== rawHandler && handler.route && answersGet && coversRawPrefix(handler.route)) {
           patterns.add(handler.route)
         }
       }

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -22,9 +22,11 @@ export default defineEventHandler(async (event) => {
     // Nothing negotiates at build, but every page rendered here has a twin
     // the crawler cannot find on its own: `.md` links are not followed, and
     // the header is only read off HTML responses, so this one is the place.
+    // Encoded the way Nuxt's `prerenderRoutes()` does, since Nitro splits the
+    // header on commas and decodes each part.
     const twin = prerenderTwin(useAgentDiscoveryConfig(event), event.path)
     if (twin) {
-      appendResponseHeader(event, 'x-nitro-prerender', twin)
+      appendResponseHeader(event, 'x-nitro-prerender', encodeURIComponent(twin))
     }
     return
   }

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -7,7 +7,7 @@ import source from '#agent-discovery/source'
 import type { AgentListEntry, NegotiationConfig } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { appendAgentResources, generatedIndexPage, getSourcePage } from '../utils/document'
-import { hasFileExtension, isExcluded, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination } from '../../shared/negotiation'
+import { hasFileExtension, isExcluded, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination, siteServesRaw } from '../../shared/negotiation'
 
 interface LlmsSection {
   title: string
@@ -77,6 +77,17 @@ async function mapLimit<T, R>(items: T[], task: (item: T) => R | Promise<R>): Pr
   return results
 }
 
+/**
+ * The adapter's listing with every route normalized the way `listAgentPages`
+ * does, so an adapter listing its homepage as `/index` lands on the same `/`
+ * the landing-page checks and the resources append key on, and an encoded
+ * slug meets the exclusion filter decoded. `llms.txt` and `llms-full.txt` go
+ * through this one call, so the two cannot disagree on what a page is.
+ */
+async function listPages(adapter: NonNullable<typeof source>, selector: Record<string, unknown> | undefined, event: H3Event): Promise<AgentListEntry[]> {
+  return ((await adapter.list?.(selector, event)) || []).map(entry => ({ ...entry, route: normalizeAgentRoute(entry.route) }))
+}
+
 function toLink(entry: AgentListEntry, domain: string) {
   return {
     title: entry.title || entry.route,
@@ -130,7 +141,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       // adapter is asked about all of them at once.
       const resolved = await mapLimit(options.sections, section => section.links?.length
         ? null
-        : (adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null))
+        : listPages(adapter, section as unknown as Record<string, unknown>, event))
 
       const unresolved: LlmsSection[] = []
       for (const [index, section] of options.sections.entries()) {
@@ -159,7 +170,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       if (!hasPageLinks) {
         // The same filter `listAgentPages` applies, so the fallback cannot
         // advertise pages `sitemap.md` deliberately hides.
-        const entries = ((await adapter.list?.(undefined, event)) || []).filter(entry => !isExcluded(entry.route, config))
+        const entries = (await listPages(adapter, undefined, event)).filter(entry => !isExcluded(entry.route, config))
         for (const [title, group] of groupBySection(entries)) {
           options.sections.push({
             title,
@@ -212,7 +223,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         // A twin the site serves with its own handler must not reach the
         // crawler: prerendering it freezes live data at build. The link still
         // points there, the handler answers it per request.
-        if (!config.ownRawRoutes?.includes(raw)) {
+        if (!siteServesRaw(config, raw)) {
           prerenderPaths.add(raw)
         }
         return { ...link, href: withBase(raw + suffix, domain) }
@@ -252,13 +263,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // its curation, so its selector must not smuggle in pages the index hides.
     const resolved = await mapLimit(sections, section => section.links?.length
       ? null
-      : (adapter.list?.(section as unknown as Record<string, unknown>, event) ?? null))
+      : listPages(adapter, section as unknown as Record<string, unknown>, event))
     for (const [index, section] of sections.entries()) {
-      // Normalized the way `listAgentPages` does, so an adapter listing its
-      // homepage as `/index` lands on the same `/` the landing-page check
-      // below looks for and the resources append keys on.
       for (const entry of resolved[index] || []) {
-        add(normalizeAgentRoute(entry.route))
+        add(entry.route)
       }
       // A section curating its documentation by hand names it in its links, so
       // the pages behind them are what the full document is. Everything else a
@@ -276,11 +284,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     // documentation, so that site still gets its whole site, as does one with
     // no sections at all.
     if (!routes.length) {
-      for (const entry of (await adapter.list?.(undefined, event)) || []) {
-        const route = normalizeAgentRoute(entry.route)
+      for (const entry of await listPages(adapter, undefined, event)) {
         // The same filter `listAgentPages` applies, matching the index hook.
-        if (!isExcluded(route, config)) {
-          add(route)
+        if (!isExcluded(entry.route, config)) {
+          add(entry.route)
         }
       }
     }
@@ -313,13 +320,17 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     }
   }) as never)
 
-  // Lets Nitro's prerender crawler discover the raw markdown twins the
-  // generated llms.txt links to. `/llms.txt` is always in the prerender
-  // queue, `/` only when the site prerenders it.
+  // Lets Nitro's prerender crawler discover the twins `llms.txt` links to
+  // whose pages are never rendered as HTML; a page that is rendered hands the
+  // crawler its own twin from its response. Flushed on `/` because that is a
+  // response Nitro reads the hint from: it only looks at HTML, so a hint on
+  // `/llms.txt` itself would go out with a `text/plain` response and be
+  // dropped. Encoded per entry the way Nuxt's `prerenderRoutes()` does, since
+  // Nitro splits the header on commas and decodes each part.
   if (emitsPrerenderHints(import.meta.preset)) {
     nitroApp.hooks.hook('beforeResponse', (event) => {
-      if (event.path === '/' || event.path === '/llms.txt') {
-        appendHeader(event, 'x-nitro-prerender', Array.from(prerenderPaths))
+      if (event.path === '/' && prerenderPaths.size) {
+        appendHeader(event, 'x-nitro-prerender', Array.from(prerenderPaths, path => encodeURIComponent(path)))
       }
     })
   }

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -1,6 +1,7 @@
 import type { H3Event } from 'h3'
 import { getRequestURL } from 'h3'
 import { useRuntimeConfig } from '#imports'
+import { AGENT_RESOURCES_HEADING } from '../../shared/defaults'
 import type { AgentContentSource, NegotiationConfig } from '../../shared/types'
 import { absolutizeHref, encodeAgentRoute, hasFileExtension, matchRoute, normalizeAgentRoute, rawDestination } from '../../shared/negotiation'
 
@@ -65,7 +66,7 @@ export function rawUrl(event: H3Event, path: string): string {
 export function renderAgentResources(event: H3Event, options: { heading?: string } = {}): string {
   const config = useAgentDiscoveryConfig(event)
   const siteUrl = getAgentSiteUrl(event)
-  const heading = options.heading ?? 'Resources for Agents'
+  const heading = options.heading ?? AGENT_RESOURCES_HEADING
 
   const lines = config.links
     .filter(link => link.title)

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -120,11 +120,13 @@ export function appendAgentResources(event: H3Event, markdown: string): string {
   return resources ? `${markdown.replace(/\n*$/, '\n\n')}${resources}` : markdown
 }
 
-const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}[ \\t]*#*[ \\t]*$`)
-const CODE_FENCE = /^[ \t]*(`{3,}|~{3,})/
+// CommonMark: up to three spaces of indentation on a heading or a fence, four
+// make an indented code block; a closing `#` run needs a space before it.
+const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^ {0,3}#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}(?:[ \\t]+#+)?[ \\t]*$`)
+const CODE_FENCE = /^ {0,3}(`{3,}|~{3,})/
 // A closing fence carries no info string, so a line opening a fence of the
 // same kind inside a block is content, not its end.
-const CLOSING_CODE_FENCE = /^[ \t]*(`{3,}|~{3,})[ \t]*$/
+const CLOSING_CODE_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 
 /**
  * Whether the body carries the heading outside a fenced code block: a page

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -132,7 +132,7 @@ const CLOSING_CODE_FENCE = /^[ \t]*(`{3,}|~{3,})[ \t]*$/
  */
 function hasAgentResourcesHeading(markdown: string): boolean {
   let fence: string | undefined
-  for (const line of markdown.split('\n')) {
+  for (const line of markdown.split(/\r?\n/)) {
     if (fence) {
       const closing = CLOSING_CODE_FENCE.exec(line)?.[1]
       if (closing && closing[0] === fence[0] && closing.length >= fence.length) {

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -142,9 +142,11 @@ function hasAgentResourcesHeading(markdown: string): boolean {
       }
       continue
     }
-    const marker = CODE_FENCE.exec(line)?.[1]
-    if (marker) {
-      fence = marker
+    const opening = CODE_FENCE.exec(line)
+    // A backtick fence's info string may not contain a backtick: such a line
+    // is text, and a tilde fence's may.
+    if (opening && !(opening[1]!.startsWith('`') && line.slice(opening[0].length).includes('`'))) {
+      fence = opening[1]
       continue
     }
     if (AGENT_RESOURCES_HEADING_LINE.test(line)) {

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -2,6 +2,7 @@ import type { H3Event } from 'h3'
 import { useNitroApp } from 'nitropack/runtime'
 import source from '#agent-discovery/source'
 import { getAgentSiteUrl, renderAgentResources, useAgentDiscoveryConfig } from './agent-discovery'
+import { AGENT_RESOURCES_HEADING } from '../../shared/defaults'
 import { extractSections } from '../../shared/sections'
 import { absolutizeMarkdownLinks, encodeAgentRoute, isExcluded, normalizeAgentRoute } from '../../shared/negotiation'
 import type { AgentIndex, AgentPage } from '../../shared/types'
@@ -106,16 +107,20 @@ export async function generatedIndexPage(event: H3Event): Promise<AgentPage> {
  * The `/` body with the discovery resources appended, shared by
  * `getAgentDocument` and the `llms-full.txt` builder so the homepage reads
  * identically wherever it is served. An empty body stays empty, so a
- * placeholder `/` entry keeps contributing nothing to `llms-full.txt`, and a
- * registry with no titled links leaves the body alone.
+ * placeholder `/` entry keeps contributing nothing to `llms-full.txt`, a
+ * registry with no titled links leaves the body alone, and so does a body
+ * already carrying the heading: a homepage that rendered the registry by hand
+ * before the module did is not listed twice.
  */
 export function appendAgentResources(event: H3Event, markdown: string): string {
-  if (!markdown.trim()) {
+  if (!markdown.trim() || AGENT_RESOURCES_HEADING_LINE.test(markdown)) {
     return markdown
   }
   const resources = renderAgentResources(event)
   return resources ? `${markdown.replace(/\n*$/, '\n\n')}${resources}` : markdown
 }
+
+const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}[ \\t]*#*[ \\t]*$`, 'm')
 
 /**
  * Resolves a page route to the exact document `/raw/<path>.md` serves.

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -122,6 +122,9 @@ export function appendAgentResources(event: H3Event, markdown: string): string {
 
 const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}[ \\t]*#*[ \\t]*$`)
 const CODE_FENCE = /^[ \t]*(`{3,}|~{3,})/
+// A closing fence carries no info string, so a line opening a fence of the
+// same kind inside a block is content, not its end.
+const CLOSING_CODE_FENCE = /^[ \t]*(`{3,}|~{3,})[ \t]*$/
 
 /**
  * Whether the body carries the heading outside a fenced code block: a page
@@ -130,13 +133,14 @@ const CODE_FENCE = /^[ \t]*(`{3,}|~{3,})/
 function hasAgentResourcesHeading(markdown: string): boolean {
   let fence: string | undefined
   for (const line of markdown.split('\n')) {
-    const marker = CODE_FENCE.exec(line)?.[1]
     if (fence) {
-      if (marker && marker[0] === fence[0] && marker.length >= fence.length) {
+      const closing = CLOSING_CODE_FENCE.exec(line)?.[1]
+      if (closing && closing[0] === fence[0] && closing.length >= fence.length) {
         fence = undefined
       }
       continue
     }
+    const marker = CODE_FENCE.exec(line)?.[1]
     if (marker) {
       fence = marker
       continue

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -113,14 +113,40 @@ export async function generatedIndexPage(event: H3Event): Promise<AgentPage> {
  * before the module did is not listed twice.
  */
 export function appendAgentResources(event: H3Event, markdown: string): string {
-  if (!markdown.trim() || AGENT_RESOURCES_HEADING_LINE.test(markdown)) {
+  if (!markdown.trim() || hasAgentResourcesHeading(markdown)) {
     return markdown
   }
   const resources = renderAgentResources(event)
   return resources ? `${markdown.replace(/\n*$/, '\n\n')}${resources}` : markdown
 }
 
-const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}[ \\t]*#*[ \\t]*$`, 'm')
+const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}[ \\t]*#*[ \\t]*$`)
+const CODE_FENCE = /^[ \t]*(`{3,}|~{3,})/
+
+/**
+ * Whether the body carries the heading outside a fenced code block: a page
+ * quoting the block it expects has not rendered it.
+ */
+function hasAgentResourcesHeading(markdown: string): boolean {
+  let fence: string | undefined
+  for (const line of markdown.split('\n')) {
+    const marker = CODE_FENCE.exec(line)?.[1]
+    if (fence) {
+      if (marker && marker[0] === fence[0] && marker.length >= fence.length) {
+        fence = undefined
+      }
+      continue
+    }
+    if (marker) {
+      fence = marker
+      continue
+    }
+    if (AGENT_RESOURCES_HEADING_LINE.test(line)) {
+      return true
+    }
+  }
+  return false
+}
 
 /**
  * Resolves a page route to the exact document `/raw/<path>.md` serves.

--- a/src/runtime/shared/defaults.ts
+++ b/src/runtime/shared/defaults.ts
@@ -30,3 +30,6 @@ export const MCP_EXCLUDED_GROUPS = ['admin']
 export function mcpExcludedGroups(extra?: string[]): Set<string> {
   return new Set([...MCP_EXCLUDED_GROUPS, ...(extra || [])])
 }
+
+/** Heading of the discovery registry block on the agent homepage. */
+export const AGENT_RESOURCES_HEADING = 'Resources for Agents'

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -377,10 +377,10 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
  * own, which prerendering would freeze at build.
  *
  * Emitted from the page's own HTML response, because that is the only kind
- * Nitro reads `x-nitro-prerender` from: the hint the llms bridge attaches to
- * `/llms.txt` is dropped with the rest of a `text/plain` response, and `/` is
- * not prerendered on every site (a locale-prefixed one starts at `/en`). A
- * twin is prerendered exactly when its page is, whatever the crawl order.
+ * Nitro reads `x-nitro-prerender` from: a hint on a `text/plain` response is
+ * dropped with the rest of it, and `/` is not prerendered on every site (a
+ * locale-prefixed one starts at `/en`). A twin is prerendered exactly when
+ * its page is, whatever the crawl order.
  */
 export function prerenderTwin(config: NegotiationConfig, path: string): string | undefined {
   const pathname = normalizePathname(path)
@@ -389,7 +389,44 @@ export function prerenderTwin(config: NegotiationConfig, path: string): string |
     return undefined
   }
   const raw = rawDestination(config, route, pathname)
-  return config.ownRawRoutes?.includes(raw) ? undefined : raw
+  return siteServesRaw(config, raw) ? undefined : raw
+}
+
+/**
+ * Whether the site answers a raw twin with a handler of its own, so nothing
+ * may prerender it: not the exact-route pass, not the llms bridge's hints and
+ * not a page's own. The one predicate behind all three, on the handler
+ * patterns `ownRawRoutes` carries, because a page matched by a wildcard route
+ * has no build-time list of twins to compare against.
+ */
+export function siteServesRaw(config: Pick<NegotiationConfig, 'ownRawRoutes'>, raw: string): boolean {
+  return config.ownRawRoutes?.some(pattern => handlerRouteMatches(pattern, raw)) ?? false
+}
+
+/**
+ * Whether a handler's route pattern covers a path, the way Nitro's router
+ * reads it: `:name` and `*` match one segment, `**` the rest. An exact string
+ * compare read `/raw/:name` as not owning the twin it serves, and the
+ * prerender froze it anyway.
+ */
+export function handlerRouteMatches(pattern: string, path: string): boolean {
+  if (!/[:*]/.test(pattern)) {
+    return pattern === path
+  }
+  const patternSegments = pattern.split('/').filter(Boolean)
+  const pathSegments = path.split('/').filter(Boolean)
+  for (const [index, segment] of patternSegments.entries()) {
+    if (segment.startsWith('**')) {
+      return true
+    }
+    if (index >= pathSegments.length) {
+      return false
+    }
+    if (segment !== '*' && !segment.startsWith(':') && segment !== pathSegments[index]) {
+      return false
+    }
+  }
+  return patternSegments.length === pathSegments.length
 }
 
 /**

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -211,9 +211,11 @@ export interface NegotiationConfig {
    */
   notAcceptable: boolean
   /**
-   * Exact-route raw destinations the site serves with a handler of its own.
-   * The prerender pass and the llms bridge's crawler hints skip them, so a
-   * twin backed by live data is never frozen at build.
+   * Route patterns of the handlers the site serves under the raw prefix
+   * itself, as Nitro registers them (`/raw/modules.md`, `/raw/:name.md`,
+   * `/raw/**:slug.md`). The exact-route prerender pass, the llms bridge's
+   * crawler hints and a page's own hint all skip a twin one of them matches,
+   * so a twin backed by live data is never frozen at build.
    */
   ownRawRoutes?: string[]
   /**

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -113,6 +113,8 @@ describe('O(1) route table', () => {
     const config = await resolved()
 
     expect(config.routes.map(route => route.path)).toEqual(['/', '/*/docs/**'])
+    // The twin file the site serves itself, as the pattern Nitro registers.
+    expect(config.ownRawRoutes).toContain('/raw/en/docs/live.md')
     // The fixture ships `en` and `fr`; neither may appear as a pattern.
     expect(config.routes.some(route => /\/(?:en|fr)\//.test(route.path))).toBe(false)
   })
@@ -208,5 +210,40 @@ describe('prerender', () => {
   it('leaves the twin of a request-time page to request time', () => {
     expect(built('/fr/docs/getting-started/index.html') || built('/fr/docs/getting-started.html')).toBe(false)
     expect(built('/raw/fr/docs/getting-started.md')).toBe(false)
+  })
+
+  it('drops the twin of a section instead of storing its redirect as HTML', async () => {
+    // `/en/docs/components` is a Vue page over a directory with no index
+    // document, so its twin answers a 302 to the first document. Nitro reads
+    // a redirect as a success and would write the HTML refresh stub h3 sends
+    // with it, which the static handler then serves in place of the 302.
+    expect(built('/en/docs/components/index.html') || built('/en/docs/components.html')).toBe(true)
+    expect(built('/raw/en/docs/components.md')).toBe(false)
+    expect(built('/raw/en/docs/components.md/index.html')).toBe(false)
+    expect(built('/raw/en/docs/components.md.html')).toBe(false)
+
+    const response = await fetch('/raw/en/docs/components.md', { redirect: 'manual' })
+    expect(response.status).toBe(302)
+    expect(response.headers.get('location')).toBe('/raw/en/docs/components/button.md')
+  })
+
+  it('skips the twin of a page with no document rather than failing the build', async () => {
+    // The fixture builds with `failOnError`, so the 404 this twin answers
+    // would have failed the whole suite had it been reported.
+    expect(built('/en/docs/playground/index.html') || built('/en/docs/playground.html')).toBe(true)
+    expect(built('/raw/en/docs/playground.md')).toBe(false)
+    expect((await fetch('/raw/en/docs/playground.md')).status).toBe(404)
+  })
+
+  it('leaves a twin the site serves itself to its handler, under a wildcard route too', async () => {
+    expect(built('/en/docs/live/index.html') || built('/en/docs/live.html')).toBe(true)
+    expect(built('/raw/en/docs/live.md')).toBe(false)
+
+    const response = await fetch('/raw/en/docs/live.md')
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain('# Live')
+    // Answered by the handler, not off a file: Nitro's asset layer would add
+    // an `ETag`.
+    expect(response.headers.get('etag')).toBe(null)
   })
 })

--- a/test/fixtures/i18n/nuxt.config.ts
+++ b/test/fixtures/i18n/nuxt.config.ts
@@ -2,12 +2,18 @@ export default defineNuxtConfig({
   modules: ['../../../src/module', '@nuxt/content', 'nuxt-llms'],
   devtools: { enabled: false },
   compatibilityDate: '2026-01-01',
-  // Two pages prerendered, the French ones left to request time. `/` is not
-  // prerendered here, so nothing ever flushes the llms bridge's crawler hint:
-  // the twins below reach the build through the pages' own responses.
+  // English pages prerendered, the French ones left to request time. `/` is
+  // not prerendered here, so nothing ever flushes the llms bridge's crawler
+  // hint: the twins reach the build through the pages' own responses. Three
+  // of the pages are Vue pages the content has no document for: a section
+  // (`/en/docs/components`), whose twin redirects, a page with no twin at all
+  // (`/en/docs/playground`), and one whose twin the site serves itself
+  // (`/en/docs/live`). `failOnError` makes the build itself the assertion
+  // that none of those ends up a failed route.
   nitro: {
     prerender: {
-      routes: ['/en/docs/getting-started', '/en/docs/components/button']
+      failOnError: true,
+      routes: ['/en/docs/getting-started', '/en/docs/components/button', '/en/docs/components', '/en/docs/playground', '/en/docs/live']
     }
   },
   agentDiscovery: {

--- a/test/fixtures/i18n/pages/en/docs/components/index.vue
+++ b/test/fixtures/i18n/pages/en/docs/components/index.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+// A section page the app renders itself, over a directory with no index
+// document. Its twin redirects to the section's first document, and the
+// prerender must not store that redirect as an HTML file in place of the 302.
+</script>
+
+<template>
+  <main>
+    <h1>Components</h1>
+    <p>Every component, listed by the app.</p>
+  </main>
+</template>

--- a/test/fixtures/i18n/pages/en/docs/live.vue
+++ b/test/fixtures/i18n/pages/en/docs/live.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+// The page behind a twin the site serves itself, see
+// `server/routes/raw/en/docs/live.md.get.ts`.
+</script>
+
+<template>
+  <main>
+    <h1>Live</h1>
+  </main>
+</template>

--- a/test/fixtures/i18n/pages/en/docs/playground.vue
+++ b/test/fixtures/i18n/pages/en/docs/playground.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+// A page with no document behind it: its twin answers 404, which is the
+// page's answer at runtime too and no reason to fail the build.
+</script>
+
+<template>
+  <main>
+    <h1>Playground</h1>
+  </main>
+</template>

--- a/test/fixtures/i18n/server/routes/raw/en/docs/live.md.get.ts
+++ b/test/fixtures/i18n/server/routes/raw/en/docs/live.md.get.ts
@@ -1,0 +1,10 @@
+/**
+ * A twin the site serves itself, reading data the build cannot freeze. The
+ * page behind it is matched by the wildcard route, so no build-time list of
+ * twins could have skipped it: the module reads this file as the pattern
+ * Nitro registers for it, and the page's own prerender hint leaves it alone.
+ */
+export default defineEventHandler((event) => {
+  setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+  return `# Live\n\nRendered at ${Date.now()}.\n`
+})

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -140,6 +140,19 @@ See the full [sitemap](https://example.com/sitemap.md) for all pages.
     expect(document.markdown).toContain('llms.txt')
   })
 
+  it('reads a fence line with an info string inside a block as content, not its end', async () => {
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '# Home\n\n````md\n```not-a-closing-fence\n## Resources for Agents\n```\n````\n' } : null
+      }
+    })
+
+    const document = await getAgentDocument(event, '/') as { markdown: string }
+
+    expect(document.markdown.match(/Resources for Agents/g)).toHaveLength(2)
+    expect(document.markdown).toContain('llms.txt')
+  })
+
   it('leaves every other page without the block', async () => {
     setAgentContentSource({
       async get(route) {

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -109,6 +109,22 @@ See the full [sitemap](https://example.com/sitemap.md) for all pages.
     })
   })
 
+  it('leaves a body that already carries the heading alone', async () => {
+    // A homepage that rendered the registry by hand before the module did,
+    // through `renderAgentResources()` in a hook or a list typed into
+    // `content/index.md`, is not listed twice.
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '# Home\n\n## Resources for Agents\n\n- [Sitemap](https://example.com/sitemap.md)\n' } : null
+      }
+    })
+
+    const document = await getAgentDocument(event, '/') as { markdown: string }
+
+    expect(document.markdown.match(/Resources for Agents/g)).toHaveLength(1)
+    expect(document.markdown).not.toContain('llms.txt')
+  })
+
   it('leaves every other page without the block', async () => {
     setAgentContentSource({
       async get(route) {

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -125,6 +125,21 @@ See the full [sitemap](https://example.com/sitemap.md) for all pages.
     expect(document.markdown).not.toContain('llms.txt')
   })
 
+  it('still appends when the heading only appears inside a code block', async () => {
+    // A homepage quoting the block it expects, say a page documenting this
+    // module, has not rendered it.
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '# Home\n\n```md\n## Resources for Agents\n\n- [x](https://example.com/x)\n```\n' } : null
+      }
+    })
+
+    const document = await getAgentDocument(event, '/') as { markdown: string }
+
+    expect(document.markdown.match(/Resources for Agents/g)).toHaveLength(2)
+    expect(document.markdown).toContain('llms.txt')
+  })
+
   it('leaves every other page without the block', async () => {
     setAgentContentSource({
       async get(route) {

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -190,6 +190,12 @@ See the full [sitemap](https://example.com/sitemap.md) for all pages.
     // And a four-space line inside a fence closes nothing.
     homepage('# Home\n\n```\n    ```\n## Resources for Agents\n```\n')
     expect(await render()).toContain('llms.txt')
+    // A backtick in a backtick fence's info string makes it text, so the
+    // heading after it is a real one; a tilde fence allows it.
+    homepage('# Home\n\n```js`x\n## Resources for Agents\n\n- [x](https://example.com/x)\n')
+    expect(await render()).not.toContain('llms.txt')
+    homepage('# Home\n\n~~~js`x\n## Resources for Agents\n~~~\n')
+    expect(await render()).toContain('llms.txt')
   })
 
   it('leaves every other page without the block', async () => {

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -168,6 +168,30 @@ See the full [sitemap](https://example.com/sitemap.md) for all pages.
     expect(document.markdown).not.toContain('llms.txt')
   })
 
+  it('reads indentation and closing hashes the way CommonMark does', async () => {
+    const homepage = (markdown: string) => setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown } : null
+      }
+    })
+    const render = async () => (await getAgentDocument(event, '/') as { markdown: string }).markdown
+
+    // Three spaces still make a heading, and so does a closing run of hashes
+    // after a space.
+    homepage('# Home\n\n   ## Resources for Agents ##\n\n- [x](https://example.com/x)\n')
+    expect(await render()).not.toContain('llms.txt')
+    // A hash glued to the text is part of it: not the heading.
+    homepage('# Home\n\n## Resources for Agents#\n')
+    expect(await render()).toContain('llms.txt')
+    // Four spaces make an indented code block, not a fence, so the heading
+    // after it is a real one.
+    homepage('# Home\n\n    ```\n## Resources for Agents\n\n- [x](https://example.com/x)\n    ```\n')
+    expect(await render()).not.toContain('llms.txt')
+    // And a four-space line inside a fence closes nothing.
+    homepage('# Home\n\n```\n    ```\n## Resources for Agents\n```\n')
+    expect(await render()).toContain('llms.txt')
+  })
+
   it('leaves every other page without the block', async () => {
     setAgentContentSource({
       async get(route) {

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -153,6 +153,21 @@ See the full [sitemap](https://example.com/sitemap.md) for all pages.
     expect(document.markdown).toContain('llms.txt')
   })
 
+  it('reads CRLF line endings the same way', async () => {
+    // A fence closed on a `\r\n` line has to close, and a heading ending in
+    // `\r` has to count, or a CRLF homepage gets the block twice.
+    setAgentContentSource({
+      async get(route) {
+        return route === '/' ? { title: 'Home', markdown: '# Home\r\n\r\n```md\r\nquoted\r\n```\r\n\r\n## Resources for Agents\r\n\r\n- [Sitemap](https://example.com/sitemap.md)\r\n' } : null
+      }
+    })
+
+    const document = await getAgentDocument(event, '/') as { markdown: string }
+
+    expect(document.markdown.match(/Resources for Agents/g)).toHaveLength(1)
+    expect(document.markdown).not.toContain('llms.txt')
+  })
+
   it('leaves every other page without the block', async () => {
     setAgentContentSource({
       async get(route) {

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -58,7 +58,7 @@ function createNuxt(routeRules: Record<string, unknown> = {}) {
       build: { templates: [] },
       nitro: {} as { plugins?: string[], alias?: Record<string, string>, static?: boolean },
       alias: {} as Record<string, string>,
-      serverHandlers: [] as { route?: string, handler: string }[],
+      serverHandlers: [] as { route?: string, handler: string, method?: string }[],
       routeRules,
       runtimeConfig: { public: {} } as Record<string, unknown> & { public: Record<string, unknown> }
     }
@@ -800,14 +800,19 @@ describe('module setup: prerender', () => {
     mkdirSync(join(layer, 'server/routes/raw/live'), { recursive: true })
     writeFileSync(join(layer, 'server/routes/raw/live/[...slug].md.get.ts'), 'export default defineEventHandler(() => "")')
     writeFileSync(join(layer, 'server/routes/raw/live/index.post.ts'), 'export default defineEventHandler(() => "")')
+    writeFileSync(join(layer, 'server/routes/raw/live/debug.md.get.dev.ts'), 'export default defineEventHandler(() => "")')
     const nuxt = await runModule({ routes: ['/', '/**'] }, {}, (nuxt) => {
       Object.assign(nuxt.options, { _layers: [{ cwd: rootDir, config: {} }, { cwd: layer, config: {} }] })
+      nuxt.options.serverHandlers.push({ route: '/raw/submit.md', handler: '/site/server/submit.ts', method: 'post' })
     })
     const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
 
     expect(config.ownRawRoutes).toContain('/raw/live/**:slug.md')
-    // A POST handler answers no twin.
+    // A handler answering no GET serves no twin, and a `.dev` file is not in
+    // the build at all.
     expect(config.ownRawRoutes).not.toContain('/raw/live')
+    expect(config.ownRawRoutes).not.toContain('/raw/submit.md')
+    expect(config.ownRawRoutes).not.toContain('/raw/live/debug.md')
     expect(prerenderTwin(config, '/live/status')).toBeUndefined()
     expect(prerenderTwin(config, '/docs/guide')).toBe('/raw/docs/guide.md')
   })

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -7,6 +7,7 @@ import { nuxtCtx } from '@nuxt/kit'
 import module from '../../src/module'
 import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from '../../src/defaults'
 import { vercelMarkdownRoutes } from '../../src/presets/vercel'
+import { prerenderTwin } from '../../src/runtime/shared/negotiation'
 import type { ModuleOptions } from '../../src/module'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
 
@@ -564,7 +565,8 @@ describe('module setup: error handler ordering', () => {
         ...(nitroConfig.errorHandler ? [nitroConfig.errorHandler].flat() : []),
         '/nitropack/runtime/internal/error/prod'
       ]
-    }
+    },
+    hooks: { hook: () => {} }
   })
 
   it('prepends the markdown handler ahead of an existing one', async () => {
@@ -738,7 +740,7 @@ describe('module setup: prerender', () => {
     // The llms bridge skips its crawler hint for the same twin, through the
     // shared config, or the crawler would fetch and freeze it all the same.
     const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
-    expect(config.ownRawRoutes).toEqual(['/raw/modules.md'])
+    expect(config.ownRawRoutes).toContain('/raw/modules.md')
   })
 
   it('detects a scanned `server/routes` file owning the twin', async () => {
@@ -788,6 +790,67 @@ describe('module setup: prerender', () => {
 
     expect(routes.has('/raw/layered.md')).toBe(false)
     expect(routes.has('/raw/index.md')).toBe(true)
+  })
+
+  it('reads a scanned dynamic twin file as the pattern Nitro registers', async () => {
+    // `raw/live/[...slug].md.get.ts` serves every twin under `/raw/live/`, and
+    // the pages behind them are matched by a wildcard route, so no build-time
+    // list of twins exists to skip: the pattern goes to the runtime instead.
+    const layer = mkdtempSync(join(tmpdir(), 'agent-discovery-layer-'))
+    mkdirSync(join(layer, 'server/routes/raw/live'), { recursive: true })
+    writeFileSync(join(layer, 'server/routes/raw/live/[...slug].md.get.ts'), 'export default defineEventHandler(() => "")')
+    writeFileSync(join(layer, 'server/routes/raw/live/index.post.ts'), 'export default defineEventHandler(() => "")')
+    const nuxt = await runModule({ routes: ['/', '/**'] }, {}, (nuxt) => {
+      Object.assign(nuxt.options, { _layers: [{ cwd: rootDir, config: {} }, { cwd: layer, config: {} }] })
+    })
+    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+
+    expect(config.ownRawRoutes).toContain('/raw/live/**:slug.md')
+    // A POST handler answers no twin.
+    expect(config.ownRawRoutes).not.toContain('/raw/live')
+    expect(prerenderTwin(config, '/live/status')).toBeUndefined()
+    expect(prerenderTwin(config, '/docs/guide')).toBe('/raw/docs/guide.md')
+  })
+
+  it('decides per queued twin before Nitro writes it', async () => {
+    type Route = { route: string, contentType?: string, error?: Error & { statusCode: number, statusMessage: string }, skip?: boolean }
+    const failed = (statusCode: number) => Object.assign(new Error(`[${statusCode}]`), { statusCode, statusMessage: '' })
+    const nuxt = await runModule({ routes: [{ path: '/modules', raw: '/raw/modules.md' }, '/', '/**'] }, {}, (nuxt) => {
+      nuxt.options.serverHandlers.push({ route: '/raw/live/**', handler: '/site/server/raw-live.ts' })
+    })
+    const hooks: Record<string, (route: Route) => void> = {}
+    const nitro = {
+      options: { dev: false, static: false, preset: 'node-server', routeRules: {}, runtimeConfig: { agentDiscovery: {} } },
+      hooks: { hook: (name: string, callback: (route: Route) => void) => { hooks[name] = callback } }
+    }
+    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
+    const run = (route: Route) => {
+      hooks['prerender:generate']!(route)
+      return route
+    }
+
+    // A page's twin, answered as markdown: written as it came.
+    expect(run({ route: '/raw/docs/guide.md', contentType: 'text/markdown; charset=utf-8' })).toEqual({ route: '/raw/docs/guide.md', contentType: 'text/markdown; charset=utf-8' })
+    // A section's twin answers a redirect, whose body is HTML: not stored in
+    // place of the 302.
+    expect(run({ route: '/raw/docs.md', contentType: 'text/html' }).skip).toBe(true)
+    // A page with no document behind it: skipped, not a failed route.
+    const missing = run({ route: '/raw/showcase.md', contentType: 'text/markdown; charset=utf-8', error: failed(404) })
+    expect(missing.skip).toBe(true)
+    expect(missing.error).toBeUndefined()
+    // The twin of an exact pattern the site named: a 404 there stays one.
+    const exact = run({ route: '/raw/index.md', contentType: 'text/markdown; charset=utf-8', error: failed(404) })
+    expect(exact.skip).toBeUndefined()
+    expect(exact.error?.statusCode).toBe(404)
+    // A server error stays one whichever pattern queued the twin.
+    expect(run({ route: '/raw/docs/broken.md', error: failed(500) }).error?.statusCode).toBe(500)
+    // A site-owned twin under a wildcard route: never written, whatever it
+    // answered, and never a failed route either.
+    const owned = run({ route: '/raw/live/status.md', error: failed(500) })
+    expect(owned.skip).toBe(true)
+    expect(owned.error).toBeUndefined()
+    // Not a twin at all: left to Nitro.
+    expect(run({ route: '/docs/guide', contentType: 'text/html' }).skip).toBeUndefined()
   })
 })
 

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -12,6 +12,8 @@ import {
   hasFileExtension,
   isNegotiablePath,
   prerenderTwin,
+  handlerRouteMatches,
+  siteServesRaw,
   matchRoute,
   negotiatedRawPath,
   normalizeAgentRoute,
@@ -503,6 +505,39 @@ describe('prerenderTwin', () => {
 
     expect(prerenderTwin(owned, '/modules')).toBeUndefined()
     expect(prerenderTwin(owned, '/docs/guide')).toBe('/raw/docs/guide.md')
+  })
+
+  it('reads the site-owned list as handler patterns, so a wildcard-matched page is covered too', () => {
+    // A page under `/docs/**` has no build-time list of twins to skip, so the
+    // module ships the patterns Nitro registers and the question is asked
+    // per path here.
+    const owned = createConfig({
+      routes: [{ path: '/docs/**' }],
+      ownRawRoutes: ['/raw/docs/live/**:slug.md', '/raw/docs/:name.md']
+    })
+
+    expect(prerenderTwin(owned, '/docs/live/status')).toBeUndefined()
+    expect(prerenderTwin(owned, '/docs/api')).toBeUndefined()
+    expect(prerenderTwin(owned, '/docs/guide/intro')).toBe('/raw/docs/guide/intro.md')
+  })
+})
+
+describe('siteServesRaw', () => {
+  it('matches a handler pattern the way Nitro routes it', () => {
+    expect(handlerRouteMatches('/raw/modules.md', '/raw/modules.md')).toBe(true)
+    expect(handlerRouteMatches('/raw/modules.md', '/raw/modules.md/x')).toBe(false)
+    expect(handlerRouteMatches('/raw/:name', '/raw/modules.md')).toBe(true)
+    expect(handlerRouteMatches('/raw/:name', '/raw/docs/guide.md')).toBe(false)
+    expect(handlerRouteMatches('/raw/*', '/raw/modules.md')).toBe(true)
+    expect(handlerRouteMatches('/raw/**', '/raw/docs/guide.md')).toBe(true)
+    expect(handlerRouteMatches('/raw/**:slug.md', '/raw/docs/guide.md')).toBe(true)
+    expect(handlerRouteMatches('/raw/docs/**', '/raw/index.md')).toBe(false)
+  })
+
+  it('owns nothing without patterns', () => {
+    expect(siteServesRaw({}, '/raw/index.md')).toBe(false)
+    expect(siteServesRaw({ ownRawRoutes: [] }, '/raw/index.md')).toBe(false)
+    expect(siteServesRaw({ ownRawRoutes: ['/raw/**'] }, '/raw/index.md')).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

Follow-up to #22 and #23. The per-page prerender hint queued twins the module never meant to write: a twin the site serves itself under a wildcard pattern (`ownRawRoutes` only listed exact routes), a section twin whose 302 Nitro stored as an HTML refresh stub served in place of the redirect, and the twin of a Vue-only page, which answered 404 and landed in `failedRoutes` on every build.

## Changes

- `ownRawRoutes` now carries the route patterns of the handlers the site serves under the raw prefix, module handlers plus scanned `server/routes/raw/**` files mapped the way Nitro maps them (`raw/[...slug].md.get.ts` becomes `/raw/**:slug.md`), and one `siteServesRaw()` predicate is shared by the exact-route pass, the llms bridge and the middleware hint
- a `prerender:generate` hook on the main Nitro drops a queued twin that is site-owned, that answered a redirect, or that answered 404 from a page's own hint. A 404 on a twin queued for an exact pattern stays a build error, the site named that one
- the llms bridge normalizes adapter routes in `llms:generate` too, so `llms.txt` and `llms-full.txt` agree on an adapter listing `/index`, and its hint only goes out on `/` since Nitro never reads it off a `text/plain` response
- both hints are encoded per entry the way Nuxt's `prerenderRoutes()` does, since Nitro splits the header on commas
- `appendAgentResources()` leaves a body that already carries the `## Resources for Agents` heading alone, so a homepage that rendered the registry by hand is not listed twice
- README: the per-page hint applies whatever the source, and the skip rules above

## Tests

- unit: `siteServesRaw` and `handlerRouteMatches`, `prerenderTwin` against patterns, the scanned dynamic file mapped to its pattern, the `prerender:generate` decisions, the resources guard
- e2e (`i18n`): three Vue pages the content has no document for, a section, a page with no twin and one whose twin `server/routes/raw/en/docs/live.md.get.ts` serves. The fixture builds with `prerender.failOnError: true`, so the build itself asserts none of them ends up a failed route, and the tests check nothing was written for them and that the redirect, the 404 and the live handler still answer at runtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved prerendering for dynamically routed Markdown twins, including parameterized and wildcard routes.
  - Added support for site-served raw Markdown routes without generating duplicate twins.
  - Prerender hints now use encoded twin paths and are emitted from the homepage.

- **Bug Fixes**
  - Prevented duplicate “Resources for Agents” sections, including when headings appear in code examples.
  - Improved handling of missing, redirected, unsupported, and site-owned routes during prerendering.

- **Documentation**
  - Updated prerendering and migration guidance for route ownership and agent-resource discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->