### PR TITLE
refactor: trim comments and drop dead code

### DIFF
--- a/src/build/content.ts
+++ b/src/build/content.ts
@@ -3,14 +3,9 @@ import type { Resolver } from '@nuxt/kit'
 import type { Nuxt } from '@nuxt/schema'
 
 /**
- * Everything the build does for the `@nuxt/content` backend.
- *
- * Kept in one file because none of it is a public API: the source resolution
- * reaches into the site's own `@nuxt/content` install, and the teardown below
- * finds what the llms feature registered by matching a route string and a
- * plugin path. A major bump moves any of that and the site keeps building, so
- * the whole surface is worth reading in one place. `module.ts` declares the
- * version range this file assumes, through `moduleDependencies`.
+ * Build-time glue for the `@nuxt/content` backend. It matches what the llms
+ * feature registered by route and plugin path, so it assumes the version range
+ * `module.ts` declares through `moduleDependencies`.
  */
 
 const logger = useLogger('nuxt-agent-discovery')
@@ -19,31 +14,18 @@ const logger = useLogger('nuxt-agent-discovery')
 const CONTENT_LLMS_PLUGIN = /features[\\/]llms[\\/]runtime[\\/]server[\\/]content-llms\.plugin/
 
 /**
- * The built-in content adapter: the runtime source, and the stringifier the
- * raw markdown route renders trees with.
- *
- * Takes the module's own `resolve` rather than creating one here. The build
- * bundles everything outside `runtime/` into a single `dist/module.mjs`, so a
- * resolver anchored on this file resolves against `src/build` before packing
- * and against `dist` after it, and the runtime path would come out one
- * directory too high in the published package.
+ * The built-in content adapter: the runtime source, and the stringifier the raw
+ * markdown route renders trees with. Takes the module's own `resolve`, since
+ * the build packs everything outside `runtime/` into one `dist/module.mjs` and
+ * a resolver anchored here would come out a directory too high.
  */
 export async function resolveContentSource(nuxt: Nuxt, resolve: Resolver['resolve']): Promise<{ sourcePath: string, minimarkStringify?: string }> {
   const sourcePath = resolve('./runtime/server/sources/content')
-  // `minimark` is the tree format `@nuxt/content` stores and serializes
-  // with, not a format this module owns: comark sources render through
-  // `comark/render` and custom sources bring their own. So the stringifier
-  // has to be the one that produced the tree. Resolved from this module's
-  // own dependencies it would pin a version that can disagree with the
-  // content backend's, and a major bump changes the markdown of every page
-  // (attribute serialization, code-fence meta, ...). Resolve it from
-  // `@nuxt/content` instead, so the two can never drift.
+  // The stringifier has to be the one that produced the tree: our own
+  // `minimark` could pin a major that disagrees with the content backend's.
   const contentEntry = await tryResolveModule('@nuxt/content', nuxt.options.modulesDir)
   const minimarkStringify = contentEntry ? await tryResolveModule('minimark/stringify', [contentEntry]) : undefined
   if (!minimarkStringify) {
-    // Points at the cause rather than the symptom: reached with
-    // `source: 'content'` on a site that has no `@nuxt/content` at all,
-    // where the next failure is an unresolvable `@nuxt/content/server`.
     logger.warn(contentEntry
       ? 'Could not resolve `minimark/stringify` from `@nuxt/content`, so raw markdown may differ from what it produces.'
       : 'The content source is enabled but `@nuxt/content` could not be resolved. Install it, or set `agentDiscovery.source` to a file exporting an `AgentContentSource`.')
@@ -52,12 +34,9 @@ export async function resolveContentSource(nuxt: Nuxt, resolve: Resolver['resolv
 }
 
 /**
- * Takes `@nuxt/content` out of the `nuxt-llms` bridge.
- *
- * This module serves the raw markdown route from the adapter, so the route
- * survives a content-backend swap. Works whichever module runs first:
- * `@nuxt/content` normalizes `contentRawMarkdown` into runtime config at
- * `modules:done`, and its handler is dropped below.
+ * Takes `@nuxt/content` out of the `nuxt-llms` bridge, leaving the raw markdown
+ * route to the adapter. Works whichever module runs first, since its handler is
+ * dropped below as well.
  */
 export function disableContentRawMarkdown(nuxt: Nuxt): void {
   const llmsOptions = nuxt.options as unknown as { llms?: Record<string, unknown> }
@@ -65,24 +44,11 @@ export function disableContentRawMarkdown(nuxt: Nuxt): void {
 }
 
 /**
- * Removes what `@nuxt/content`'s llms feature registered.
- *
- * `@nuxt/content` installs that feature from inside its own setup, so the
- * supported off switch (`nuxt.options['content.llms'] = false`, the literal
- * key its `configKey` declares) is already too late unless this module happens
- * to be listed first. Drop what the feature registered instead, which does not
- * depend on module order:
- *
- * - the raw markdown handler, because this module serves that route from the
- *   adapter so it survives a content-backend swap
- * - the nitro plugin, because it builds `llms.txt` sections and renders
- *   `llms-full.txt` through a second markdown pipeline (`toHast` plus
- *   `@nuxtjs/mdc`), which disagrees with what `/raw/**.md` returns and has no
- *   comark equivalent. Both now come from the adapter.
- *
- * Reversible upstream: gating that `installModule` on `@nuxt/content`'s own
- * `options.llms !== false` would make `content: { llms: false }` work and let
- * all of this go.
+ * Removes what `@nuxt/content`'s llms feature registered: the raw markdown
+ * handler and the nitro plugin, both of which the adapter now covers. The
+ * supported off switch (`nuxt.options['content.llms'] = false`) is too late
+ * unless this module is listed first, but dropping what the feature registered
+ * does not depend on module order.
  */
 export function dropContentLlmsFeature(nuxt: Nuxt): void {
   const handlers = nuxt.options.serverHandlers
@@ -94,10 +60,8 @@ export function dropContentLlmsFeature(nuxt: Nuxt): void {
   }
 
   // At `nitro:config` rather than here: `@nuxt/content` does not await that
-  // `installModule`, so the plugin is registered by a floating promise with no
-  // ordering guarantee against `modules:done`. It has always landed in time in
-  // practice, but `nitro:config` fires later and receives the same array, so
-  // there is nothing to gain by relying on it.
+  // `installModule`, so the plugin lands on a floating promise with no ordering
+  // guarantee against `modules:done`.
   nuxt.hook('nitro:config', (nitroConfig) => {
     const plugins = nitroConfig.plugins || []
     const index = plugins.findIndex(plugin => CONTENT_LLMS_PLUGIN.test(String(plugin)))
@@ -106,9 +70,7 @@ export function dropContentLlmsFeature(nuxt: Nuxt): void {
       return
     }
 
-    // Only a feature that actually ran must have left a plugin behind. A site
-    // setting `nuxt.options['content.llms'] = false` itself, or a future
-    // `@nuxt/content` without the feature, is not a problem.
+    // Only a feature that actually ran must have left a plugin behind.
     const feature = (nuxt.options._installedModules || []).find(module => module.meta?.configKey === 'content.llms')
     if (feature && !(feature.meta as { disabled?: boolean } | undefined)?.disabled) {
       logger.warn('`@nuxt/content`\'s llms plugin is installed but could not be found to remove it, so `llms.txt` may come out with duplicate sections. Please report this with the `@nuxt/content` version.')

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,10 +1,8 @@
 /**
  * User agents served markdown without an explicit `Accept` header.
  *
- * One list for every surface: the deploy-preset rewrite matchers, the Nitro
- * middleware, the error handler and the `robots.txt` AI policy. Re-check
- * quarterly against https://github.com/ai-robots-txt/ai.robots.txt — new agent
- * UAs appear frequently and stale entries cost nothing to drop.
+ * One list for the rewrite matchers, the middleware, the error handler and the
+ * `robots.txt` AI policy. Re-check against https://github.com/ai-robots-txt/ai.robots.txt.
  */
 export const AGENT_USER_AGENTS = [
   'ClaudeBot',
@@ -28,11 +26,8 @@ export const AGENT_USER_AGENTS = [
 ]
 
 /**
- * MCP definition groups the public server card hides.
- *
- * Defined in `runtime/shared/defaults.ts`, since the card route applies it
- * again per request rather than trusting the merged runtime config, and
- * re-exported here so the defaults still read as one list.
+ * MCP definition groups the public server card hides. Defined in the shared
+ * defaults, which the card route applies again per request.
  */
 export { MCP_EXCLUDED_GROUPS } from './runtime/shared/defaults'
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,20 +40,14 @@ export interface McpServerCardOptions {
   license?: string
   version?: string
   /**
-   * Definition groups kept off the public card, by the subdirectory they live
-   * in under `server/mcp/tools`. Extends the built-in default (`admin`, see
-   * `MCP_EXCLUDED_GROUPS` in `defaults.ts`) rather than replacing it: admin
-   * tools behind a bearer token are on the server but are not something to
-   * advertise.
+   * Definition groups kept off the public card, by subdirectory under
+   * `server/mcp/tools`. Extends the default (`admin`) rather than replacing it.
    */
   excludeGroups?: string[]
 }
 
 export interface ModuleOptions {
-  /**
-   * Canonical site URL. Left empty, it is resolved per-request from the
-   * incoming host, which keeps preview deployments correct.
-   */
+  /** Canonical site URL. Resolved from the request host when empty. */
   siteUrl?: string
   /** Site name, used in `sitemap.md` and markdown error bodies. */
   siteName?: string
@@ -61,18 +55,13 @@ export interface ModuleOptions {
   rawPrefix?: string
   /**
    * Content adapter feeding the raw markdown route, `sitemap.md` and the
-   * `nuxt-llms` bridge. `'auto'` detects `@nuxt/content`; a path points at a
-   * file exporting an `AgentContentSource` (build one for comark with
-   * `createComarkSource()` from `#agent-discovery/comark`); `false` disables every
-   * content-backed feature and leaves negotiation and discovery running
-   * against whatever already serves the raw markdown.
+   * `nuxt-llms` bridge. `'auto'` detects `@nuxt/content`, a path points at a
+   * file exporting an `AgentContentSource`, `false` disables every
+   * content-backed feature and leaves negotiation running against whatever
+   * already serves the raw markdown.
    */
   source?: 'auto' | 'content' | false | string
-  /**
-   * Page patterns markdown is negotiated for. `*` matches one path segment,
-   * `**` one or more, so a locale prefix is one pattern and the generated
-   * CDN route table stays O(patterns) in page count.
-   */
+  /** Page patterns markdown is negotiated for. `*` matches one segment, `**` one or more. */
   routes?: (string | AgentRoute)[]
   excludePrefixes?: {
     /** Extra prefixes on top of the defaults. */
@@ -101,45 +90,32 @@ export interface ModuleOptions {
   /** Answer errors with a markdown body when the client asked for markdown. */
   errors?: boolean
   /**
-   * Answer a negotiated page with 406 when the request's `Accept` allows
-   * neither of its two representations, which is what RFC 9110 asks for.
-   *
-   * Off by default. Browsers and `fetch()` send a wildcard and are never
-   * affected, and neither is a navigation or a known agent, but a client
-   * sending a narrow `Accept` it did not mean starts getting an error where it
-   * used to get a page. See the "Strict content negotiation" README section.
+   * Answer a negotiated page with 406 when its `Accept` allows neither
+   * representation (RFC 9110). Off by default: a client sending a narrow
+   * `Accept` it did not mean would get an error instead of a page.
    */
   notAcceptable?: boolean
   sitemap?: {
-    /**
-     * Serve `/sitemap.md`, a markdown index of every page. Pass an object to
-     * control how pages are grouped into sections.
-     */
+    /** Serve `/sitemap.md`. Pass an object to control how pages are grouped into sections. */
     markdown?: boolean | Partial<SitemapSections>
   }
   robots?: {
     /**
-     * Allow the agent user-agent list in `robots.txt`, through
-     * `@nuxtjs/robots` when installed, otherwise through a generated
-     * `/robots.txt` (skipped when a static one exists).
+     * Allow the agent user-agent list in `robots.txt`, through `@nuxtjs/robots`
+     * when installed, otherwise through a generated `/robots.txt`.
      */
     aiPolicy?: boolean
     /** `Content-Signal` line for the wildcard group. `false` to omit. */
     contentSignal?: string | false
     /**
-     * `Disallow` lines for the wildcard group, in the generated `robots.txt`
-     * and contributed to `@nuxtjs/robots` when that module serves the route.
-     * Wildcard only, deliberately: the per-agent `Allow` groups exempt their
-     * agents from these rules, so what search engines skip stays reachable
-     * for the agents the site names. Not derived from `excludePrefixes`
-     * either, because an excluded path is not necessarily crawl-forbidden.
+     * `Disallow` lines for the wildcard group. The per-agent `Allow` groups
+     * exempt the listed agents from them.
      */
     disallow?: string[]
   }
   /**
-   * Agent Skills served under `/.well-known/skills/`, with a generated
-   * `index.json`. `false` to disable; otherwise the directory is scanned and
-   * the feature turns itself off when it does not exist.
+   * Agent Skills served under `/.well-known/skills/` with a generated
+   * `index.json`. Off when the directory does not exist.
    */
   skills?: false | {
     /** Directory holding one subdirectory per skill, relative to the root. */
@@ -163,15 +139,10 @@ interface AgentDiscoveryPublicRuntimeConfig {
 declare module '@nuxt/schema' {
   interface NuxtHooks {
     /**
-     * Lets other modules add discovery links and agent user agents.
-     *
-     * Fires once, but not always at the same point: with `@nuxtjs/robots`
-     * listed before this module it fires from that module's `robots:config`
-     * pass. The links array collects contributions only, and they are
-     * appended after the module's own links wherever the hook fired from, so
-     * push onto it rather than reading from it. Register the listener during
-     * `setup()`: a listener registered from a later lifecycle hook can miss
-     * the early firing entirely.
+     * Lets other modules add discovery links and agent user agents. Fires once,
+     * possibly early from the `robots:config` pass of `@nuxtjs/robots`, so
+     * register the listener during `setup()` and push onto `links` rather than
+     * reading from it.
      */
     'agent-discovery:extend': (registry: { links: DiscoveryLink[], userAgents: string[] }) => void | Promise<void>
   }
@@ -180,13 +151,8 @@ declare module '@nuxt/schema' {
 }
 
 /**
- * Whether a companion module is installed and will actually run. `hasNuxtModule`
- * alone is not enough: `@nuxtjs/robots`, `@nuxtjs/sitemap` and
- * `@nuxtjs/mcp-toolkit` all return early from their own `setup()` on
- * `{ enabled: false }`, staying installed while registering nothing. And
- * `<configKey>: false` is how Nuxt disables a module by its config key, which
- * is not the same as `{ enabled: false }`: optional chaining alone reads it as
- * `undefined !== false` and counts the module as active.
+ * Installed and not disabled. The companion modules return early from `setup()`
+ * on `{ enabled: false }`, and `<configKey>: false` disables a module too.
  */
 function hasActiveNuxtModule(nuxt: Nuxt, name: string, configKey: string): boolean {
   if (!hasNuxtModule(name, nuxt)) {
@@ -204,23 +170,10 @@ export default defineNuxtModule<ModuleOptions>({
       nuxt: '>=3.0.0'
     }
   },
-  /**
-   * `@nuxt/content` is optional, so this never installs it: with
-   * `optional: true` Nuxt validates the version when the package is there and
-   * skips the entry entirely when it is not.
-   *
-   * Worth declaring because this module reaches into v3 internals rather than a
-   * public API, and every one of those failures is silent. It imports
-   * `@nuxt/content/server` and `#content/manifest`, resolves `minimark/stringify`
-   * out of the installed copy, and removes the llms feature's nitro plugin by
-   * matching the path it registers. A major bump moves any of those and the
-   * site keeps building, with `llms.txt` quietly carrying duplicate sections.
-   *
-   * Deliberately duplicates the `peerDependencies` range, which a package
-   * manager only warns about: keep the two in step when bumping. Nothing else
-   * gets an entry here, because every other integration fails loudly enough
-   * that the install-time warning is the right amount of noise.
-   */
+  // Optional, so this never installs `@nuxt/content`. Declared because the
+  // built-in source reaches into v3 internals (`@nuxt/content/server`,
+  // `#content/manifest`, `minimark/stringify`) that a major bump would break
+  // silently. Keep in step with `peerDependencies`.
   moduleDependencies: {
     '@nuxt/content': { version: '^3.0.0', optional: true }
   },
@@ -229,8 +182,7 @@ export default defineNuxtModule<ModuleOptions>({
     siteName: '',
     rawPrefix: '/raw',
     source: 'auto',
-    // Option arrays merge by concatenation, so the routes default is applied
-    // in setup instead: a site defining its own patterns replaces it.
+    // Arrays merge by concatenation, so the routes default is applied in setup.
     routes: [],
     excludePrefixes: { extend: [] },
     userAgents: { extend: [] },
@@ -251,93 +203,30 @@ export default defineNuxtModule<ModuleOptions>({
     const logger = useLogger('nuxt-agent-discovery')
     const { resolve } = createResolver(import.meta.url)
 
-    // Nuxt generates the `runtimeConfig` type from the site's own resolved
-    // config, so a `Record<string, string>` like `sitemapSections.labels` comes
-    // back with that site's literal keys and stops accepting the type this
-    // module declares. Assign through the module's own shape instead, which
-    // still checks every value. Only bites a site with this module linked from
-    // source, where its `src` is type-checked along with the app.
+    // Nuxt derives the `runtimeConfig` type from the site's resolved config,
+    // which narrows `Record<string, string>` fields to that site's literal
+    // keys. Assign through the module's own shape instead.
     const runtimeConfig = nuxt.options.runtimeConfig as unknown as AgentDiscoveryRuntimeConfig & { public: AgentDiscoveryPublicRuntimeConfig }
 
     const rawPrefix = withoutTrailingSlash(withLeadingSlash(options.rawPrefix || '/raw'))
-    // Normalized, not validated: a pattern without a leading slash can never
-    // match a pathname, and silently emitted a prerender entry of
-    // `/rawabout.md`. The intent is unambiguous, so there is nothing to warn
-    // about.
+    // A pattern without a leading slash never matches, so normalize rather than warn.
     const routes: AgentRoute[] = (options.routes?.length ? options.routes : ['/', '/**'])
       .map(route => typeof route === 'string' ? { path: route } : route)
       .map(route => ({ ...route, path: withLeadingSlash(route.path) }))
-    // Copied, not aliased. `agent-discovery:extend` lets a site push onto this
-    // list, and a `replace` array comes straight from the site's config, which
-    // in a monorepo can be one const imported by two apps.
-    // `replace` wins, and saying both is the one case here where the intent is
-    // genuinely unclear, so it is the one worth a warning.
     for (const [name, option] of [['userAgents', options.userAgents], ['excludePrefixes', options.excludePrefixes]] as const) {
       if (option?.replace && option.extend?.length) {
         logger.warn(`\`${name}\` has both \`replace\` and \`extend\`; \`replace\` wins and the extended entries are dropped.`)
       }
     }
-
+    // Copied, not aliased: `agent-discovery:extend` pushes onto the list and a
+    // `replace` array may be config shared between apps. The prefixes are
+    // deduped too, since they become an alternation in the CDN lookahead.
     const userAgents = options.userAgents?.replace
       ? [...options.userAgents.replace]
       : [...AGENT_USER_AGENTS, ...(options.userAgents?.extend || [])]
-    // Same shape, same copy, and deduped on top: this list becomes an
-    // alternation in the generated CDN lookahead, so a site spelling out a
-    // default it also extends would double it there for nothing.
     const excludePrefixes = [...new Set(options.excludePrefixes?.replace
       ? options.excludePrefixes.replace
       : [...EXCLUDE_PREFIXES, ...(options.excludePrefixes?.extend || [])])]
-
-    // An exact route whose `raw` destination negotiates back into the
-    // middleware makes it proxy itself forever, in one hop (`/about` →
-    // `/about.md`) or through other routes (`/a` → `/b.md` → `/a.md` → …).
-    // The walk mirrors the runtime chain on normalized pathnames, the
-    // spelling the inner request re-enters with: a destination under
-    // `rawPrefix` or an excluded prefix never re-enters negotiation, a
-    // wildcard destination always lands under `rawPrefix`, a dotted
-    // non-`.md` path reads as an asset, and a path no pattern matches
-    // terminates after one hop. Revisiting a pathname is the loop.
-    const negotiationConfig = { rawPrefix } as NegotiationConfig
-    const nextHop = (pathname: string): string | undefined => {
-      if (isRawPath(negotiationConfig, pathname)
-        || excludePrefixes.some(prefix => pathname.startsWith(prefix))) {
-        return undefined
-      }
-      const base = pathname.endsWith('.md') ? pathname.slice(0, -3) : pathname
-      if (base.length <= 1 || (base === pathname && hasFileExtension(base))) {
-        return undefined
-      }
-      const matched = matchRoute(routes, base)
-      return matched ? normalizePathname(rawDestination(negotiationConfig, matched, base)) : undefined
-    }
-    for (const route of routes) {
-      if (!route.raw || route.path.includes('*')) {
-        continue
-      }
-      const visited = new Set<string>()
-      let hop = nextHop(normalizePathname(route.raw))
-      while (hop) {
-        if (visited.has(hop)) {
-          throw new Error(`[nuxt-agent-discovery] \`routes\`: the \`raw\` destination \`${route.raw}\` for \`${route.path}\` negotiates back to itself. Point it under \`${rawPrefix}\`, or exclude it through \`excludePrefixes\`.`)
-        }
-        visited.add(hop)
-        hop = nextHop(hop)
-      }
-    }
-
-    // The discovery-link registry, assembled at `modules:done` and extended
-    // through `agent-discovery:extend`. The hook fires once, from whichever
-    // consumer needs it first: `@nuxtjs/robots` snapshots the user agents when
-    // it fires `robots:config` from its own `modules:done`, which runs before
-    // ours whenever it is listed first, so waiting for our own `modules:done`
-    // handed it the un-extended list.
-    const links: DiscoveryLink[] = []
-    // Hook contributions land in their own list and are appended after the
-    // module's own, so their position never depends on which consumer fired
-    // the hook first.
-    const hookLinks: DiscoveryLink[] = []
-    let extended: Promise<void> | undefined
-    const extendRegistry = () => extended ??= nuxt.callHook('agent-discovery:extend', { links: hookLinks, userAgents })
 
     // Mutated until `modules:done`, then read by the runtime and the presets.
     const config: NegotiationConfig = {
@@ -357,14 +246,51 @@ export default defineNuxtModule<ModuleOptions>({
       }
     }
 
+    // An exact route whose `raw` destination negotiates back into the
+    // middleware proxies itself forever, directly or through other routes.
+    // Walk the runtime chain on normalized pathnames; revisiting one is the loop.
+    const nextHop = (pathname: string): string | undefined => {
+      if (isRawPath(config, pathname) || excludePrefixes.some(prefix => pathname.startsWith(prefix))) {
+        return undefined
+      }
+      const base = pathname.endsWith('.md') ? pathname.slice(0, -3) : pathname
+      if (base.length <= 1 || (base === pathname && hasFileExtension(base))) {
+        return undefined
+      }
+      const matched = matchRoute(routes, base)
+      return matched ? normalizePathname(rawDestination(config, matched, base)) : undefined
+    }
+    for (const route of routes) {
+      if (!route.raw || route.path.includes('*')) {
+        continue
+      }
+      const visited = new Set<string>()
+      let hop = nextHop(normalizePathname(route.raw))
+      while (hop) {
+        if (visited.has(hop)) {
+          throw new Error(`[nuxt-agent-discovery] \`routes\`: the \`raw\` destination \`${route.raw}\` for \`${route.path}\` negotiates back to itself. Point it under \`${rawPrefix}\`, or exclude it through \`excludePrefixes\`.`)
+        }
+        visited.add(hop)
+        hop = nextHop(hop)
+      }
+    }
+
+    // The discovery-link registry, assembled at `modules:done`.
+    // `agent-discovery:extend` fires once, from whichever consumer needs it
+    // first: `@nuxtjs/robots` snapshots the user agents from its own
+    // `modules:done`, which runs before ours when it is listed first. Hook
+    // contributions are appended after the module's own links either way.
+    const links: DiscoveryLink[] = []
+    const hookLinks: DiscoveryLink[] = []
+    let extended: Promise<void> | undefined
+    const extendRegistry = () => extended ??= nuxt.callHook('agent-discovery:extend', { links: hookLinks, userAgents })
+
     /* ------------------------------- source ------------------------------- */
 
     let sourcePath: string | undefined
     let builtinContentSource = false
     let minimarkStringify: string | undefined
     if (options.source === 'content' || (options.source === 'auto' && hasNuxtModule('@nuxt/content'))) {
-      // Everything the built-in adapter needs from the site's `@nuxt/content`
-      // install, in `build/content.ts` with the rest of that backend.
       const contentSource = await resolveContentSource(nuxt, resolve)
       sourcePath = contentSource.sourcePath
       minimarkStringify = contentSource.minimarkStringify
@@ -375,10 +301,8 @@ export default defineNuxtModule<ModuleOptions>({
       sourcePath = await resolvePath(options.source)
     }
 
-    // The MCP server card lists whatever the site's MCP server exposes, which
-    // only `@nuxtjs/mcp-toolkit` knows. Detected, never depended on, the same
-    // way `@nuxtjs/robots` and `@nuxtjs/sitemap` are. Starts on the stub, and
-    // the detection below swaps it.
+    // `@nuxtjs/mcp-toolkit` is detected, never depended on: the alias starts
+    // on the stub and `modules:done` swaps it.
     const aliases = {
       '#agent-discovery/source': sourcePath || resolve('./runtime/server/sources/none'),
       '#agent-discovery/comark': resolve('./runtime/server/sources/comark'),
@@ -389,27 +313,20 @@ export default defineNuxtModule<ModuleOptions>({
       ...(minimarkStringify ? { 'minimark/stringify': minimarkStringify } : {}),
       ...aliases
     })
-    // Also aliased app-side, purely so a site whose `tsconfig.json` extends the
-    // app config (the common single-tsconfig setup) can typecheck a server
-    // route importing `#agent-discovery`. Nitro is what actually resolves it.
+    // Also aliased app-side so a single-tsconfig site can typecheck a server
+    // route importing `#agent-discovery`.
     nuxt.options.alias = defu(nuxt.options.alias, aliases)
 
-    // Detection waits for `modules:done` for the same reason the companion
-    // modules do: `@nuxtjs/seo`-style declarative `moduleDependencies` are
-    // installed after every listed module's `setup()`, so deciding here would
-    // read a toolkit installed that way as absent and serve a card listing no
-    // tools at all, silently. Nitro resolves the alias table well after this
-    // hook, so swapping the entry now still lands.
+    const staticBuild = Boolean(nuxt.options.nitro?.static) || (nuxt.options as { _generate?: boolean })._generate === true
+
+    // Every companion module is detected at `modules:done`: one pulled in
+    // through `moduleDependencies` (as `@nuxtjs/seo` does) installs after
+    // every listed module's `setup()`. Nitro resolves the alias table later
+    // still, so swapping the entry here lands.
     nuxt.hook('modules:done', () => {
-      // Active, not merely installed: the toolkit's setup also returns early
-      // under `nuxt generate`, registering none of the `#nuxt-mcp-toolkit/*`
-      // virtual modules its listing API imports. Aliasing the real re-export
-      // in that state fails the Nitro build on an unresolvable id, so the two
-      // build conditions are mirrored here on top of the shared check.
-      const mcpToolkit = hasActiveNuxtModule(nuxt, '@nuxtjs/mcp-toolkit', 'mcp')
-        && !nuxt.options.nitro?.static
-        && (nuxt.options as { _generate?: boolean })._generate !== true
-      if (!mcpToolkit) {
+      // Under `nuxt generate` the toolkit registers none of its virtual
+      // modules, and aliasing the real re-export then fails the Nitro build.
+      if (staticBuild || !hasActiveNuxtModule(nuxt, '@nuxtjs/mcp-toolkit', 'mcp')) {
         return
       }
 
@@ -421,8 +338,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     /* ------------------------------- handlers ----------------------------- */
 
-    // Held in a variable so `siteServesRoute` below can tell this handler
-    // apart from one the site registered on the same route.
+    // Kept so `siteRawRoutes` can tell this handler from a site-registered one.
     const rawHandler = resolve('./runtime/server/routes/raw')
     if (sourcePath) {
       addServerHandler({ route: `${rawPrefix}/**`, handler: rawHandler })
@@ -434,9 +350,6 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/.well-known/api-catalog', handler: resolve('./runtime/server/routes/api-catalog') })
     }
     if (options.discovery?.mcpServerCard) {
-      // The default lives in `defaults.ts` with the other lists, and the
-      // option extends it rather than replacing it, so the merge happens here
-      // and the route reads the resolved list.
       runtimeConfig.agentDiscoveryMcp = {
         ...options.discovery.mcpServerCard,
         excludeGroups: [...mcpExcludedGroups(options.discovery.mcpServerCard.excludeGroups)]
@@ -444,11 +357,9 @@ export default defineNuxtModule<ModuleOptions>({
       addServerHandler({ route: '/.well-known/mcp/server-card.json', handler: resolve('./runtime/server/routes/mcp-server-card') })
     }
 
-    // `source: false` is a site saying something else already serves the raw
-    // markdown, so negotiation still runs against it. `'auto'` resolving to
-    // nothing is a site that installed the module and has no adapter: rewriting
-    // every page to a prefix nothing serves would answer agents with a 404 on
-    // pages that render fine in HTML, which is worse than not installing it.
+    // `source: false` means something else serves the raw markdown. `'auto'`
+    // resolving to nothing means no adapter at all, and rewriting every page
+    // to a prefix nothing serves would answer agents with a 404.
     const negotiates = Boolean(sourcePath) || options.source === false
     if (!negotiates) {
       logger.warn('No content source resolved, so markdown negotiation is off. Install `@nuxt/content`, point `agentDiscovery.source` at a file exporting an `AgentContentSource`, or set `source: false` if another route already serves the raw markdown.')
@@ -466,14 +377,10 @@ export default defineNuxtModule<ModuleOptions>({
           : []
         nitroConfig.errorHandler = [errorHandler, ...handlers]
       })
-      // Prepending above is not enough: any module registered later whose
-      // `nitro:config` hook also prepends lands ahead (evlog does, and its
-      // handler serializes agent errors as JSON and ends the response, so the
-      // markdown bodies never fired unless the site reordered `modules`). The
-      // resolved options are re-sorted here instead, after every hook has run;
-      // rollup reads them later, when it emits the handler chain. The
-      // markdown handler passes anything that is not a markdown request
-      // through untouched, so going first takes nothing from the others.
+      // Prepending is not enough: a module registered later whose
+      // `nitro:config` hook also prepends lands ahead (evlog does, and ends
+      // agent errors as JSON). Re-sort once every hook has run; the markdown
+      // handler passes other requests through, so going first costs nothing.
       nuxt.hook('nitro:init', (nitro) => {
         const handlers = nitro.options.errorHandler as unknown
         if (Array.isArray(handlers)) {
@@ -488,9 +395,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     addImports({ name: 'useCanonical', from: resolve('./runtime/app/composables/useCanonical') })
 
-    // The Nitro runtime hooks, declared where a site's server code can see
-    // them. Without this every `nitroApp.hooks.hook('agent-discovery:*')` call
-    // needs a cast, which is a poor API to document.
+    // Declares the Nitro runtime hooks so a site's server code needs no cast.
     const hookTypes = addTypeTemplate({
       filename: 'agent-discovery/hooks.d.ts',
       getContents: () => `
@@ -500,29 +405,22 @@ import type { AgentIndex } from ${JSON.stringify(resolve('./runtime/shared/types
 declare module 'nitropack/types' {
   interface NitroRuntimeHooks {
     /**
-     * Transforms a page before the content adapter stringifies it. The second
-     * argument is whatever the adapter works on: a minimark tree for
-     * \`@nuxt/content\`, the backend's own document elsewhere.
+     * Transforms a page before the content adapter stringifies it. The page is
+     * whatever the adapter works on, a minimark tree for \`@nuxt/content\`.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     'agent-discovery:document': (event: H3Event, page: any) => void | Promise<void>
     /**
-     * Fills in the generated \`/raw/index.md\`, for a site whose landing page is
-     * a Vue page rather than a document. Set \`title\` and \`description\`, which
-     * reach the frontmatter, and push markdown blocks onto \`body\`.
+     * Fills in the generated \`/raw/index.md\` for a site whose landing page is
+     * a Vue page. Set \`title\` and \`description\`, push markdown blocks onto \`body\`.
      */
     'agent-discovery:index': (event: H3Event, index: AgentIndex) => void | Promise<void>
     /** Enriches the served MCP server card with live tools, resources and prompts. */
     'agent-discovery:mcp-server-card': (event: H3Event, card: Record<string, unknown>) => void | Promise<void>
     /**
-     * Adds to \`sitemap.md\` before it is rendered, for the pages a content
-     * adapter cannot know about, in the order the sections appear. Keys are
-     * the raw first path segment of the grouped routes (\`docs\`, \`blog\`; the
-     * second segment under an expanded prefix, \`pages\` for top-level ones),
-     * with \`sitemap.markdown.labels\` applied at render only. Extend an
-     * existing section through that key (\`sections.get('docs')\`); a new
-     * section may use any key, which renders capitalized unless \`labels\`
-     * overrides it.
+     * Adds to \`sitemap.md\` before it is rendered. Keys are the first path
+     * segment of the grouped routes (\`docs\`, \`blog\`, \`pages\` for top-level
+     * ones), with \`sitemap.markdown.labels\` applied at render.
      */
     'agent-discovery:sitemap': (event: H3Event, sections: Map<string, { title: string, href: string }[]>) => void | Promise<void>
   }
@@ -538,40 +436,25 @@ export {}
     /* ------------------------------- robots ------------------------------- */
 
     if (options.robots?.aiPolicy) {
-      // Feed the shared user-agent list into the robots module instead of
-      // competing for the `/robots.txt` route.
-      //
-      // Registered whether or not `@nuxtjs/robots` is installed, since the
-      // hook simply never fires without it. Waiting for detection would be too
-      // late: that module calls `robots:config` from its own `modules:done`,
-      // which runs before ours whenever it is listed first.
-      //
-      // Through its hook, not `nuxt.options.robots`: that module reads its
-      // options during its own setup, so a site listing it first (which
-      // `@nuxtjs/sitemap` asks for) would silently get none of this.
+      // Fed into `@nuxtjs/robots` through its hook rather than
+      // `nuxt.options.robots`, which that module reads during its own setup.
+      // Registered unconditionally: the hook never fires without the module,
+      // and it fires from that module's `modules:done`, before ours when it is
+      // listed first.
       const contentSignal = options.robots.contentSignal
       const disallow = options.robots.disallow || []
-      // Typed with the hook signature `@nuxtjs/robots` exports, so a group
-      // shape change in a robots major fails this build instead of silently
-      // pushing groups it no longer reads. The cast is only for the hook name,
-      // which that module declares through no global augmentation.
+      // Typed with the hook signature `@nuxtjs/robots` exports so a group shape
+      // change fails this build. The cast only covers the hook name.
       const onRobotsConfig = nuxt.hook as unknown as (
         name: 'robots:config',
         cb: RobotsModuleHooks['robots:config']
       ) => void
       onRobotsConfig('robots:config', async (robotsConfig) => {
-        // The groups below snapshot the user-agent list, so anything a site
-        // adds through `agent-discovery:extend` has to be in it already.
+        // The groups snapshot the user-agent list, so extend it first.
         await extendRegistry()
-        // `Content-Signal` and the `disallow` lines belong on the wildcard
-        // group, which this module's own `robots.txt` route emits too.
-        // Without this either would be lost the moment a site adds
-        // `@nuxtjs/robots`. The agent groups pushed below stay allow-only on
-        // purpose: a UA-specific group exempts its agent from the wildcard
-        // rules, so what search engines are kept out of stays reachable for
-        // the agents the site names. The groups are normalized before the
-        // hook fires, but the declared type still carries the `Arrayable`
-        // input shape.
+        // `Content-Signal` and `disallow` go on the wildcard group, as in this
+        // module's own `robots.txt` route. The agent groups stay allow-only:
+        // a UA-specific group exempts its agent from the wildcard rules.
         for (const group of robotsConfig.groups) {
           const groupAgents = Array.isArray(group.userAgent) ? group.userAgent : [group.userAgent]
           if (!groupAgents.includes('*')) {
@@ -581,8 +464,6 @@ export {}
             group.contentSignal = [contentSignal]
           }
           if (disallow.length) {
-            // Deduplicated against what the site already wrote in that
-            // module's own config, so one path is never disallowed twice.
             const existing = Array.isArray(group.disallow) ? group.disallow : (group.disallow ? [group.disallow] : [])
             group.disallow = [...existing, ...disallow.filter(path => !existing.includes(path))]
           }
@@ -595,22 +476,11 @@ export {}
         })))
       })
 
-      // Whether to serve `/robots.txt` ourselves is decided at `modules:done`,
-      // not here: `@nuxtjs/seo` pulls `@nuxtjs/robots` in through Nuxt's
-      // declarative `moduleDependencies`, which are installed after this
-      // `setup()` runs. `hasNuxtModule` says no at this point, and the handler
-      // we would register is dead code behind theirs.
       nuxt.hook('modules:done', () => {
-        // Active, not merely installed: a robots module disabled through its
-        // own options registers no `/robots.txt` route, so deferring to it
-        // served nobody the agent policy.
+        // A disabled robots module registers no `/robots.txt` route.
         if (hasActiveNuxtModule(nuxt, '@nuxtjs/robots', 'robots')) {
           return
         }
-        // The name check above covers the modules we know. Anything else
-        // serving that route wins it at runtime, and ours would be dead code
-        // whose agent groups never reach a crawler, so say so rather than
-        // registering it.
         if (nuxt.options.serverHandlers.some(handler => handler.route === '/robots.txt')) {
           logger.warn('Another module already serves `/robots.txt`, so the AI robots policy is not applied to it. Contribute the `agentDiscovery.userAgents` list through that module instead.')
           return
@@ -626,17 +496,10 @@ export {}
 
     /* ------------------------------- sitemap ------------------------------ */
 
-    // The raw markdown twins are alternate representations of pages already in
-    // the sitemap, not pages of their own, so they must never be listed as
-    // separate URLs. Every site that pairs a sitemap module with a raw markdown
-    // route needs this, so the module does it rather than leaving each one to
-    // remember.
-    //
-    // Through the module's runtime hook rather than `sitemap.exclude`:
-    // `@nuxtjs/sitemap` resolves its options during its own setup and bakes
-    // them into a virtual module, so mutating `nuxt.options.sitemap` afterwards
-    // does nothing unless the site happens to list this module first. Detection
-    // waits for `modules:done` for the `moduleDependencies` reason above.
+    // The raw twins are alternate representations, not pages, so they must
+    // stay out of `sitemap.xml`. Through the runtime hook rather than
+    // `sitemap.exclude`, which `@nuxtjs/sitemap` bakes into a virtual module
+    // during its own setup.
     nuxt.hook('modules:done', () => {
       if (hasActiveNuxtModule(nuxt, '@nuxtjs/sitemap', 'sitemap')) {
         addServerPlugin(resolve('./runtime/server/plugins/sitemap'))
@@ -672,43 +535,19 @@ export {}
       disableContentRawMarkdown(nuxt)
     }
 
-    /**
-     * Route-rule patterns with a response cache that a negotiated pattern
-     * reaches, which decide where the CDN redirects instead of rewriting.
-     *
-     * Collected three times, because rules keep arriving as the build goes:
-     * at `modules:done` from `nuxt.options.routeRules`, which is what the
-     * runtime config snapshots; at `nitro:build:before` from Nitro's own
-     * table, the only place a rule added in a `nitro:config` hook ever lands
-     * (`createNitro` builds a fresh object, so those never reach
-     * `nuxt.options`); and once more when the Vercel preset emits its table,
-     * for a page-level `defineRouteRules({ isr })` applied during the Nuxt
-     * build after every hook here. Missing one means emitting a
-     * URL-preserving rewrite onto a route that really is cached, which is the
-     * one error here that poisons a cache.
-     *
-     * Rebuilt from scratch on every pass rather than accumulated: each later
-     * snapshot is authoritative, and a rule flipped back to `{ isr: false }`
-     * has to drop off the list or the CDN keeps redirecting a route that is
-     * no longer cached.
-     *
-     * The street runs one way only: what lands on `nuxt.options.routeRules`
-     * before `createNitro` (this module's own `/` header rule included) is
-     * defu'd into Nitro's table, so pass one still sees everything written
-     * through `nuxt.options` and the header rule reaches every preset.
-     */
+    // Route-rule patterns with a response cache that a negotiated pattern
+    // reaches; the CDN redirects there instead of rewriting. Collected three
+    // times because rules keep arriving: at `modules:done` from
+    // `nuxt.options.routeRules`, at `nitro:build:before` from Nitro's own
+    // table (the only place a rule added in `nitro:config` lands), and when
+    // the Vercel preset emits its table (for a page-level
+    // `defineRouteRules({ isr })`). Rebuilt from scratch on every pass so a
+    // rule flipped back to `{ isr: false }` drops off.
     const collectCachedRoutes = (routeRules?: Record<string, { isr?: unknown, swr?: unknown, cache?: unknown, static?: unknown } | undefined>) => {
       const previous = config.cachedRoutes.splice(0, config.cachedRoutes.length)
       for (const [key, rule] of Object.entries(routeRules || {})) {
-        // Every shape Nitro turns into a response cache, read the way Nitro
-        // reads it. `isr: 0` and `swr: 0` are not one: the Vercel builder skips
-        // a falsy `isr` outright and `normalizeRouteRules` only configures a
-        // cache for a truthy `swr`, so no cached asset is ever written. A bare
-        // `'cache' in rule` counted `cache: false`, an opt-out, as a cache.
-        // `static` is the legacy Vercel spelling that `deprecateSWR` turns into
-        // `isr: !static`, so `static: false` is a real ISR route no other key
-        // here names; it is inert under `future.nativeSWR`, which errs towards
-        // a redirect and is the safe direction.
+        // Read the way Nitro reads it: `isr: 0` and `swr: 0` are not caches,
+        // `cache: false` is an opt-out, and the legacy `static: false` is ISR.
         const cached = rule && (rule.isr || rule.swr || rule.cache
           || ('static' in rule && !(rule as { static?: boolean | number }).static))
         if (!cached) {
@@ -718,26 +557,18 @@ export {}
         if (config.excludePrefixes.some(prefix => staticPrefix(key).startsWith(prefix)) || staticPrefix(key).startsWith(`${rawPrefix}/`)) {
           continue
         }
-        // The question is whether the path negotiates at all, which for an
-        // exact rule is `matchRoute`, not `patternsOverlap`: overlap puts
-        // every path under a `/` pattern, so a non-page rule like
-        // `/llms.txt` joined the list and the CDN gave it a 307 to a
-        // `/raw/llms.txt.md` that does not exist. A dotted last segment is an
-        // asset either way, the same rule `negotiatedRawPath` applies.
+        // For an exact rule the question is whether the path negotiates, not
+        // whether it overlaps a pattern: `/llms.txt` overlaps `/**` but is not a page.
         const negotiable = key.includes('*')
           ? routes.some(route => patternsOverlap(key, route.path))
           : Boolean(matchRoute(routes, key)) && !hasFileExtension(key)
         if (negotiable) {
           config.cachedRoutes.push(key)
-          // Only for rules the earlier passes had not seen, so a rebuild does
-          // not repeat the whole list on every pass.
           if (!previous.includes(key)) {
             logger.info(`Route rule \`${key}\` has a response cache: request-time markdown negotiation is disabled there, and the CDN routes redirect to the raw markdown instead of rewriting.`)
           }
         }
       }
-      // The other direction of the rebuild, so a disappearing cache is as
-      // visible as an appearing one.
       for (const key of previous) {
         if (!config.cachedRoutes.includes(key)) {
           logger.info(`Route rule \`${key}\` no longer has a response cache: the CDN routes rewrite it again instead of redirecting.`)
@@ -747,34 +578,24 @@ export {}
 
     nuxt.hook('modules:done', async () => {
       // Prerendered documents bake the site URL in, so resolve it from the
-      // site config or the llms domain when not set explicitly. Request-time
-      // responses still fall back to the incoming host.
+      // site config or the llms domain. Request-time responses still fall
+      // back to the incoming host.
       const siteOptions = nuxt.options as { site?: { url?: string, name?: string }, llms?: { domain?: string } }
       if (!config.siteUrl) {
         config.siteUrl = (siteOptions.site?.url || siteOptions.llms?.domain || '').replace(/\/$/, '')
       }
-      // Falls back the same way `siteUrl` does, so a site that already told
-      // `@nuxtjs/seo` its name does not repeat it here.
       if (!config.siteName) {
         config.siteName = siteOptions.site?.name || ''
       }
 
-      // Every helper here treats `siteUrl` as an origin: `rawUrl()` compares
-      // against `new URL(siteUrl).origin`, then concatenates the raw path onto
-      // the configured value, so a path would end up in the middle of the URL.
-      // Failing at build is better than shipping documents whose every link is
-      // silently wrong.
+      // `siteUrl` is used as an origin everywhere, so a path in it would
+      // corrupt every link. `site.url` is commonly written without a scheme,
+      // and `new URL()` then throws a bare `Invalid URL`.
       if (config.siteUrl) {
-        // Parsed defensively: `site.url` is commonly written without a scheme,
-        // and `new URL('example.com')` throws a bare `Invalid URL` that names
-        // neither the option nor this module.
-        let parsed: URL | undefined
+        let parsed: URL
         try {
           parsed = new URL(config.siteUrl)
         } catch {
-          parsed = undefined
-        }
-        if (!parsed) {
           throw new Error(`[nuxt-agent-discovery] \`siteUrl\` is not a valid URL (${config.siteUrl}). Give it a scheme, as in \`https://example.com\`.`)
         }
         if (parsed.pathname !== '/') {
@@ -782,46 +603,38 @@ export {}
         }
       }
 
-      // Prerendered documents bake this in, and the prerenderer sends no host
-      // header, so an empty value here becomes `http://localhost` in every
-      // canonical URL and every absolutized link of the built output.
+      // The prerenderer sends no host header, so an empty value becomes
+      // `http://localhost` in every prerendered URL.
       if (!config.siteUrl && nuxt.options.nitro.static) {
         logger.warn('No `siteUrl`: set it, or `site.url`, or `llms.domain`. Prerendered documents resolve it from the request, which is `localhost` at build time.')
       }
 
+      // This plugin builds `llms.txt` from the adapter, replacing the llms
+      // feature of `@nuxt/content`.
       if (hasLlms && sourcePath) {
-        // Whatever `@nuxt/content`'s own llms feature registered goes first,
-        // because this plugin builds `llms.txt` from the adapter instead.
         dropContentLlmsFeature(nuxt)
         addServerPlugin(resolve('./runtime/server/plugins/llms'))
       }
 
       /* ------------------------------ registry ----------------------------- */
 
-      // Advertised only when something serves it. This module does not generate
-      // `sitemap.xml`, so keying on the option alone meant a zero-config site
-      // pointed agents, the api-catalog and `robots.txt` at a 404, and so does
-      // a sitemap module a site installed but disabled. A site that serves its
-      // own can register it through `discovery.links`.
+      // Advertised only when something serves it: this module does not
+      // generate `sitemap.xml`.
       if (options.discovery?.sitemapXml !== false && hasActiveNuxtModule(nuxt, '@nuxtjs/sitemap', 'sitemap')) {
         links.push({ href: '/sitemap.xml', rel: 'sitemap', type: 'application/xml', title: 'Sitemap (XML)' })
       }
       if (sourcePath && options.sitemap?.markdown) {
         links.push({ href: '/sitemap.md', rel: 'sitemap', type: 'text/markdown', title: 'Sitemap (Markdown): every page on the site' })
       }
-      // Advertised only once something would be in it. The catalog groups the
-      // links carrying an `anchor` with a `service-desc`/`service-doc` rel, and
-      // a site with none of `nuxt-llms`, skills or an MCP card has no such
-      // link: the route answered `{"linkset":[]}` while the `Link` header on
-      // `/` pointed agents at it. Registered further down, once the rest of the
-      // registry is known.
+      // Advertised only once something would be in it: the catalog lists the
+      // `service-desc`/`service-doc` links carrying an `anchor`. Registered
+      // after the hook so contributed links count.
       const catalogLink: DiscoveryLink = { href: '/.well-known/api-catalog', rel: 'api-catalog', type: 'application/linkset+json', title: 'API catalog: every service document this site publishes' }
       if (options.discovery?.mcpServerCard) {
         const card = options.discovery.mcpServerCard
         const endpoint = card.endpoint.startsWith('/') ? `${config.siteUrl}${card.endpoint}` : card.endpoint
         links.push({ href: '/.well-known/mcp/server-card.json', rel: 'service-desc', type: 'application/json', title: `MCP server card: MCP endpoint at ${endpoint}`, anchor: card.endpoint })
-        // The endpoint itself, so an agent reading the resources block or the
-        // error body can reach it without fetching the card first.
+        // The endpoint itself, reachable without fetching the card first.
         links.push({ href: card.endpoint, rel: 'service', title: 'MCP endpoint (streamable HTTP)', header: false })
         if (card.documentation) {
           links.push({ href: card.documentation, rel: 'service-doc', type: 'text/html', anchor: card.endpoint, header: false })
@@ -842,8 +655,7 @@ export {}
       }
       if (skills.length) {
         links.push({ href: SKILLS_INDEX, rel: 'index', type: 'application/json', title: 'Agent skills index: every skill published by this site' })
-        // The skills themselves stay out of the `Link` header, which
-        // advertises the discovery documents rather than every resource.
+        // Only the index goes in the `Link` header.
         for (const skill of skills) {
           links.push({ href: `${SKILLS_PREFIX}${skill.name}/SKILL.md`, rel: 'service-doc', type: 'text/markdown', title: `Agent skill: ${skill.name}`, anchor: '/', header: false })
         }
@@ -854,46 +666,39 @@ export {}
       links.push(...(options.discovery?.links || []))
 
       await extendRegistry()
-      // Wherever the hook fired from, its links slot in after the built-ins
-      // and the site's own.
       links.push(...hookLinks)
 
-      // After the hook, so a link contributed by another module counts too.
       if (options.discovery?.apiCatalog && links.some(link => link.anchor && (link.rel === 'service-desc' || link.rel === 'service-doc'))) {
         links.unshift(catalogLink)
       }
 
+      // Layer configs concatenate, so a layer and the app both declaring
+      // `/llms.txt` would double it. First one wins.
+      const seen = new Set<string>()
       for (const link of links) {
         if (!isValidRel(link.rel)) {
           throw new Error(`[nuxt-agent-discovery] \`rel="${link.rel}"\` (${link.href}) is not an IANA-registered link relation. Use a registered rel or an absolute URI extension relation.`)
         }
+        const key = `${link.rel} ${link.href}`
+        if (!seen.has(key)) {
+          seen.add(key)
+          config.links.push(link)
+        }
       }
-      // Layer configs concatenate, so a layer and the app both declaring
-      // `/llms.txt` would double it in the `Link` header, the api-catalog and
-      // every error body. First one wins, which keeps the layer's ordering.
-      const seen = new Set<string>()
-      config.links.push(...links.filter(link => !seen.has(`${link.rel} ${link.href}`) && seen.add(`${link.rel} ${link.href}`)))
 
-      // `/sitemap.md` is not a page twin: without this a catch-all route
-      // pattern rewrites it to `${rawPrefix}/sitemap.md` at the edge and in the
-      // middleware, shadowing whatever serves it, and the request 404s.
-      //
-      // Keyed on the registered link, not on this module owning the route. A
-      // site that serves its own `/sitemap.md` with `sitemap.markdown` off and
-      // registers it through `discovery.links` needs the exclusion just as
-      // much, and was left broken by the narrower check.
+      // `/sitemap.md` is not a page twin: without this a catch-all pattern
+      // rewrites it under `rawPrefix`. Keyed on the registered link rather than
+      // on this module owning the route, so a site serving its own through
+      // `discovery.links` gets the exclusion too.
       if (config.links.some(link => link.href === '/sitemap.md') && !config.excludePrefixes.includes('/sitemap.md')) {
         config.excludePrefixes.push('/sitemap.md')
       }
 
       /* ----------------------------- route rules ---------------------------- */
 
-      // Only the `Link` header, and only on `/`. `Vary` used to be written here
-      // too, once per configured pattern, which under the default `/**` became
-      // a `routeRules` entry matching every path on the site: assets, the API,
-      // `/llms.txt`, `/robots.txt`. A route rule cannot express an exclusion,
-      // so the header now comes from the negotiation middleware, which already
-      // knows exactly which paths have two representations.
+      // Only the `Link` header, and only on `/`. A `Vary` route rule under
+      // `/**` would hit every path on the site and a route rule cannot express
+      // an exclusion, so `Vary` comes from the middleware.
       if (config.linkHeader && config.links.length) {
         nuxt.options.routeRules = defu(nuxt.options.routeRules, {
           '/': { headers: { Vary: MARKDOWN_VARY, Link: formatLinkHeader(config.links) } }
@@ -901,8 +706,7 @@ export {}
       }
 
       // A cached response cannot vary on Accept/User-Agent, so request-time
-      // negotiation is disabled there. The CDN rewrites still cover those
-      // pages because they run before the cache.
+      // negotiation is off there. The CDN rewrites run before the cache.
       collectCachedRoutes(nuxt.options.routeRules)
 
       /* ---------------------------- runtime config --------------------------- */
@@ -918,15 +722,11 @@ export {}
     /* ------------------------------ prerender ------------------------------ */
 
     // The route patterns of every handler the site serves under the raw
-    // prefix, read the way Nitro registers them: one a module registered
-    // (this module's own `${rawPrefix}/**` handler excepted, or every twin
-    // would read as site-owned and nothing would prerender), or a scanned
-    // `server/routes` file, which never reaches `serverHandlers` and is mapped
-    // from its filename the way Nitro maps it (`raw/[...slug].md.get.ts` →
-    // `/raw/**:slug.md`) in every layer's server dir, since a layer's routes
-    // are scanned like the root's. Patterns rather than paths, because a page
-    // matched by a wildcard route has no build-time list of twins: the
-    // runtime asks `siteServesRaw()` per path instead.
+    // prefix: module-registered handlers (this module's own excepted) and
+    // scanned `server/routes` files in every layer, mapped from their filename
+    // the way Nitro maps them (`raw/[...slug].md.get.ts` to `/raw/**:slug.md`).
+    // Patterns rather than paths, since a wildcard route has no build-time
+    // list of twins; the runtime asks `siteServesRaw()` per path.
     const rawSegments = rawPrefix.split('/').filter(Boolean)
     const coversRawPrefix = (pattern: string): boolean => {
       const segments: string[] = []
@@ -959,8 +759,7 @@ export {}
         if (suffix?.index !== undefined && suffix[0]) {
           route = route.slice(0, suffix.index)
         }
-        // A handler that answers no GET serves no twin, and a `.dev` one does
-        // not exist in the build at all.
+        // No GET means no twin, and a `.dev` handler is not in the build.
         const method = suffix?.groups?.method
         if ((method && method !== 'get' && method !== 'head') || suffix?.groups?.env === 'dev') {
           continue
@@ -991,20 +790,13 @@ export {}
       return [...patterns]
     }
 
-    // With a server behind the site, only the built-in source prerenders: a
-    // custom adapter (comark) reads content at request time on purpose. A
-    // fully static build has no server to fall back to, so everything the
-    // discovery documents advertise must be prerendered whatever the source.
-    //
-    // At `modules:done`, not here: a twin the site backs with its own handler
-    // (an swr route reading a live API) must be left alone, or prerendering
-    // freezes it at build, and handlers registered by modules listed later
-    // are not visible yet. The same patterns go into `ownRawRoutes` so the
-    // llms bridge and the negotiation middleware skip their crawler hints for
-    // them too.
-    const staticBuild = Boolean(nuxt.options.nitro?.static) || (nuxt.options as { _generate?: boolean })._generate === true
-    // The twins this pass queued, which stay build errors when they 404: the
-    // site named those patterns, so a missing document there is a mistake.
+    // Behind a server only the built-in source prerenders; a custom adapter
+    // reads content at request time. A static build has no server, so
+    // everything advertised is prerendered whatever the source. At
+    // `modules:done` so handlers registered by later modules are visible: a
+    // twin the site serves itself must not be frozen at build.
+    // Twins queued for exact patterns stay build errors when they 404, since
+    // the site named them.
     const queuedRawRoutes = new Set<string>()
     nuxt.hook('modules:done', () => {
       config.ownRawRoutes = siteRawRoutes()
@@ -1028,10 +820,9 @@ export {}
     /* ------------------------------- presets ------------------------------- */
 
     if (negotiates) {
-      // Nitro's rule table is a fresh object built at `createNitro`, so rules
-      // another module added in `nitro:config` exist only there. The runtime
-      // config was deep-cloned at the same point; syncing Nitro's copy here
-      // still reaches the server bundle, because rollup stringifies it later.
+      // Rules another module added in `nitro:config` exist only in Nitro's
+      // table, and the runtime config was deep-cloned at `createNitro`, so
+      // sync the copy rollup stringifies later.
       nuxt.hook('nitro:build:before', (nitro) => {
         collectCachedRoutes(nitro.options.routeRules)
         const runtime = nitro.options.runtimeConfig.agentDiscovery as NegotiationConfig | undefined
@@ -1040,21 +831,14 @@ export {}
         }
       })
       nuxt.hook('nitro:init', (nitro) => {
-        // The preset collects once more when it emits its table: an inline
-        // `defineRouteRules({ isr })` lands on Nitro's rules during the Nuxt
-        // build, after both passes above, and the CDN table is the one output
-        // late enough to honour it.
+        // The preset collects once more when it emits its table, late enough
+        // to see an inline `defineRouteRules({ isr })`.
         setupVercelPreset(nitro, config, collectCachedRoutes)
 
-        // Every queued twin passes here before Nitro writes it, whichever of
-        // the exact-route pass, the llms bridge or a page's own hint queued
-        // it. One the site serves itself is never frozen, whatever listed it.
-        // One the raw route could not answer as markdown is dropped rather
-        // than written or reported: a section answers a redirect, whose HTML
-        // body Nitro would otherwise store in place of the 302, and a page
-        // with no document behind it answers 404, which is that page's answer
-        // at runtime too and no reason to fail the build. The twins queued for
-        // exact patterns keep their errors: the site named those.
+        // Every queued twin passes here before Nitro writes it. One the site
+        // serves itself is never frozen. One that answered a redirect or a 404
+        // is dropped rather than written or reported, except the twins queued
+        // for exact patterns, which the site named.
         nitro.hooks.hook('prerender:generate', (route) => {
           if (!isRawPath(config, route.route)) {
             return

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -20,11 +20,7 @@ export interface VercelRoute {
   continue?: boolean
 }
 
-/**
- * The negotiation middleware returns early for anything but GET/HEAD, so every
- * emitted route carries the same restriction. Without it a POST to a page path
- * was rewritten or 406ed at the edge where the origin runs its handler.
- */
+/** The negotiation middleware only answers GET/HEAD, so every emitted route carries the same restriction. */
 const METHODS = ['GET', 'HEAD']
 
 interface RouteMatcher {
@@ -36,35 +32,17 @@ interface RouteMatcher {
 const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
 /**
- * A literal path the way the edge sees it: Vercel matches `src` against the
- * percent-encoded request path, and header values must stay ASCII, while the
- * config spells routes decoded. `encodeAgentRoute` is the encoder the raw
- * handler and `hasCdnLinkPair` already use, so the table and the runtime
- * agree on every spelling. Applied before `compilePattern` too, where the
- * static text of a wildcard pattern has the same problem; the wildcards
- * survive it untouched.
+ * Vercel matches `src` against the percent-encoded request path while the
+ * config spells routes decoded. Wildcards survive the encoder untouched.
  */
 const escapeEncoded = (path: string) => escapeRegExp(encodeAgentRoute(path))
 
 /**
- * `Accept` values that explicitly refuse markdown, as an anchored pattern: a
- * `text/markdown` range carrying `q=0`, with or without trailing zeroes, and
- * whatever follows it.
- *
- * The negotiation core reads q-values per RFC 9110, so the Nitro middleware
- * serves HTML for `Accept: text/markdown;q=0, text/html`. A CDN matcher is a
- * plain regex over the raw header, with no way to express "markdown, but not at
- * q=0" as a positive match. A `missing` matcher says it directly: the rewrite
- * applies only when this does not match. A real Vercel edge has been observed
- * anchoring the value and matching it case-insensitively; the Build Output
- * docs only document `caseSensitive` for `src`, so the `[qQ]` below spells
- * both cases and nothing here depends on the observation.
- *
- * `q=0.5` and friends must not match, hence the `(\.0+)?` rather than a loose
- * tail, and the boundary that follows keeps `q=0.05` (a real quality) out. The
- * whitespace before that boundary is load-bearing: RFC 9110 allows spaces
- * around a list separator, and without it `text/markdown;q=0 , text/html` was
- * served markdown by the edge after explicitly refusing it.
+ * `Accept` values that refuse markdown with `q=0`, used as a `missing` matcher
+ * because a regex over the raw header cannot express "markdown, but not at
+ * q=0". `[qQ]` since only `src` documents `caseSensitive`, `(\.0+)?` to keep a
+ * real `q=0.05` out, and the space before the boundary since RFC 9110 allows
+ * one around a list separator.
  */
 const REFUSES_MARKDOWN = String.raw`.*text/markdown\s*;\s*[qQ]=0(\.0+)?(\s*[;,].*)?`
 
@@ -72,45 +50,24 @@ const REFUSES_MARKDOWN = String.raw`.*text/markdown\s*;\s*[qQ]=0(\.0+)?(\s*[;,].
 const TOKEN = String.raw`[a-z0-9!#$%&'*+.^_|~-]+`
 
 /**
- * `Accept` values leaving a negotiated page something to serve: a `text/html`
- * or `text/markdown` range, or a wildcard covering one of them.
- *
- * The `missing` matcher for the 406 route, so the page is refused only when
- * this does not match. Anchored at media-range boundaries the same way
- * `acceptMarkdown` is, and for the same reason: a bare substring also matches
- * inside a parameter value, so `Accept: application/json;profile="text/html"`
- * read as offering HTML when the only range in it is JSON.
- *
- * The list separator has to be a real one too. `(.*,)?` treated the comma in
- * `profile="x,text/html;q=0"` as the end of a range, which put the quoted
- * fragment at the head of the next one and read it as an offer. Only quotes
- * closed before the comma count, so a separator inside a quoted value cannot
- * split the header.
- *
- * Still not the q-value ranking the runtime does, because a matcher is a plain
- * regex over the raw header. A representation offered and then refused with
- * `q=0` reads as offered here, so the edge serves the page where the origin
- * answers 406. That is the fail-safe direction, and the one this route wants
- * above all others.
+ * `Accept` values leaving a negotiated page something to serve, as the
+ * `missing` matcher for the 406 route. Anchored at media-range boundaries, and
+ * a comma inside a quoted value must not split the header, since a bare
+ * substring matches inside a parameter value too. It ranks no q-values, so a
+ * range refused with `q=0` reads as offered and the edge serves the page.
  */
 const ACCEPTS_A_REPRESENTATION = String.raw`(([^"]|"[^"]*")*,)?\s*(text/(html|markdown|\*)|\*/\*)\s*([;,].*)?`
 
 /**
- * An `Accept` carrying at least one media range, however unacceptable.
- *
- * Both halves have to be there: `text/`, `/html` and `text/html/extra` are
- * mangled rather than unacceptable, and the runtime ignores those rather than
- * refusing over them. A looser test here would 406 at the edge what the origin
- * serves, which is the one divergence this route cannot have.
+ * An `Accept` carrying at least one media range. Both halves have to be there:
+ * the runtime ignores a mangled range like `text/` rather than refusing over
+ * it, and a looser test would 406 at the edge what the origin serves.
  */
 const ANY_MEDIA_RANGE = String.raw`(.*,)?\s*${TOKEN}/${TOKEN}\s*([;,].*)?`
 
 /**
- * `has` matcher for the Vercel Build Output API, which anchors the value.
- *
- * Case-folded letter by letter, the way `REFUSES_MARKDOWN` spells `[qQ]`: the
- * origin matches user agents case-insensitively, an observed edge does too,
- * and nothing here may depend on the observation.
+ * `has` matcher for the user agent, which the Build Output API anchors.
+ * Case-folded letter by letter because only `src` documents `caseSensitive`.
  */
 function agentUserAgentPattern(config: NegotiationConfig): string {
   const fold = (value: string) => value.replace(/[a-z]/gi, letter => `[${letter.toLowerCase()}${letter.toUpperCase()}]`)
@@ -123,73 +80,46 @@ function patternDest(pattern: string): string {
   return pattern.replace(/\*\*|\*/g, () => `$${++capture}`)
 }
 
-/**
- * Negative lookahead keeping the excluded prefixes out of a wildcard match,
- * mirroring the runtime's exclusion check.
- */
+/** Keeps the excluded prefixes out of a wildcard match, mirroring the runtime's exclusion check. */
 function excludeLookahead(config: NegotiationConfig): string {
   const prefixes = [`${config.rawPrefix}/`, ...config.excludePrefixes].map(escapeEncoded)
   return `(?!${prefixes.join('|')})`
 }
 
-/**
- * Mirrors the runtime's dotted-asset rule: a dot anywhere in the last path
- * segment means asset, while mid-path dots (`/docs/3.x/...`) stay negotiable.
- */
+/** The runtime's dotted-asset rule: a dot in the last segment means asset, `/docs/3.x/` stays negotiable. */
 const NO_DOTTED_LAST_SEGMENT = String.raw`(?!.*\.[^/]*$)`
 
 /**
  * One negotiated route: a rewrite on a prerendered page, a 307 on a cached one.
- *
- * A rewrite keeps the page URL, which is the whole point of doing this at the
- * CDN rather than redirecting like every other implementation does. It is only
- * safe when the destination is a prerendered file: a response cache keyed on
- * the request path alone ignores `Vary`, so rewriting an `isr`/`swr` page would
- * let its HTML and markdown variants overwrite each other under the same key.
- * Cached patterns get a 307 instead, so each URL keeps a single variant and the
- * client resolves the twin before any cache lookup.
- *
- * `Location` carries no query of its own, and does not need one: `src` matches
- * the pathname excluding the querystring, and the CDN re-attaches the incoming
- * query to the destination itself ("all query strings that are found in the
- * source path will be passed to the destination path"). That is the same thing
- * the Nitro middleware does by hand for the presets that have no CDN, so a
- * query-driven page like `/compare?tools=a,b` reaches
- * `/raw/compare.md?tools=a,b` either way.
+ * A rewrite keeps the page URL, but a response cache keyed on the request path
+ * alone ignores `Vary`, so rewriting an `isr`/`swr` page would let its HTML and
+ * markdown variants overwrite each other under one key. `Location` carries no
+ * query of its own, since the CDN re-attaches the incoming one.
  */
 function negotiatedRoute(src: string, dest: string, has: RouteMatcher[], cached: boolean, missing?: RouteMatcher[]): VercelRoute {
   if (cached) {
     return { src, status: 307, headers: { Location: dest, Vary: MARKDOWN_VARY }, has, ...(missing ? { missing } : {}), methods: METHODS }
   }
-  // `check: true` looks the destination up in the filesystem first, which is
-  // where prerendered raw files live.
+  // `check: true` looks the destination up in the filesystem, where prerendered raw files live.
   return { src, dest, has, ...(missing ? { missing } : {}), methods: METHODS, check: true }
 }
 
 /**
  * Routes prepended to `.vercel/output/config.json` (Build Output API v3) to
  * serve markdown through content negotiation at the edge, where prerendered
- * pages never reach Nitro. The table stays O(route patterns), never O(pages).
+ * pages never reach Nitro. One entry per route pattern, never one per page.
  *
- * The two `Vary` routes must come first and carry `continue: true`: Nitro emits
- * its own `routeRules` header routes *after* these rewrites and without
- * `continue`, so they never run for a request that gets rewritten to a
- * prerendered raw markdown file. The first labels the pages, cached patterns
- * included even though their 307 carries `Vary` itself, so the HTML variant is
- * labelled as well; the second labels the markdown representations those pages
- * send a client to.
+ * The two `Vary` routes come first and carry `continue: true`: Nitro emits its
+ * own `routeRules` header routes after these and without `continue`, so they
+ * never run for a request that gets rewritten to a prerendered file.
  */
 export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
-  // `text/markdown` at the head of a media range, not anywhere in the header.
-  // A bare substring also matched it inside a parameter value, so
-  // `Accept: text/html;profile="text/markdown"` was served markdown.
+  // Anchored at a media-range boundary: a bare substring also matches inside a
+  // parameter value, so `Accept: text/html;profile="text/markdown"` reads as markdown.
   const acceptMarkdown = { type: 'header', key: 'accept', value: String.raw`(.*,)?\s*text/markdown\s*([;,].*)?` }
-  // Only on the `Accept` routes. A known agent user agent gets markdown
-  // whatever its `Accept` says, which is what the negotiation core does too.
+  // Only on the `Accept` routes: a known agent gets markdown whatever its `Accept` says.
   const refusesMarkdown = [{ type: 'header', key: 'accept', value: REFUSES_MARKDOWN }]
-  // An empty list has no matcher, not an empty alternation: `.*().*` matches
-  // every user agent there is, so `userAgents: { replace: [] }` served markdown
-  // to browsers at the edge while the runtime correctly matched nothing.
+  // An empty list has no matcher: `.*().*` matches every user agent there is.
   const agentUserAgent = config.userAgents.length
     ? { type: 'header', key: 'user-agent', value: agentUserAgentPattern(config) }
     : undefined
@@ -197,11 +127,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
 
   const routes: VercelRoute[] = []
 
-  /**
-   * One negotiated pattern: the `Accept` route, then the agent one. A site that
-   * emptied the user-agent list gets the first only, rather than an empty
-   * alternation that matches every client.
-   */
+  /** The `Accept` route, then the agent one, which a site with no user agents left does without. */
   const pushNegotiated = (src: string, dest: string, cached: boolean) => {
     routes.push(negotiatedRoute(src, dest, [acceptMarkdown], cached, refusesMarkdown))
     if (agentUserAgent) {
@@ -209,12 +135,9 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     }
   }
 
-  // Tell CDNs the response depends on `Accept` / `User-Agent`, then keep
-  // routing. The dotted-segment lookahead is what keeps this off the documents
-  // that have a single representation: without it this route labelled
-  // `/llms.txt`, `/robots.txt`, `/sitemap.xml` and every file in `public/`,
-  // which fragments a shared cache per user-agent for nothing. It takes the
-  // `.md` twins out too, which the route below puts back deliberately.
+  // Tell CDNs the response depends on `Accept` / `User-Agent`, then keep routing.
+  // The dotted-segment lookahead keeps this off single-representation documents
+  // like `/llms.txt`, whose shared cache would fragment per user agent.
   const varySources = config.routes.map(route => compilePattern(encodeAgentRoute(route.path)).source.slice(1, -1))
   routes.push({
     src: `^${NO_DOTTED_LAST_SEGMENT}${excluded}(?:${varySources.join('|')})$`,
@@ -223,19 +146,9 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     continue: true
   })
 
-  // The markdown representations themselves: everything under the raw prefix,
-  // the `.md` twins, and `/sitemap.md`. Their own handlers set the header, but
-  // a prerendered file never reaches a handler, and a request one of the
-  // rewrites below matches never reaches what Nitro emits from `routeRules`
-  // either.
-  //
-  // A negotiated page rewrites or 307s to one of these, so the response a
-  // client keeps, and the one a shared cache stores, is the twin's. Labelling
-  // only the page leaves the URL the hop actually lands on saying nothing about
-  // the two representations behind it, which is what a checker following the
-  // redirect sees. The cost is a shared cache keyed per user-agent on these
-  // documents, which is why they were left alone until it turned out the
-  // negotiated pair has to be consistent end to end.
+  // The markdown representations themselves. A prerendered file never reaches
+  // the handler that sets the header, and a negotiated page rewrites or 307s to
+  // one of these, so the pair has to carry `Vary` end to end.
   const twinSources = config.routes.flatMap((route) => {
     if (route.path.includes('*')) {
       return [`${excluded}${compilePattern(encodeAgentRoute(route.path)).source.slice(1, -1)}\\.md`]
@@ -243,9 +156,8 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     // `/` has no `.md` twin URL, matching the rewrite loop below.
     return route.path === '/' ? [] : [`${escapeEncoded(route.path)}\\.md`]
   })
-  // Keyed on the registered link rather than on this module serving the route,
-  // the same way the exclusion is: a site with `sitemap.markdown` off that
-  // serves its own through `discovery.links` needs the label just as much.
+  // Keyed on the registered link, not on this module serving the route: a site
+  // serving its own `/sitemap.md` through `discovery.links` needs the label too.
   const markdownSources = [
     `${escapeEncoded(config.rawPrefix)}/.*`,
     ...twinSources,
@@ -258,24 +170,18 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     continue: true
   })
 
-  // The canonical/alternate pair the raw handler sets, for the prerendered
-  // twins the CDN answers off the filesystem where no handler ever runs.
-  // Unlike `Vary` the value embeds the page URL, so it is one route per
-  // pattern with a capture reference, and it needs a configured site URL: the
-  // edge cannot know the request host at build time, so a zero-config
-  // deployment keeps the header on the origin-rendered responses only.
-  // Deliberately absent from the negotiated page rewrites: those URLs also
-  // serve the HTML representation, which carries no such pair.
+  // The canonical/alternate pair the raw handler sets, for prerendered twins the
+  // CDN answers off the filesystem. The value embeds the page URL, so it needs a
+  // configured site URL: the edge cannot know the request host at build time.
+  // Absent from the page rewrites, whose URLs also serve HTML.
   if (config.siteUrl) {
     const canonicalLink = (href: string) => formatLinkHeader([
       { href, rel: 'canonical' },
       { href, rel: 'alternate', type: 'text/html' }
     ])
-    // Twins with a static entry of their own: every exact pattern whose raw
-    // destination sits under `rawPrefix`, plus the root twin when only a
-    // wildcard covers `/`, whose capture would otherwise mis-derive the page
-    // as `/index`. An exact destination under an excluded prefix is the
-    // site's own document and gets no entry at all.
+    // Twins with a static entry of their own: exact patterns whose raw
+    // destination sits under `rawPrefix`, plus the root twin, whose wildcard
+    // capture would otherwise mis-derive the page as `/index`.
     const isRaw = (raw: string) => isRawPath(config, raw)
     const rootTwin = `${config.rawPrefix}/index.md`
     const statics: { raw: string, href: string }[] = []
@@ -284,32 +190,25 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
         continue
       }
       const raw = rawDestination(config, route, route.path)
-      // Two exact routes can name the same twin (`/` and `/index` both map to
-      // the root twin): one entry per `src`, or the table carries two
-      // conflicting headers. The root twin is always the site URL, because
-      // the origin folds `/index` into `/` whichever route named it.
+      // Two exact routes can name the same twin, `/` and `/index` both mapping to
+      // the root one: one entry per `src`, or two conflicting headers.
       if (!isRaw(raw) || statics.some(entry => entry.raw === raw)) {
         continue
       }
-      // The origin folds a trailing `/index` into the directory it indexes,
-      // so `/docs/index`'s twin advertises `/docs`, the URL that answers.
-      // Encoded like the raw handler's `canonicalUrl`, and because a raw
-      // UTF-8 header value is invalid at the edge anyway.
+      // The origin folds a trailing `/index` into the directory it indexes, so
+      // `/docs/index`'s twin advertises `/docs`, the URL that answers.
       const page = route.path.endsWith('/index') ? route.path.slice(0, -6) || '/' : route.path
       statics.push({ raw, href: page === '/' || raw === rootTwin ? config.siteUrl : `${config.siteUrl}${encodeAgentRoute(page)}` })
     }
     if (!statics.some(entry => entry.raw === rootTwin)) {
-      // `/raw/index.md` folds to `/` at the origin whatever the patterns say
-      // (the generated index serves it), so the wildcard capture must never
-      // read it as `/index`. Keyed on the twin, not on a `/` route existing:
-      // a `/` route with a `raw` override elsewhere leaves the twin unowned.
+      // `/raw/index.md` folds to `/` at the origin whatever the patterns say, so
+      // the wildcard capture must never read it as `/index`.
       statics.push({ raw: rootTwin, href: config.siteUrl })
     }
     // The wildcard capture must not also match a statically-mapped twin.
     const rawExclusion = statics.length ? `(?!(?:${statics.map(entry => escapeEncoded(entry.raw.slice(config.rawPrefix.length))).join('|')})$)` : ''
     // A trailing `/index` folds away at the origin, so a capture reading
-    // `/docs/index.md` would advertise `/docs/index`, a page URL the handler
-    // never serves. Those twins carry no edge pair rather than a wrong one.
+    // `/docs/index.md` would advertise a page URL the handler never serves.
     const noIndex = String.raw`(?!.*/index\.md$)`
     for (const route of config.routes) {
       if (route.path.includes('*')) {
@@ -318,8 +217,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
         routes.push({ src: `^${excluded}${noIndex}${body}\\.md$`, headers: { Link: link }, methods: METHODS, continue: true })
         routes.push({ src: `^${escapeEncoded(config.rawPrefix)}${rawExclusion}${noIndex}${body}\\.md$`, headers: { Link: link }, methods: METHODS, continue: true })
       } else if (route.path !== '/' && !route.path.endsWith('/index') && isRaw(rawDestination(config, route, route.path))) {
-        // An index-shaped exact path folds like the wildcard capture above,
-        // so its page twin gets no entry either.
+        // An index-shaped exact path folds the same way, so its twin gets no entry.
         routes.push({ src: `^${escapeEncoded(route.path)}\\.md$`, headers: { Link: canonicalLink(`${config.siteUrl}${encodeAgentRoute(route.path)}`) }, methods: METHODS, continue: true })
       }
     }
@@ -329,17 +227,9 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   }
 
   // Opt-in: a negotiated page has exactly two representations, so an `Accept`
-  // allowing neither is a 406 per RFC 9110 rather than a page the client just
-  // said it cannot read. Emitted here as well as in the middleware because a
-  // prerendered page is answered off the filesystem and never reaches it, so
-  // without this the option would be on for the pages Nitro renders and
-  // quietly off for the rest of the site.
-  //
-  // The guards are the middleware's, as matchers: an `Accept` has to be there
-  // and carry a media range at all, must not offer a representation, and a
-  // navigation or a known agent is never refused. The body is empty, where the
-  // origin renders the markdown one, which is the price of answering before
-  // anything runs.
+  // allowing neither is a 406 per RFC 9110. Emitted here as well as in the
+  // middleware because a prerendered page never reaches it, which would leave
+  // the option on for the pages Nitro renders and off for the rest of the site.
   if (config.notAcceptable) {
     routes.push({
       src: `^${NO_DOTTED_LAST_SEGMENT}${excluded}(?:${varySources.join('|')})$`,
@@ -356,8 +246,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   }
 
   // The `/` routeRule carries the same `Link` header, but a homepage request
-  // rewritten below to a prerendered raw markdown file never reaches it.
-  // Deliberately method-agnostic, mirroring the route rule it stands in for.
+  // rewritten below never reaches it. Method-agnostic like the rule it stands in for.
   const linkHeader = config.linkHeader ? formatLinkHeader(config.links) : ''
   if (linkHeader) {
     routes.push({
@@ -367,25 +256,20 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     })
   }
 
-  // Whether a rule covers a whole pattern, so the pattern itself is demoted to
-  // a redirect. Comparing static-prefix lengths instead used to tie `/` with
-  // `/**`, so a single cached homepage demoted every page on the site.
+  // Whether a rule covers a whole pattern, so the pattern itself is demoted to a redirect.
   const patternCached = (pattern: string) => config.cachedRoutes.some(rule => ruleCoversPattern(rule, pattern))
 
   // A cached rule narrower than the pattern covering it, `routeRules['/docs/**']`
   // under the default `/**`, gets its own 307 pair ahead of that pattern's
-  // rewrite. Marking the whole pattern cached instead would demote every page on
-  // the site to a redirect because one section happens to be cached.
+  // rewrite. Marking the whole pattern cached would demote every page on the site.
   for (const rule of config.cachedRoutes) {
-    // An exact rule is only negotiable through the route it matches. Without
-    // one there is no twin to send the client to, and inventing a
-    // `rawPrefix + rule + '.md'` destination 307s to a URL that 404s.
+    // An exact rule is only negotiable through the route it matches: without one
+    // there is no twin, and an invented `rawPrefix + rule + '.md'` 307s to a 404.
     const wildcard = rule.includes('*')
     const matched = wildcard ? undefined : matchRoute(config.routes, rule)
 
-    // This loop handles what a rule caches *beyond* the patterns it fully
-    // covers; those are demoted wholesale below. Skipping a rule with nothing
-    // left over is what keeps a path from collecting two redirects.
+    // This loop handles what a rule caches beyond the patterns it fully covers,
+    // which are demoted wholesale below, or a path collects two redirects.
     if (wildcard) {
       if (!config.routes.some(route => patternsOverlap(rule, route.path) && !patternCached(route.path))) {
         continue
@@ -405,34 +289,26 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   }
 
   for (const route of config.routes) {
-    // Cached only when a rule covers the pattern itself. A narrower rule was
-    // handled above, so this pattern keeps its rewrite for everything outside
-    // it. The `.md` twins stay rewrites either way: that URL only ever serves
-    // markdown, so there is no second variant to poison.
+    // Cached only when a rule covers the pattern itself; a narrower rule was
+    // handled above. The `.md` twins stay rewrites: that URL serves one variant.
     const cached = patternCached(route.path)
 
     if (route.path.includes('*')) {
       const body = compilePattern(encodeAgentRoute(route.path)).source.slice(1, -1)
       const dest = `${encodeAgentRoute(config.rawPrefix)}${patternDest(encodeAgentRoute(route.path))}.md`
-      // Explicit `.md` twin URLs, whatever the headers say. The last wildcard
-      // capture stops before the suffix thanks to the `\.md$` anchor.
       routes.push({
         src: `^${excluded}${body}\\.md$`,
         dest,
         methods: METHODS
       })
-      // The dotted-last-segment lookahead keeps `.md` URLs on the rewrite above
-      // and assets (`_payload.json`, images) out.
       pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${body}$`, dest, cached)
     } else {
       const dest = encodeAgentRoute(rawDestination(config, route, route.path))
       if (route.path !== '/') {
         routes.push({ src: `^${escapeEncoded(route.path)}\\.md$`, dest, methods: METHODS })
       }
-      // The same two guards the wildcard branch carries. Without them an exact
-      // pattern negotiated at the edge where the runtime refuses it: a dotted
-      // one like `/faq.html` reads as an asset, and `/mcp` sits behind an
-      // excluded prefix.
+      // The same two guards as the wildcard branch: `/faq.html` reads as an asset
+      // and `/mcp` sits behind an excluded prefix, both refused by the runtime.
       pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${escapeEncoded(route.path)}/?$`, dest, cached)
     }
   }
@@ -442,25 +318,18 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
 
 /**
  * Patches the Vercel Build Output config after Nitro compiles. We edit
- * `.vercel/output/config.json` (Build Output API v3), not `vercel.json`,
- * which has a different schema. The `check: true` and `continue` flags are
- * documented on the Source route type:
- * https://vercel.com/docs/build-output-api/configuration
+ * `.vercel/output/config.json` (Build Output API v3), not `vercel.json`, which
+ * has a different schema. https://vercel.com/docs/build-output-api/configuration
  */
 export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig, collectCachedRoutes?: (routeRules: Nitro['options']['routeRules']) => void) {
-  // `nuxt generate` on Vercel resolves the `vercel-static` preset, whose name
-  // contains "vercel" but which emits no function routes at all. Patching the
-  // table there leaves rewrites pointing at a filesystem that only holds what
-  // was prerendered, with nothing behind them to fall through to.
+  // `nuxt generate` resolves the `vercel-static` preset, whose name contains
+  // "vercel" but which emits no function routes to fall through to.
   if (nitro.options.dev || nitro.options.static || !nitro.options.preset.includes('vercel')) {
     return
   }
-  // The emitted table injects the canonical/alternate `Link` pair on the raw
-  // twins (only with a site URL, see `vercelMarkdownRoutes`). Told to the
-  // runtime so the raw handler skips its own copy exactly there, or every
-  // origin-rendered raw response carries the pair twice, doubling per hop.
-  // On Nitro's copy of the config: the module-scope one was cloned away at
-  // `createNitro`, and rollup stringifies this one later.
+  // The emitted table injects the `Link` pair on the raw twins, so the raw
+  // handler has to skip its own copy or every origin-rendered raw response
+  // carries it twice. Set on Nitro's copy: the module-scope one was cloned away.
   if (config.siteUrl) {
     const runtime = nitro.options.runtimeConfig.agentDiscovery as NegotiationConfig | undefined
     if (runtime) {
@@ -469,13 +338,8 @@ export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig, colle
   }
   nitro.hooks.hook('compiled', async () => {
     // The last read of the rule table before it decides rewrite or 307: an
-    // inline `defineRouteRules({ isr })` only lands on it during the Nuxt
-    // build, after every module hook has run. The runtime config is already
-    // inlined by now, so a rule that changed between `nitro:build:before` and
-    // here reaches this table only and the origin keeps the earlier list.
-    // Benign in both directions: a rule appearing here demotes the pattern to
-    // a 307, and one disappearing leaves a rewrite landing on `/raw/**.md`,
-    // where the middleware never takes its 307 branch.
+    // inline `defineRouteRules({ isr })` only lands on it during the Nuxt build,
+    // after every module hook has run.
     collectCachedRoutes?.(nitro.options.routeRules)
     const vcJSON = resolve(nitro.options.output.dir, 'config.json')
     const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8'))

--- a/src/rels.ts
+++ b/src/rels.ts
@@ -1,12 +1,8 @@
 /**
- * Link relations accepted for discovery links.
- *
- * The IANA Link Relations registry
- * (https://www.iana.org/assignments/link-relations), plus `sitemap`, which is
- * not registered but is the de-facto relation every crawler understands.
- * Extension relations are allowed as absolute URIs, per RFC 8288 § 2.1.2.
- * Everything else (`llms`, `mcp`, `design`, ...) fails the build: invented
- * rels are exactly the drift this module exists to stop.
+ * Link relations accepted for discovery links: the IANA registry
+ * (https://www.iana.org/assignments/link-relations) plus the unregistered but
+ * universally understood `sitemap`. Extension relations are allowed as absolute
+ * URIs, per RFC 8288 § 2.1.2, and anything else fails the build.
  */
 const IANA_RELS = new Set([
   'about', 'acl', 'alternate', 'amphtml', 'api-catalog', 'appendix',
@@ -33,7 +29,6 @@ const IANA_RELS = new Set([
   'stylesheet', 'subsection', 'successor-version', 'sunset', 'tag',
   'terms-of-service', 'timegate', 'timemap', 'type', 'ugc', 'up',
   'version-history', 'via', 'webmention', 'working-copy', 'working-copy-of',
-  // De-facto, unregistered but universally understood.
   'sitemap'
 ])
 

--- a/src/runtime/app/composables/useCanonical.ts
+++ b/src/runtime/app/composables/useCanonical.ts
@@ -4,9 +4,8 @@ import { joinURL } from 'ufo'
 import { useHead, useRequestURL, useRoute, useRuntimeConfig } from '#imports'
 
 /**
- * Adds a canonical URL for the current route plus, optionally, a
- * `rel="alternate"; type="text/markdown"` link pointing at the agent-friendly
- * markdown counterpart:
+ * Adds a canonical link for the current route, plus a
+ * `rel="alternate"; type="text/markdown"` link when a markdown twin is given.
  *
  * ```ts
  * useCanonical(() => `${route.path}.md`)

--- a/src/runtime/server/error.ts
+++ b/src/runtime/server/error.ts
@@ -5,13 +5,10 @@ import { errorMarkdown, prefersMarkdownError, MARKDOWN_VARY } from '../shared/ne
 
 /**
  * Answers errors with a short markdown body when the client is asking for
- * markdown (explicit `Accept`, a known AI agent, a `.md` URL, or any
- * non-browser client requesting a page).
+ * markdown.
  *
  * Registered ahead of Nuxt's HTML error handler through the `nitro:config`
- * hook. Returning without writing a response hands the error back to the
- * chain, so browsers keep the HTML error page and API clients keep the JSON
- * payload.
+ * hook. Returning without writing a response hands the error back to the chain.
  */
 const errorHandler: NitroErrorHandler = async (error, event, { defaultHandler }) => {
   if (event.handled || getRequestHeader(event, 'x-nuxt-error')) {
@@ -30,9 +27,8 @@ const errorHandler: NitroErrorHandler = async (error, event, { defaultHandler })
     return
   }
 
-  // Nitro's default handler is what logs unhandled errors, sets the status
-  // and computes the hardening headers (`nosniff`, `x-frame-options`, ...).
-  // Nuxt's HTML handler goes through it too, so keep the same behavior.
+  // The default handler logs the error, sets the status and computes the
+  // hardening headers. Nuxt's HTML handler goes through it too.
   const res = await defaultHandler(error, event, { json: true })
   const status = res.status || error.statusCode || 500
 
@@ -47,15 +43,13 @@ const errorHandler: NitroErrorHandler = async (error, event, { defaultHandler })
   setResponseHeader(event, 'Vary', MARKDOWN_VARY)
   setResponseHeader(event, 'Cache-Control', 'no-cache')
 
-  // A route can report the path the client asked for (see the raw route,
-  // which serves page paths) through `data.path`.
+  // A route can report the path the client asked for through `data.path`.
   const data = error.data as { path?: unknown } | undefined
 
   return send(event, errorMarkdown(config, {
     path: typeof data?.path === 'string' ? data.path : event.path,
     status,
-    // Not sanitized on the way here: `createError` only warns about an unsafe
-    // status message, and Nitro returns it verbatim. `errorMarkdown` strips it.
+    // Nitro returns the status message verbatim, so `errorMarkdown` strips it.
     statusMessage: res.statusText,
     siteUrl: getAgentSiteUrl(event)
   }))

--- a/src/runtime/server/mcp/definitions.ts
+++ b/src/runtime/server/mcp/definitions.ts
@@ -1,7 +1,6 @@
 /**
- * `@nuxtjs/mcp-toolkit`'s listing API, behind the `#agent-discovery/mcp`
- * alias. Aliased to `none.ts` when the toolkit is absent or has bailed out,
- * so this import only ever runs where the toolkit's own virtual modules
- * (`#nuxt-mcp-toolkit/tools.mjs`, which `listMcpDefinitions` imports) exist.
+ * `@nuxtjs/mcp-toolkit`'s listing API, behind the `#agent-discovery/mcp` alias.
+ * Aliased to `none.ts` when the toolkit is absent or has bailed out, since this
+ * import pulls in the toolkit's own virtual modules.
  */
 export { listMcpDefinitions } from '@nuxtjs/mcp-toolkit/server'

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -4,26 +4,18 @@ import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { isNegotiablePath, negotiatedRawPath, normalizePathname, notAcceptable, prerenderTwin, ruleMatchesPath, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
- * Serves markdown through content negotiation on the Nitro server.
+ * Serves markdown through content negotiation on the Nitro server. On Vercel
+ * the same negotiation happens at the edge, so this covers dev and the other
+ * presets, where those rewrites don't exist.
  *
- * In production on Vercel the same negotiation happens at the edge, before
- * the filesystem is consulted. Those rewrites don't exist in dev or on other
- * presets, so this covers `.md` twin URLs, `Accept: text/markdown` and known
- * AI agents there, and answers unknown pages with the markdown 404 from the
- * raw route.
- *
- * Caveat: Nitro serves prerendered files ahead of user handlers, so on a
- * built Node server a prerendered page stays HTML while `.md` URLs and
- * never-prerendered pages come through here. In dev nothing is prerendered,
- * so every path is negotiated.
+ * Nitro serves prerendered files ahead of user handlers, so on a built Node
+ * server only `.md` URLs and never-prerendered pages reach here.
  */
 export default defineEventHandler(async (event) => {
   if (import.meta.prerender) {
-    // Nothing negotiates at build, but every page rendered here has a twin
-    // the crawler cannot find on its own: `.md` links are not followed, and
-    // the header is only read off HTML responses, so this one is the place.
-    // Encoded the way Nuxt's `prerenderRoutes()` does, since Nitro splits the
-    // header on commas and decodes each part.
+    // The crawler cannot find a page's twin on its own: `.md` links are not
+    // followed. Encoded the way `prerenderRoutes()` does, since Nitro splits
+    // the header on commas and decodes each part.
     const twin = prerenderTwin(useAgentDiscoveryConfig(event), event.path)
     if (twin) {
       appendResponseHeader(event, 'x-nitro-prerender', encodeURIComponent(twin))
@@ -43,22 +35,15 @@ export default defineEventHandler(async (event) => {
   const rawPath = negotiatedRawPath(config, event.path, { accept, userAgent })
 
   if (!rawPath) {
-    // The HTML half of a page that has both representations. Its markdown half
-    // is labelled further down, and a shared cache that stored this one without
-    // `Vary` would replay the HTML to an agent asking for markdown.
-    //
-    // Set here rather than through a `routeRules` header: a route rule cannot
-    // express a negative pattern, so a catch-all pattern labelled every asset,
-    // every discovery document and the whole API surface as varying.
+    // A shared cache storing the HTML half without `Vary` would replay it to an
+    // agent asking for markdown. Not a `routeRules` header, since a route rule
+    // has no negative pattern and a catch-all would label every asset too.
     if (isNegotiablePath(config, event.path)) {
       setResponseHeader(event, 'Vary', MARKDOWN_VARY)
     }
 
-    // Those two representations are all there is, so an `Accept` allowing
-    // neither has nothing to be served. Opt-in through `notAcceptable`, and
-    // guarded there against everything that sends a narrow `Accept` without
-    // meaning it. The error handler renders the body, listing what the page
-    // does have.
+    // Nothing to serve when neither representation is acceptable. The error
+    // handler renders the body.
     if (notAcceptable(config, {
       method: event.method,
       path: event.path,
@@ -73,26 +58,17 @@ export default defineEventHandler(async (event) => {
   }
 
   // A cached response cannot vary on Accept/User-Agent, so in production a
-  // negotiated page is redirected to its raw twin rather than answered in
-  // place, the same thing the CDN routes do. An explicit `.md` URL is not
-  // negotiated (it has one variant, so its cache entry is safe) and is served
-  // normally. Dev has no response cache, and a site that caches every page
-  // (ISR on Vercel) would otherwise never negotiate locally.
-  //
-  // The query has to be re-attached by hand here. The CDN 307 gets it for
-  // free, because Vercel matches a route's `src` against the pathname alone
-  // and passes the incoming query on to the destination, so both paths land on
-  // the same URL for a page whose content is its query.
+  // negotiated page is redirected to its raw twin the way the CDN routes do.
+  // An explicit `.md` URL has one variant, so its cache entry is safe.
   const pathname = normalizePathname(event.path)
   if (!import.meta.dev && !pathname.endsWith('.md')
     && config.cachedRoutes.some(rule => ruleMatchesPath(rule, pathname))) {
-    const query = event.path.slice(event.path.indexOf('?') + 1)
+    const index = event.path.indexOf('?')
     setResponseHeader(event, 'Vary', MARKDOWN_VARY)
-    return sendRedirect(event, event.path.includes('?') ? `${rawPath}?${query}` : rawPath, 307)
+    return sendRedirect(event, index === -1 ? rawPath : `${rawPath}${event.path.slice(index)}`, 307)
   }
 
-  // Forward the host headers so the raw handler resolves the same site URL
-  // as the outer request.
+  // Host headers forwarded so the raw handler resolves the same site URL.
   const headers: Record<string, string> = { accept: 'text/markdown' }
   for (const name of ['host', 'x-forwarded-host', 'x-forwarded-proto']) {
     const value = getRequestHeader(event, name)
@@ -101,24 +77,21 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  // The query rides along: the CDN re-attaches it to a rewrite destination for
-  // free, and the redirect branch above does it by hand, so a source whose
-  // pages depend on the query has to see it here too.
+  // The query rides along, since a source's pages can depend on it.
   const queryIndex = event.path.indexOf('?')
   const response = await useNitroApp().localFetch(
     queryIndex === -1 ? rawPath : `${rawPath}${event.path.slice(queryIndex)}`,
     { headers }
   )
 
-  // The inner request has already handled and logged the original failure
-  // against the raw path; rethrowing reports the status on the path the
-  // client asked for and keeps its `Cache-Control: no-cache`.
+  // Rethrown so the status lands on the path the client asked for, keeping the
+  // `Cache-Control: no-cache` that goes with it.
   if (response.status >= 500) {
     throw createError({ statusCode: response.status, statusMessage: response.statusText })
   }
 
-  // The raw route redirects a section path to its first document. Replaying the
-  // status alone would hand the client a 3xx with no `Location` to follow.
+  // The raw route redirects a section path to its first document, so the status
+  // alone would hand the client a 3xx with no `Location` to follow.
   const location = response.headers.get('location')
   if (response.status >= 300 && response.status < 400 && location) {
     setResponseHeader(event, 'Vary', MARKDOWN_VARY)
@@ -127,12 +100,7 @@ export default defineEventHandler(async (event) => {
 
   setResponseStatus(event, response.status)
   setResponseHeader(event, 'Content-Type', response.headers.get('content-type') || 'text/markdown; charset=utf-8')
-  // The markdown half of a page that also has an HTML one, and the explicit
-  // `.md` twin that reaches here too. That URL serves markdown to every client,
-  // so nothing about it depends on the request, but it is where a negotiated
-  // page sends one, and the raw route it proxies labels its own responses the
-  // same way. Leaving it off here made the twin the one URL in the chain whose
-  // answer differed by preset.
+  // Also on the explicit `.md` twin, which the raw route labels the same way.
   setResponseHeader(event, 'Vary', MARKDOWN_VARY)
 
   for (const name of ['cache-control', 'x-content-type-options', 'x-frame-options', 'referrer-policy']) {

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -9,7 +9,7 @@ import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discove
 import { appendAgentResources, generatedIndexPage, getSourcePage } from '../utils/document'
 import { hasFileExtension, isExcluded, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination, siteServesRaw } from '../../shared/negotiation'
 
-interface LlmsSection {
+type LlmsSection = {
   title: string
   description?: string
   links?: { title: string, description?: string, href: string }[]
@@ -33,24 +33,18 @@ function toLocalUrl(href: string, domain: string): { pathname: string, suffix: s
 }
 
 /**
- * The page route a link points at, or `undefined` when it names something with
- * no markdown representation: another origin, `llms-full.txt`, an asset, an
- * endpoint under an excluded prefix.
- *
- * Judged by exclusion and extension alone, not by `routes`: a curated section
- * may name pages outside the negotiated patterns, and listing them is its
- * call, so a site narrowing `routes` must not get its curation duplicated by
- * the whole-site fallback. What has to stay out is data, `/openapi.json` by
- * its extension and `/api/v1/tools` by its prefix.
+ * The page route a link points at, or `undefined` when it names something with no
+ * markdown representation. Judged by exclusion and extension alone, not by
+ * `routes`: a curated section may name pages outside the negotiated patterns, and
+ * listing them is its call.
  */
 function pageRoute(config: NegotiationConfig, href: string, domain: string): string | undefined {
   const local = toLocalUrl(href, domain)
   if (!local) {
     return undefined
   }
-  // `URL.pathname` comes out percent-encoded while every backend stores
-  // decoded paths, so the route is decoded the same way the raw handler
-  // decodes its slug, or a curated link to `/docs/café` resolves no page.
+  // `URL.pathname` comes out percent-encoded while every backend stores decoded
+  // paths, or a curated link to `/docs/café` resolves no page.
   const route = normalizeAgentRoute(local.pathname)
   return !isExcluded(route, config) && (route === '/' || !hasFileExtension(route)) ? route : undefined
 }
@@ -59,11 +53,8 @@ function pageRoute(config: NegotiationConfig, href: string, domain: string): str
 const CONCURRENCY = 8
 
 /**
- * `Promise.all` with a bounded number of workers, results in input order.
- *
- * A documentation site hands this hundreds of routes and sections, and firing
- * every `get()` at once is what turns building `llms-full.txt` into a burst
- * the content backend has to absorb in one go.
+ * `Promise.all` with a bounded number of workers, results in input order. Firing
+ * every `get()` at once turns `llms-full.txt` into a burst the backend absorbs whole.
  */
 async function mapLimit<T, R>(items: T[], task: (item: T) => R | Promise<R>): Promise<R[]> {
   const results: R[] = []
@@ -78,11 +69,9 @@ async function mapLimit<T, R>(items: T[], task: (item: T) => R | Promise<R>): Pr
 }
 
 /**
- * The adapter's listing with every route normalized the way `listAgentPages`
- * does, so an adapter listing its homepage as `/index` lands on the same `/`
- * the landing-page checks and the resources append key on, and an encoded
- * slug meets the exclusion filter decoded. `llms.txt` and `llms-full.txt` go
- * through this one call, so the two cannot disagree on what a page is.
+ * The adapter's listing with every route normalized the way `listAgentPages` does,
+ * so an adapter listing its homepage as `/index` lands on the same `/` the
+ * landing-page checks key on. `llms.txt` and `llms-full.txt` share this one call.
  */
 async function listPages(adapter: NonNullable<typeof source>, selector: Record<string, unknown> | undefined, event: H3Event): Promise<AgentListEntry[]> {
   return ((await adapter.list?.(selector, event)) || []).map(entry => ({ ...entry, route: normalizeAgentRoute(entry.route) }))
@@ -114,14 +103,9 @@ function groupBySection(entries: AgentListEntry[]): Map<string, AgentListEntry[]
 /**
  * The `nuxt-llms` bridge, and the only place `llms.txt` gets its pages.
  *
- * `@nuxt/content`'s own llms feature is removed by the module (see the bridge
- * block in `src/module.ts`) because it rendered `llms-full.txt` through a
- * second markdown pipeline that disagreed with `/raw/**.md` and had no comark
- * equivalent. Sections and documents both come from the content adapter now, so
- * every backend produces the same document, and a site's `llms.sections` config
- * keeps working: the section is handed to the adapter, which reads the keys it
- * declares (`contentCollection`/`contentFilters` for `@nuxt/content`,
- * `navigation` for comark).
+ * Sections and documents both come from the content adapter, so every backend
+ * produces the same document and a site's `llms.sections` config keeps working:
+ * the section is handed over, and the adapter reads the keys it declares.
  */
 export default defineNitroPlugin((nitroApp: NitroApp) => {
   const prerenderPaths = new Set<string>()
@@ -131,17 +115,12 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     const domain = options.domain || getAgentSiteUrl(event)
 
     if (source) {
-      // Narrowed once, because the check above does not carry into the
-      // closures below.
       const adapter = source
 
-      // Sections the site declared. One that already carries links is left
-      // alone; otherwise the adapter is asked whether the section names
-      // something it can resolve. Sections do not depend on each other, so the
-      // adapter is asked about all of them at once.
+      // A section that already carries links owns its curation and is left alone.
       const resolved = await mapLimit(options.sections, section => section.links?.length
         ? null
-        : listPages(adapter, section as unknown as Record<string, unknown>, event))
+        : listPages(adapter, section, event))
 
       const unresolved: LlmsSection[] = []
       for (const [index, section] of options.sections.entries()) {
@@ -152,9 +131,7 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         if (entries?.length) {
           section.links = entries.map(entry => toLink(entry, domain))
         } else if (!section.description) {
-          // A selector no adapter recognises, or one that matched nothing: a
-          // section left with neither links nor prose renders as a dangling
-          // heading. Config that outlived a backend swap is the common case.
+          // Neither links nor prose renders as a dangling heading.
           unresolved.push(section)
         }
       }
@@ -162,14 +139,13 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         options.sections.splice(options.sections.indexOf(section), 1)
       }
 
-      // Nothing resolved to pages, so list them all. Only a link the site
-      // serves markdown for counts as a page: the "Documentation Sets" section
-      // `nuxt-llms` contributes points at `llms-full.txt`, and a site listing
-      // its API endpoints has named no documentation either.
+      // Only a link the site serves markdown for counts as a page: the
+      // "Documentation Sets" section `nuxt-llms` contributes points at
+      // `llms-full.txt`, and API endpoints are not documentation either.
       const hasPageLinks = options.sections.some(section => section.links?.some(link => pageRoute(config, link.href, domain)))
       if (!hasPageLinks) {
         // The same filter `listAgentPages` applies, so the fallback cannot
-        // advertise pages `sitemap.md` deliberately hides.
+        // advertise pages `sitemap.md` hides.
         const entries = (await listPages(adapter, undefined, event)).filter(entry => !isExcluded(entry.route, config))
         for (const [title, group] of groupBySection(entries)) {
           options.sections.push({
@@ -181,13 +157,9 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       }
     }
 
-    // The landing page. An adapter whose pages come from structured data has no
-    // `/` entry (its homepage is a Vue page), but the module still serves
-    // `/raw/index.md` for it, so without this nothing links the document an
-    // agent is most likely to want first.
+    // An adapter whose homepage is a Vue page has no `/` entry, yet the module
+    // still serves `/raw/index.md` for it.
     const linked = options.sections.some(section => section.links?.some(link => toLocalUrl(link.href, domain)?.pathname === '/'))
-    // The exclusion guard is for symmetry with the fallback listings: a site
-    // excluding `/` has said the landing page is not agent surface.
     if (source && !linked && !isExcluded('/', config) && matchRoute(config.routes, '/')) {
       options.sections.unshift({
         title: 'Overview',
@@ -195,7 +167,6 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       })
     }
 
-    // Rewrite page links to their raw markdown twins.
     for (const section of options.sections) {
       if (!section.links) {
         continue
@@ -207,11 +178,8 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         }
         const { pathname, suffix } = local
 
-        // Off-site links keep whatever they were written as, but a same-origin
-        // one has to come out absolute: `llms.txt` is read detached from the
-        // site, so a relative href in it points nowhere. An excluded path is
-        // the site's own document, not a page with a raw twin: rewriting it
-        // would mint a URL that 404s.
+        // A same-origin link comes out absolute, since `llms.txt` is read detached
+        // from the site. An excluded path has no raw twin to rewrite it to.
         const route = (pathname === '/' || !hasFileExtension(pathname)) && !isExcluded(pathname, config)
           ? matchRoute(config.routes, pathname)
           : undefined
@@ -220,9 +188,8 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         }
 
         const raw = rawDestination(config, route, pathname)
-        // A twin the site serves with its own handler must not reach the
-        // crawler: prerendering it freezes live data at build. The link still
-        // points there, the handler answers it per request.
+        // Prerendering a twin the site serves with its own handler freezes live
+        // data at build. The link still points there, the handler answers it.
         if (!siteServesRaw(config, raw)) {
           prerenderPaths.add(raw)
         }
@@ -235,17 +202,12 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     if (!source) {
       return
     }
-    // Narrowed once, because the check above does not carry into the closures
-    // below.
     const adapter = source
     const config = useAgentDiscoveryConfig(event)
     const domain = options.domain || getAgentSiteUrl(event)
 
-    // The full document follows the sections the site declared, the same set
-    // `llms.txt` lists. Rendering every route instead pulls in pages kept out
-    // of the documentation on purpose: a landing page, a showcase, a template
-    // gallery. A section names its pages through a selector the adapter
-    // resolves, or through the links it curates by hand, and both end up here.
+    // The full document follows the sections the site declared. Rendering every
+    // route instead pulls in a showcase, a template gallery, a landing page.
     const routes: string[] = []
     const seen = new Set<string>()
     const add = (route: string) => {
@@ -255,23 +217,17 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
       }
     }
 
-    // Selectors resolved together, then added in section order: the dedupe
-    // keeps the first route it sees, so the order the document comes out in
-    // has to be the order the sections are declared in.
+    // Selectors resolved together, then added in section order: the dedupe keeps
+    // the first route it sees, so declaration order is the document's order.
     const sections = options.sections || []
-    // The same guard `llms.txt` applies: a section carrying its own links owns
-    // its curation, so its selector must not smuggle in pages the index hides.
     const resolved = await mapLimit(sections, section => section.links?.length
       ? null
-      : listPages(adapter, section as unknown as Record<string, unknown>, event))
+      : listPages(adapter, section, event))
     for (const [index, section] of sections.entries()) {
       for (const entry of resolved[index] || []) {
         add(entry.route)
       }
-      // A section curating its documentation by hand names it in its links, so
-      // the pages behind them are what the full document is. Everything else a
-      // section can point at (`/openapi.json`, an API endpoint, another site)
-      // has no page to render, and `llms.txt` reads those links the same way.
+      // A section's other links name data or another site, so no page to render.
       for (const link of section.links || []) {
         const route = pageRoute(config, link.href, domain)
         if (route) {
@@ -279,31 +235,23 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
         }
       }
     }
-    // No section named a page, so render them all, on the same condition
-    // `llms.txt` lists them all. Sections pointing only at data name no
-    // documentation, so that site still gets its whole site, as does one with
-    // no sections at all.
+    // No section named a page, so render them all, matching what `llms.txt` lists.
     if (!routes.length) {
       for (const entry of await listPages(adapter, undefined, event)) {
-        // The same filter `listAgentPages` applies, matching the index hook.
         if (!isExcluded(entry.route, config)) {
           add(entry.route)
         }
       }
     }
 
-    // The landing page, mirroring the index hook: `llms.txt` links `/` (or
-    // its generated `/raw/index.md`) whenever no section names it, so the
-    // full document has to hold the page it advertises.
+    // Mirrors the index hook: `llms.txt` links `/` whenever no section names it,
+    // so the full document has to hold the page it advertises.
     if (!seen.has('/') && !isExcluded('/', config) && matchRoute(config.routes, '/')) {
       routes.unshift('/')
     }
 
-    // The same `get()` the raw route calls, so a page reads identically
-    // whether an agent fetches `/raw/**.md` or the single full document. `/`
-    // is the one route with a fallback: an adapter with no `/` entry still
-    // has the generated index behind `/raw/index.md`, and one that does carries
-    // the same resources block the raw route appends.
+    // The same `get()` the raw route calls, so a page reads identically whether an
+    // agent fetches `/raw/**.md` or the full document. `/` alone has a fallback.
     const pages = await mapLimit(routes, async (route) => {
       const page = await getSourcePage(route, event)
       if (route !== '/') {
@@ -320,13 +268,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     }
   }) as never)
 
-  // Lets Nitro's prerender crawler discover the twins `llms.txt` links to
-  // whose pages are never rendered as HTML; a page that is rendered hands the
-  // crawler its own twin from its response. Flushed on `/` because that is a
-  // response Nitro reads the hint from: it only looks at HTML, so a hint on
-  // `/llms.txt` itself would go out with a `text/plain` response and be
-  // dropped. Encoded per entry the way Nuxt's `prerenderRoutes()` does, since
-  // Nitro splits the header on commas and decodes each part.
+  // Lets the prerender crawler discover twins whose pages are never rendered as
+  // HTML. Flushed on `/` because Nitro reads the hint from HTML responses only,
+  // and `/llms.txt` goes out as `text/plain`. Encoded per entry, since Nitro
+  // splits the header on commas and decodes each part.
   if (emitsPrerenderHints(import.meta.preset)) {
     nitroApp.hooks.hook('beforeResponse', (event) => {
       if (event.path === '/' && prerenderPaths.size) {
@@ -337,12 +282,10 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
 })
 
 /**
- * Whether the hint header goes out at all. Only the prerender crawler ever
- * reads it, and it is not free anywhere else: a documentation site collects
- * hundreds of twin paths, and `nitro-dev` used to be in this list, which put
- * them all in one header on every `/` and `/llms.txt` response. The Nuxt dev
- * proxy never relayed those responses: the server logged a 200 and the
- * client hung.
+ * Whether the hint header goes out at all. Widening this is not free: with
+ * `nitro-dev` in the list, a docs site's hundreds of twin paths land in one header
+ * on every `/` response, which the Nuxt dev proxy never relays. The server logs a
+ * 200 and the client hangs.
  */
 export function emitsPrerenderHints(preset: unknown): boolean {
   return preset === 'nitro-prerender'

--- a/src/runtime/server/plugins/sitemap.ts
+++ b/src/runtime/server/plugins/sitemap.ts
@@ -7,24 +7,16 @@ import type { SitemapInputCtx } from '@nuxtjs/sitemap'
 /**
  * Drops the raw markdown twins from every sitemap `@nuxtjs/sitemap` builds.
  *
- * They are alternate representations of pages that are already listed, not
- * pages of their own, and the prerender source picks the generated `.md` files
- * up like any other route.
- *
- * At runtime rather than through `sitemap.exclude`, because that option is read
- * during the sitemap module's own setup: a build-time contribution only lands
- * when the site happens to list this module first, and never at all when
- * `@nuxtjs/seo` installs the sitemap through `moduleDependencies`. The hook
- * fires for the prerendered sitemaps too, since those are built by fetching the
- * route through this same Nitro app.
+ * At runtime rather than through `sitemap.exclude`, which is read during that
+ * module's own setup: a build-time contribution only lands when the site lists
+ * this module first, and never when `@nuxtjs/seo` installs the sitemap through
+ * `moduleDependencies`.
  */
 export default defineNitroPlugin((nitroApp) => {
   const { rawPrefix } = useAgentDiscoveryConfig()
 
-  // Typed with the context `@nuxtjs/sitemap` exports, so a shape change in a
-  // sitemap major fails this build instead of silently filtering nothing. The
-  // cast is only for the hook name, which that module declares through no
-  // global augmentation.
+  // Typed with the context `@nuxtjs/sitemap` exports, so a shape change fails
+  // this build. The cast is only for the hook name, which it does not augment.
   const onSitemapInput = nitroApp.hooks.hook as unknown as (
     name: 'sitemap:input',
     cb: (ctx: SitemapInputCtx) => void

--- a/src/runtime/server/routes/api-catalog.ts
+++ b/src/runtime/server/routes/api-catalog.ts
@@ -15,10 +15,10 @@ export default defineEventHandler((event) => {
     if (!link.anchor || (link.rel !== 'service-desc' && link.rel !== 'service-doc')) {
       continue
     }
-    const anchor = absolutizeHref(link.anchor === '/' ? '/' : link.anchor, siteUrl).replace(/\/$/, '') || `${siteUrl}/`
+    const anchor = absolutizeHref(link.anchor, siteUrl).replace(/\/$/, '') || `${siteUrl}/`
     let group = groups.get(anchor)
     if (!group) {
-      group = { anchor: link.anchor === '/' ? `${siteUrl}/` : absolutizeHref(link.anchor, siteUrl) }
+      group = { anchor: absolutizeHref(link.anchor, siteUrl) }
       groups.set(anchor, group)
     }
     const entries = (group[link.rel] ||= []) as { href: string, type?: string }[]
@@ -26,10 +26,8 @@ export default defineEventHandler((event) => {
   }
 
   setResponseHeader(event, 'Content-Type', 'application/linkset+json; charset=utf-8')
-  // Built from `discovery.links`, which is settled at build time, so the
-  // document is host-independent only when a site URL is configured. Without
-  // one the body carries the request origin, which must never be cached and
-  // handed to the next host that asks.
+  // Without a configured site URL the body carries the request origin, so it
+  // must never be cached and handed to the next host that asks.
   setResponseHeader(event, 'Cache-Control', config.siteUrl ? 'public, max-age=3600' : 'no-cache')
   return { linkset: [...groups.values()] }
 })

--- a/src/runtime/server/routes/mcp-server-card.ts
+++ b/src/runtime/server/routes/mcp-server-card.ts
@@ -27,28 +27,17 @@ interface McpDefinition {
 }
 
 /**
- * MCP server card.
- *
- * The static half comes from `discovery.mcpServerCard`. The live half, what
- * the server actually exposes, is read from `@nuxtjs/mcp-toolkit` when the
- * site runs it: every adopter was otherwise writing the same plugin to copy
- * `listMcpDefinitions()` onto the card, and a card listing tools the server
- * no longer has is worse than no card.
- *
- * Detected, never depended on. Without the toolkit the import resolves to a
- * stub and the card is exactly what config declares. Either way
- * `agent-discovery:mcp-server-card` runs last, so a site can add or correct
- * anything.
+ * MCP server card: the static half from `discovery.mcpServerCard`, the live
+ * half from `@nuxtjs/mcp-toolkit` when the site runs it. Without the toolkit
+ * the import resolves to a stub and the card is what config declares.
+ * `agent-discovery:mcp-server-card` runs last, so a site can correct anything.
  */
 export default defineEventHandler(async (event) => {
   const card = useRuntimeConfig(event).agentDiscoveryMcp as McpServerCardConfig
   const siteUrl = getAgentSiteUrl(event)
 
-  // No `$schema`: the URL this used to carry 404s, and so does the one the
-  // draft that would define it (SEP-2127) proposes, because that draft is
-  // unmerged. The released MCP spec has no server card, so the shape below is
-  // pre-standard by nature and advertising a schema it cannot be checked
-  // against is worse than advertising none.
+  // No `$schema`: the released MCP spec has no server card, and the draft that
+  // would define one is unmerged, so the URL it proposes 404s.
   const serverCard: Record<string, unknown> = {
     serverInfo: {
       name: card.name,
@@ -77,13 +66,6 @@ export default defineEventHandler(async (event) => {
       resources: McpDefinition[]
       prompts: McpDefinition[]
     }
-    // Groups come from the subdirectory a definition sits in, which is how a
-    // site separates its admin tools from the ones anybody may call. The build
-    // merges the `admin` default into `excludeGroups` already, but this list
-    // arrives through runtime config, where
-    // `NUXT_AGENT_DISCOVERY_MCP_EXCLUDE_GROUPS` replaces it wholesale. Unioning
-    // the defaults back in keeps a deploy-time override from publishing the
-    // admin tools.
     const excluded = mcpExcludedGroups(card.excludeGroups)
     const isPublic = (definition: McpDefinition) => !definition.group || !excluded.has(definition.group)
 
@@ -101,10 +83,8 @@ export default defineEventHandler(async (event) => {
   await useNitroApp().hooks.callHook('agent-discovery:mcp-server-card', event, serverCard)
 
   setResponseHeader(event, 'Content-Type', 'application/json; charset=utf-8')
-  // The other discovery documents are build-time output and cache for an hour.
-  // This one is not: the definitions are listed per request and the hook runs
-  // after them, so a shared cache would keep advertising a tool the server has
-  // since dropped, which is worse than serving no card at all.
+  // Listed per request, so a shared cache would keep advertising a tool the
+  // server has since dropped.
   setResponseHeader(event, 'Cache-Control', 'no-cache')
   return serverCard
 })

--- a/src/runtime/server/routes/raw.ts
+++ b/src/runtime/server/routes/raw.ts
@@ -8,7 +8,7 @@ import { encodeAgentRoute, formatLinkHeader, hasCdnLinkPair, normalizePathname, 
  * Serves the raw markdown representation of a page. `getAgentDocument()` builds
  * the document, this handler is the HTTP part.
  *
- * `Vary` is on every response, redirects included: a negotiated page redirects
+ * `Vary` is on the document and redirect responses: a negotiated page redirects
  * here, so this is the response the client keeps and a shared cache stores.
  */
 export default defineEventHandler(async (event) => {

--- a/src/runtime/server/routes/raw.ts
+++ b/src/runtime/server/routes/raw.ts
@@ -5,24 +5,11 @@ import { getAgentDocument } from '../utils/document'
 import { encodeAgentRoute, formatLinkHeader, hasCdnLinkPair, normalizePathname, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
- * Serves the raw markdown representation of a page from the content adapter.
+ * Serves the raw markdown representation of a page. `getAgentDocument()` builds
+ * the document, this handler is the HTTP part.
  *
- * The document itself is built by `getAgentDocument()`, which anything running
- * in-process can call for the same bytes. What is left here is the HTTP part:
- * the status codes, the headers and the redirect.
- *
- * A missing page has to answer a real 404 so agents can tell an unknown URL
- * from an empty one. The error handler renders it as markdown for the raw
- * prefix, reporting the documentation path the client asked for through
- * `data.path`.
- *
- * `Vary` is on every response here, redirects included. This URL serves
- * markdown to every client, so nothing about it depends on the request, but it
- * is where a negotiated page sends one: the CDN answers `Accept: text/markdown`
- * on a cached page with a 307, so the response the client keeps, and the one a
- * shared cache stores, is this one. Without the header on it, whatever follows
- * the hop lands on a URL with two representations behind it and nothing saying
- * so.
+ * `Vary` is on every response, redirects included: a negotiated page redirects
+ * here, so this is the response the client keeps and a shared cache stores.
  */
 export default defineEventHandler(async (event) => {
   const config = useAgentDiscoveryConfig(event)
@@ -34,7 +21,7 @@ export default defineEventHandler(async (event) => {
   }
 
   // Left unnormalized: `getAgentDocument` owns that, and decoding here as well
-  // would decode a doubly-encoded path twice, resolving it to a different page.
+  // would decode a doubly-encoded path twice.
   const path = slug.slice(0, -3)
   const document = await getAgentDocument(event, path)
 
@@ -44,8 +31,7 @@ export default defineEventHandler(async (event) => {
 
   setResponseHeader(event, 'Vary', MARKDOWN_VARY)
 
-  // The canonical URL and every absolutized link fall back to the request
-  // origin when no site URL is configured, so the body is host-dependent and
+  // Without a configured site URL the body embeds the request origin, so it
   // must not enter a shared cache.
   if (!config.siteUrl) {
     setResponseHeader(event, 'Cache-Control', 'no-cache')
@@ -57,11 +43,9 @@ export default defineEventHandler(async (event) => {
 
   setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
 
-  // On Vercel the CDN table already injects this pair on the twins it knows
-  // (see `hasCdnLinkPair`), and a header route applies to origin-rendered
-  // responses too, so setting it here as well shipped it twice, doubling per
-  // hop. Everywhere else, and for the twins the table does not cover, this
-  // handler is the only place the pair can come from.
+  // On Vercel the CDN header table already injects this pair on the twins it
+  // covers, origin-rendered responses included, so setting it here would ship
+  // it twice. Everywhere else this handler is the only source.
   if (!(config.cdnLinkPairs && hasCdnLinkPair(config, pathname))) {
     setResponseHeader(event, 'Link', formatLinkHeader([
       { href: document.canonicalUrl, rel: 'canonical' },

--- a/src/runtime/server/routes/robots.txt.ts
+++ b/src/runtime/server/routes/robots.txt.ts
@@ -3,9 +3,9 @@ import { useRuntimeConfig } from '#imports'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 
 /**
- * Generated `robots.txt` allowing the same agent list the negotiation
- * matches, so the two can never drift apart. Only registered when the site
- * has neither a static `public/robots.txt` nor `@nuxtjs/robots`.
+ * Generated `robots.txt` allowing the same agent list the negotiation matches.
+ * Only registered when the site has neither a static `public/robots.txt` nor
+ * `@nuxtjs/robots`.
  */
 export default defineEventHandler((event) => {
   const config = useAgentDiscoveryConfig(event)
@@ -16,9 +16,8 @@ export default defineEventHandler((event) => {
   if (contentSignal) {
     lines.push(`Content-Signal: ${contentSignal}`)
   }
-  // Wildcard group only: the agent groups below exempt their agents from
-  // these rules, deliberately, so what search engines are kept out of stays
-  // reachable for the agents the site names.
+  // Wildcard group only: the agent groups below exempt their agents from these
+  // rules, so what search engines are kept out of stays reachable for agents.
   for (const path of disallow || []) {
     lines.push(`Disallow: ${path}`)
   }
@@ -33,10 +32,8 @@ export default defineEventHandler((event) => {
   }
 
   setResponseHeader(event, 'Content-Type', 'text/plain; charset=utf-8')
-  // Same as the api-catalog: the agent list and the content signal are both
-  // build-time configuration, but the sitemap line is only host-independent
-  // when a site URL is configured. Without one the body carries the request
-  // origin, which must never be cached and handed to the next host that asks.
+  // Without a configured site URL the sitemap line carries the request origin,
+  // so it must not be cached. Same rule as the api-catalog.
   setResponseHeader(event, 'Cache-Control', config.siteUrl ? 'public, max-age=3600' : 'no-cache')
   return lines.join('\n')
 })

--- a/src/runtime/server/routes/sitemap.md.ts
+++ b/src/runtime/server/routes/sitemap.md.ts
@@ -10,17 +10,9 @@ const escapeLabel = (label: string) => label
   .replace(/\]/g, '\\]')
 
 /**
- * Markdown index of every page, grouped by first path segment. Pages covered
- * by the negotiation routes link to their raw markdown twin so agents keep
- * getting markdown when they follow them.
- *
- * Through `rawUrl()`, which is the same `rawDestination()` the CDN rewrites,
- * the middleware and the `llms.txt` bridge resolve. Hand-rolling the twin here
- * put `/` on the HTML page while `llms.txt` pointed it at `/raw/index.md`, in
- * two documents an agent reads together, and ignored `raw` overrides.
- *
- * Carries `Vary` like the raw route does, so every markdown document the module
- * serves answers the same way about what its response depends on.
+ * Markdown index of every page, grouped by first path segment. Links point at
+ * the raw markdown twin, resolved through `rawUrl()` so they cannot drift from
+ * the CDN rewrites, the middleware and the `llms.txt` bridge.
  */
 export default defineEventHandler(async (event) => {
   const config = useAgentDiscoveryConfig(event)
@@ -30,8 +22,6 @@ export default defineEventHandler(async (event) => {
 
   const { expand, labels } = config.sitemapSections
 
-  // Top-level pages share one section; anything deeper is grouped by its first
-  // segment, or by its second when that prefix is expanded.
   const sectionKey = (route: string): string => {
     const parts = route.split('/').filter(Boolean)
     if (parts.length < 2) {
@@ -43,29 +33,28 @@ export default defineEventHandler(async (event) => {
   const sections = new Map<string, { title: string, href: string }[]>()
   for (const entry of entries) {
     const key = sectionKey(entry.route)
-    const href = entry.rawUrl
     if (!sections.has(key)) {
       sections.set(key, [])
     }
-    sections.get(key)!.push({ title: entry.title || entry.route, href })
+    sections.get(key)!.push({ title: entry.title || entry.route, href: entry.rawUrl })
   }
 
-  // The content adapter only knows the pages it holds. A site with hand-written
-  // routes, a Vue-rendered showcase or a design document has no other way to
-  // put them in the index an agent reads first.
+  // The adapter only knows the pages it holds, so hand-written routes and
+  // Vue-rendered pages are added here.
   await useNitroApp().hooks.callHook('agent-discovery:sitemap', event, sections)
 
-  const siteName = config.siteName || new URL(siteUrl).hostname
+  const hostname = new URL(siteUrl).hostname
+  const siteName = config.siteName || hostname
   const lines: string[] = [
     `# ${siteName} Sitemap`,
     '',
-    `> Markdown index of every page on ${new URL(siteUrl).hostname}. Links point at the raw markdown; append \`.md\` to any page URL (or set \`Accept: text/markdown\`) to get it from the page URL instead.`,
+    `> Markdown index of every page on ${hostname}. Links point at the raw markdown; append \`.md\` to any page URL (or set \`Accept: text/markdown\`) to get it from the page URL instead.`,
     ''
   ]
 
   for (const [key, pages] of sections) {
-    // Own keys only: a section named `constructor` or `toString` would
-    // otherwise read a function off `Object.prototype` and print it as a label.
+    // Own keys only: a section named `constructor` would otherwise read a
+    // function off `Object.prototype` and print it as a label.
     const label = (Object.hasOwn(labels, key) && labels[key]) || key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
     lines.push(`## ${label}`, '')
     for (const page of pages) {
@@ -76,8 +65,7 @@ export default defineEventHandler(async (event) => {
 
   setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
   setResponseHeader(event, 'Vary', MARKDOWN_VARY)
-  // Same rule as the api-catalog: every URL below embeds the request origin
-  // when no site URL is configured, so the body is host-dependent.
+  // Without a configured site URL every URL below embeds the request origin.
   if (!config.siteUrl) {
     setResponseHeader(event, 'Cache-Control', 'no-cache')
   }

--- a/src/runtime/server/routes/skills-files.ts
+++ b/src/runtime/server/routes/skills-files.ts
@@ -21,9 +21,8 @@ function contentType(path: string): string {
 }
 
 /**
- * Serves one file of a skill from the bundled server assets. Only paths under
- * a skill listed in the catalog are reachable, so the route cannot be walked
- * outside the skills directory.
+ * Serves one file of a skill from the bundled server assets. Only paths under a
+ * skill listed in the catalog are reachable.
  */
 export default defineEventHandler(async (event) => {
   const pathname = getRequestURL(event).pathname

--- a/src/runtime/server/routes/skills-index.ts
+++ b/src/runtime/server/routes/skills-index.ts
@@ -2,10 +2,7 @@ import { defineEventHandler, setResponseHeader } from 'h3'
 import { useRuntimeConfig } from '#imports'
 import type { SkillEntry } from '../../shared/types'
 
-/**
- * The Agent Skills catalog, generated from the skills directory at build time
- * so it can never fall out of step with the files actually served.
- */
+/** The Agent Skills catalog, generated from the skills directory at build time. */
 export default defineEventHandler((event) => {
   const { skills } = useRuntimeConfig(event).agentDiscoverySkills as { skills: SkillEntry[] }
 

--- a/src/runtime/server/sources/comark.ts
+++ b/src/runtime/server/sources/comark.ts
@@ -33,9 +33,7 @@ interface ComarkSelector {
 /** Depth-first walk collecting every page node, section label carried down. */
 function collect(items: ComarkNavigationItem[], entries: AgentListEntry[], section?: string): void {
   for (const item of items) {
-    // A node with children names the group its pages belong to, which is the
-    // grouping `comark-docs` built by hand. Its own index page belongs in that
-    // group too, not in the ungrouped bucket with the standalone pages.
+    // A node with children names the group its pages belong to, index included.
     const group = item.children?.length ? section ?? item.title : section
     if (item.page !== false && item.path) {
       entries.push({ route: item.path, title: item.title, description: item.description, section: group })
@@ -108,9 +106,8 @@ export function createComarkSource(getContent: (event: H3Event) => Promise<Comar
       if (!node) {
         return null
       }
-      // Descend to the first node that is actually a page. A section header
-      // carries `page: false`, so walking blindly to `children[0]` can redirect
-      // to a path whose `get()` returns null, costing a hop to reach a 404.
+      // A section header carries `page: false`, so walking to `children[0]`
+      // can redirect to a path whose `get()` returns null.
       const firstPage = (items: ComarkNavigationItem[]): string | undefined => {
         for (const item of items) {
           if (item.page !== false && item.path && item.path !== route) {
@@ -127,10 +124,9 @@ export function createComarkSource(getContent: (event: H3Event) => Promise<Comar
     },
 
     /**
-     * The shared document pipeline on a comark tree, with only the fetch and
-     * the render around it. The two adapters have to come out byte-identical:
-     * a site moving backend changes the adapter and nothing else, and
-     * `test/e2e/expected.ts` is what holds them to it.
+     * The shared document pipeline on a comark tree, with only the fetch and the
+     * render around it. Both adapters come out byte-identical, which
+     * `test/e2e/expected.ts` holds them to.
      */
     async get(route: string, event: H3Event) {
       const content = await getContent(event)
@@ -140,25 +136,18 @@ export function createComarkSource(getContent: (event: H3Event) => Promise<Comar
         return null
       }
 
-      // Copied before anything touches it. The hook below hands this to a
-      // site's own transformer, and the link pass bakes a per-request origin
-      // into every href, which with `siteUrl: ''` differs between requests.
-      // Whether comark's cache hands back a shared object is its business.
+      // Copied before anything mutates it, since comark's cache may hand back
+      // a shared object.
       const page = { ...item, nodes: structuredClone(item.nodes) }
 
-      // Lets sites transform the document (MDC components → plain markdown)
-      // without replacing the whole source. Called before the nodes are read,
-      // so a transformer can swap them wholesale.
+      // Called before the nodes are read, so a transformer can swap them wholesale.
       await useNitroApp().hooks.callHook('agent-discovery:document', event, page)
 
       const nodes = page.nodes as DocNode[]
       const frontmatter = (page.data || {}) as { title?: string, description?: string, links?: unknown }
 
-      // comark 0.6 declares `removeLastStyle` and reads it nowhere, so a
-      // highlighter's `<style>` node would render into the markdown verbatim.
-      // The pipeline drops it, along with the rest of what the `@nuxt/content`
-      // adapter does to its tree. comark keeps all frontmatter in `data`, with
-      // no `meta` split, so the links come from there.
+      // comark 0.6 declares `removeLastStyle` and reads it nowhere, so the
+      // pipeline drops the `<style>` node. All frontmatter lives in `data`.
       prepareDocumentTree(nodes, {
         title: frontmatter.title,
         description: frontmatter.description,
@@ -166,21 +155,15 @@ export function createComarkSource(getContent: (event: H3Event) => Promise<Comar
         siteUrl: getAgentSiteUrl(event)
       })
 
-      // `render`, not `renderMarkdown`: the latter routes through
-      // `renderFrontmatter`, which re-emits `data` as a YAML block the raw
-      // route already writes, and trims the trailing newline the documents
-      // are built around. `markdown/html` is the format the minimark
-      // stringifier uses, and the one the two agree on.
-      //
-      // Imported dynamically, so this resolves the site's own comark rather
-      // than a copy of ours: the same guarantee the module buys for
-      // `minimark/stringify` by aliasing it.
+      // `render`, not `renderMarkdown`: the latter re-emits `data` as a YAML
+      // block the raw route already writes and trims the trailing newline.
+      // `markdown/html` is the format the minimark stringifier uses. Imported
+      // dynamically to resolve the site's own comark rather than a copy of ours.
       const { render } = await import('comark/render')
       const markdown = await render({ nodes: nodes as never }, { format: 'markdown/html' })
 
-      // An empty render means a document with no body, the structured-page
-      // case the other adapter 404s. With a title there is still a document
-      // to serve, the lead above.
+      // No body is the structured-page case the other adapter 404s, unless the
+      // lead above gives it one.
       if (markdown.trim() === '' && !frontmatter.title) {
         return null
       }

--- a/src/runtime/server/sources/content.ts
+++ b/src/runtime/server/sources/content.ts
@@ -31,17 +31,15 @@ function titleCase(value: string): string {
 }
 
 /**
- * Built-in `@nuxt/content` v3 adapter: `queryCollection()` over
- * `type: 'page'` collections, stringified with minimark. Mirrors the raw
- * markdown route `@nuxt/content` registers when `nuxt-llms` is present, so
- * swapping to this module changes nothing for agents.
+ * Built-in `@nuxt/content` v3 adapter: `queryCollection()` over `type: 'page'`
+ * collections, stringified with minimark. Mirrors the raw markdown route
+ * `@nuxt/content` registers when `nuxt-llms` is present.
  */
 const source: AgentContentSource = {
   /**
-   * Reads `contentCollection` and `contentFilters` off the section, the same
-   * two keys `@nuxt/content`'s llms feature declared, so a site's existing
-   * `llms.sections` config keeps working after this module takes the feature
-   * over. A selector naming anything else is not ours.
+   * Reads the same `contentCollection` and `contentFilters` keys
+   * `@nuxt/content`'s llms feature declared, so an existing `llms.sections`
+   * config keeps working. A selector naming anything else is not ours.
    */
   async list(selector: AgentSectionSelector | undefined, event: H3Event) {
     const { contentCollection, contentFilters } = (selector || {}) as ContentSelector
@@ -49,14 +47,13 @@ const source: AgentContentSource = {
       return null
     }
 
-    const names = contentCollection ? [contentCollection as keyof Collections] : pageCollections()
-    if (contentCollection && !pageCollections().includes(contentCollection as keyof Collections)) {
+    const pageNames = pageCollections()
+    if (contentCollection && !pageNames.includes(contentCollection as keyof Collections)) {
       return null
     }
+    const names = contentCollection ? [contentCollection as keyof Collections] : pageNames
 
-    // One query per collection, all in flight at once. `Promise.all` keeps the
-    // results in the order the collections were declared, which is the order
-    // the flattened listing has to come out in.
+    // `Promise.all` keeps the collection declaration order the listing needs.
     const results = await Promise.all(names.map(async (collection) => {
       const query = queryCollection(event, collection)
         .select('path', 'title', 'description')
@@ -77,28 +74,19 @@ const source: AgentContentSource = {
 
   /**
    * First page under a section path, so `/raw/getting-started.md` lands on the
-   * section's first document instead of a 404 when the directory has no index.
-   *
-   * Ordered by `stem`, which keeps the `1.`/`2.` filename prefixes the path has
-   * already dropped, so this lands where the site's own navigation does rather
-   * than on whatever sorts first alphabetically.
+   * section's first document instead of a 404. Ordered by `stem`, which keeps
+   * the `1.`/`2.` filename prefixes the path has dropped, so this lands where
+   * the site's own navigation does.
    */
   async firstLeaf(route: string, event: H3Event) {
     const prefix = `${withLeadingSlash(route).replace(/\/$/, '')}/`
     // `%` is a `LIKE` wildcard and the prefix comes from the URL, so `/raw/%.md`
-    // would match every page in every collection and materialize them all
-    // before the check below throws them away. `_` is a wildcard too but only
-    // for a single character, which is a real path character and barely widens
-    // anything, so it stays.
+    // would materialize every page in every collection.
     if (prefix.includes('%')) {
       return null
     }
-    // One collection at a time, returning on the first match. `list()` needs
-    // every collection and parallelizes; this one needs the first that answers,
-    // so a later collection is a query nothing asked for. It is also the raw
-    // route's 404 path, where the common case is no match at all, and a
-    // `Promise.all` there would reject the whole lookup over a collection the
-    // answer never depended on.
+    // Sequential, unlike `list()`: a `Promise.all` would reject the whole
+    // lookup over a collection the answer never depended on.
     for (const collection of pageCollections()) {
       const pages = await queryCollection(event, collection)
         .select('path', 'stem')
@@ -106,10 +94,8 @@ const source: AgentContentSource = {
         .where('path', 'NOT LIKE', '%/.navigation')
         .order('stem', 'ASC')
         .all() as { path: string }[]
-      // `where` has no `ESCAPE` clause, and the path comes from the URL, where
-      // `%` and `_` are `LIKE` wildcards: `/raw/do_s.md` matches `/docs/...`.
-      // The pattern only ever widens the match, so a plain prefix check on the
-      // way out is enough to pin it back down.
+      // `where` has no `ESCAPE` clause, so `_` still widens the match
+      // (`/raw/do_s.md` matches `/docs/...`). Pinned back down here.
       const page = pages.find(entry => entry.path?.startsWith(prefix))
       if (page?.path) {
         return page.path
@@ -131,29 +117,21 @@ const source: AgentContentSource = {
         break
       }
     }
-    // A structured page carries no markdown body: a YAML landing page, or a
-    // collection backed by data rather than prose. It has no markdown
-    // representation, so the raw route 404s it and the landing page falls
-    // through to the generated index, which is what a site wants for `/`.
+    // A structured page (YAML landing page, data collection) has no markdown
+    // representation, so the raw route 404s it and `/` falls through to the index.
     if (!page?.body?.value) {
       return null
     }
 
-    // Copied before anything touches it, the way the comark adapter does:
-    // whether `queryCollection` hands back a shared object is its business,
-    // and both the hook below and the pipeline mutate the tree in place.
-    // `appendRelatedLinks` in particular is not idempotent.
+    // Copied before anything mutates it: the hook and the pipeline both edit
+    // the tree in place, and `appendRelatedLinks` is not idempotent.
     page = { ...page, body: { ...page.body, value: structuredClone(page.body.value) } }
 
-    // Lets sites transform the minimark tree (MDC components → plain
-    // markdown) without replacing the whole source.
+    // Lets sites transform the tree without replacing the whole source.
     await useNitroApp().hooks.callHook('agent-discovery:document', event, page)
 
-    // Mutated in place: `page.body` below stringifies this same array. The
-    // minimark stringifier drops a highlighter's `<style>` node only while it
-    // is the last one, so the pipeline strips it before appending anything.
-    // `@nuxt/content` keeps `links` either at the root or under `meta`,
-    // depending on the collection schema.
+    // Mutated in place: `page.body` below stringifies this same array. `links`
+    // sits at the root or under `meta`, depending on the collection schema.
     prepareDocumentTree(page.body.value as unknown as DocNode[], {
       title: page.title,
       description: page.description,

--- a/src/runtime/server/sources/pipeline.ts
+++ b/src/runtime/server/sources/pipeline.ts
@@ -2,8 +2,7 @@ import { absolutizeTreeLinks } from '../../shared/negotiation'
 
 /**
  * The node shape minimark and comark agree on: `[tag, props, ...children]`.
- * Enough to walk and edit a document without importing either backend, which
- * is what lets both adapters run the same pipeline.
+ * Enough to edit a document without importing either backend.
  */
 export type DocNode = [string, Record<string, unknown>?, ...unknown[]]
 
@@ -20,9 +19,8 @@ export interface PrepareDocumentOptions {
 
 /**
  * A highlighter appends a `<style>` node carrying the per-document CSS
- * variables. It is meaningless in a markdown representation, and neither
- * backend drops it once something follows it, so it goes before the related
- * links are appended.
+ * variables. Neither backend drops it once something follows it, so it goes
+ * before the related links are appended.
  */
 function removeStyleNodes(nodes: DocNode[]): void {
   for (let i = nodes.length - 1; i >= 0; i--) {
@@ -53,15 +51,23 @@ function appendRelatedLinks(nodes: DocNode[], links: unknown): void {
   if (!Array.isArray(links) || links.length === 0) {
     return
   }
-  // Frontmatter is user content: a `links: [null]` or a half-filled entry
-  // must be skipped, not thrown on. A numeric label stays a label, because
-  // YAML reads `label: 2024` as a number and the adapters rendered it before.
-  const items = links
-    .filter((link): link is { label: string | number, to: string } => typeof link === 'object' && link !== null
-      && (typeof (link as { label?: unknown }).label === 'number'
-        || (typeof (link as { label?: unknown }).label === 'string' && (link as { label: string }).label !== ''))
-      && typeof (link as { to?: unknown }).to === 'string' && (link as { to: string }).to !== '')
-    .map(link => ['li', {}, ['a', { href: link.to }, String(link.label)]] as DocNode)
+  // Frontmatter is user content: a `links: [null]` or a half-filled entry is
+  // skipped, not thrown on. A numeric label stays a label, since YAML reads
+  // `label: 2024` as a number.
+  const items: DocNode[] = []
+  for (const link of links) {
+    if (typeof link !== 'object' || link === null) {
+      continue
+    }
+    const { label, to } = link as { label?: unknown, to?: unknown }
+    if (typeof to !== 'string' || to === '') {
+      continue
+    }
+    if (typeof label !== 'number' && (typeof label !== 'string' || label === '')) {
+      continue
+    }
+    items.push(['li', {}, ['a', { href: to }, String(label)]])
+  }
   if (items.length > 0) {
     nodes.push(['hr', {}])
     nodes.push(['ul', {}, ...items])
@@ -70,10 +76,8 @@ function appendRelatedLinks(nodes: DocNode[], links: unknown): void {
 
 /**
  * Everything both adapters do to a parsed document before handing the tree to
- * their own stringifier. The two renderings have to come out byte-identical,
- * which is easier to hold when the steps live in one place.
- *
- * Mutates in place: the callers hand the same array to their renderer.
+ * their own stringifier, kept in one place because the two renderings have to
+ * come out byte-identical. Mutates in place.
  */
 export function prepareDocumentTree(nodes: DocNode[], options: PrepareDocumentOptions): void {
   removeStyleNodes(nodes)

--- a/src/runtime/server/utils/agent-discovery.ts
+++ b/src/runtime/server/utils/agent-discovery.ts
@@ -6,9 +6,8 @@ import type { AgentContentSource, NegotiationConfig } from '../../shared/types'
 import { absolutizeHref, encodeAgentRoute, hasFileExtension, matchRoute, normalizeAgentRoute, rawDestination } from '../../shared/negotiation'
 
 export function useAgentDiscoveryConfig(event?: H3Event): NegotiationConfig {
-  // Through `unknown`: a site's generated `runtimeConfig` type narrows the
-  // records this config carries to that site's own literal keys, which no
-  // longer overlap with the module's declaration.
+  // Through `unknown`: a site's generated `runtimeConfig` type narrows these
+  // records to that site's own literal keys.
   return useRuntimeConfig(event).agentDiscovery as unknown as NegotiationConfig
 }
 
@@ -20,11 +19,8 @@ export function getAgentSiteUrl(event: H3Event): string {
 
 /**
  * Absolute URL of a page's raw markdown twin, from the same route config the
- * negotiation and the CDN rewrites use. Pages that don't negotiate (and
- * anything already pointing at a file) come back untouched, absolute.
- *
- * Sites hand-rolling this drift the moment `routes` changes: a hardcoded
- * `/docs/` prefix keeps rewriting after the config has moved on.
+ * negotiation and the CDN rewrites use. Paths that don't negotiate, and
+ * anything already pointing at a file, come back absolute and untouched.
  */
 export function rawUrl(event: H3Event, path: string): string {
   const config = useAgentDiscoveryConfig(event)
@@ -47,9 +43,8 @@ export function rawUrl(event: H3Event, path: string): string {
     }
   }
 
-  // Decoded like the raw handler decodes its slug, then re-encoded on the way
-  // out, so a non-ASCII route is spelled here exactly as the `Link` header
-  // and `canonical_url` frontmatter spell it.
+  // Decoded then re-encoded, so a non-ASCII route is spelled exactly as the
+  // `Link` header and the `canonical_url` frontmatter spell it.
   pathname = normalizeAgentRoute(pathname)
   const route = pathname === '/' || !hasFileExtension(pathname) ? matchRoute(config.routes, pathname) : undefined
 
@@ -57,11 +52,9 @@ export function rawUrl(event: H3Event, path: string): string {
 }
 
 /**
- * The discovery registry as a markdown block. The module appends it to the
- * `/` document itself, on the raw route and in `llms-full.txt`, so a site
- * only calls this for a page it renders by hand. Same list the `Link` header
- * and the api-catalog are built from, so a resource can never be advertised
- * in one place and missed in another.
+ * The discovery registry as a markdown block, from the same list the `Link`
+ * header and the api-catalog are built from. The module already appends it to
+ * the `/` document, so a site only calls this for a page it renders by hand.
  */
 export function renderAgentResources(event: H3Event, options: { heading?: string } = {}): string {
   const config = useAgentDiscoveryConfig(event)
@@ -78,19 +71,15 @@ export function renderAgentResources(event: H3Event, options: { heading?: string
 export { agentDiscoveryOpenApi } from './openapi'
 export type { AgentOpenApiOptions } from './openapi'
 
-// The pieces an agent-facing tool is built from, so a site's MCP `list-pages`
-// and `get-page` stay one call each and cannot drift from what the raw route
-// and the CDN rewrites do. See the "Agent tooling" section of the README.
+// The pieces an agent-facing tool is built from. See "Agent tooling" in the README.
 export { listAgentPages } from './pages'
 export type { AgentPageListing, AgentPageListOptions } from './pages'
 export { getAgentDocument } from './document'
 export type { AgentDocument, AgentDocumentOptions } from './document'
 export { extractSections } from '../../shared/sections'
 
-// The absolutization passes are deliberately not exported: the module runs one
-// over whatever `get()` returns, so an adapter that forgets cannot emit
-// relative links, and one that does it anyway is unaffected because the pass is
-// idempotent.
+// The absolutization passes are not exported: the module runs one over whatever
+// `get()` returns, and the pass is idempotent.
 
 /** Identity helper for typed custom content sources. */
 export function defineAgentContentSource(source: AgentContentSource): AgentContentSource {

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -18,33 +18,20 @@ export interface AgentDocument {
 }
 
 export interface AgentDocumentOptions {
-  /**
-   * `##` headings to narrow the body to, for a caller that wants one part of
-   * a long page. Ignored when none of them match, since a document minus
-   * everything is not a useful answer.
-   */
+  /** `##` headings to narrow the body to. Ignored when none match, since a document minus everything is useless. */
   sections?: string[]
   /**
-   * Resolve a route under an excluded prefix anyway. By default it comes back
-   * `null`, the same answer every listing gives: an excluded path has no
-   * markdown twin as far as the site advertises. The opt-in exists for MCP
-   * tools, which are exactly where a site serves what it does not advertise
-   * (a nightly docs version kept out of `sitemap.md` and `llms.txt`).
+   * Resolve a route under an excluded prefix anyway. It comes back `null` by
+   * default, the answer every listing gives. The opt-in is for MCP tools, where a
+   * site serves what it does not advertise, a nightly docs version for instance.
    */
   includeExcluded?: boolean
 }
 
 /**
- * The landing page as markdown, for a site whose `/` is a Vue page rather than
- * a content document. The bridge already links `/raw/index.md` from `llms.txt`,
- * and both `nuxt/ui` docs and `nuxt.com` hand-wrote this route to stop it
- * 404ing. Everything structural comes from the registry; `agent-discovery:index`
- * is where the site fills in what only it knows.
- *
- * The hook gets the whole document, not just its body: the title and
- * description of a landing page like this live wherever the site keeps them,
- * and `siteName` is a fallback rather than the answer. There is no page to read
- * them off, which is the reason this branch exists at all.
+ * The landing page as markdown, for a site whose `/` is a Vue page rather than a
+ * content document. The hook gets the whole document, not just its body: there is
+ * no page to read a title and description off, and `siteName` is only a fallback.
  */
 async function generatedIndex(event: H3Event, siteUrl: string): Promise<AgentIndex & { markdown: string }> {
   const config = useAgentDiscoveryConfig(event)
@@ -61,8 +48,6 @@ async function generatedIndex(event: H3Event, siteUrl: string): Promise<AgentInd
     markdown: [
       `# ${index.title}`,
       '',
-      // Same shape a content document comes out in, so the two paths read
-      // alike whichever one served the file.
       ...(index.description ? [`> ${index.description}`, ''] : []),
       ...(index.body.length ? [...index.body, ''] : []),
       ...(resources ? [resources] : []),
@@ -74,16 +59,11 @@ async function generatedIndex(event: H3Event, siteUrl: string): Promise<AgentInd
 }
 
 /**
- * `source.get()` plus the link absolutization every adapter would otherwise
- * have to remember.
- *
- * A markdown document is read detached from the site it came from, so a
- * site-relative link in it points nowhere. The built-in adapters already
- * rewrite their document tree, where they can also see the links in MDC
- * component props; this pass is idempotent over that, because it only matches a
- * destination starting with a single slash and those are already absolute.
- * Doing it here rather than in each adapter is what keeps a custom source from
- * silently emitting relative links.
+ * `source.get()` plus link absolutization, since a markdown document is read
+ * detached from the site it came from. Idempotent over the built-in adapters,
+ * which rewrite their document tree already: this only matches a destination
+ * starting with a single slash. Here rather than per adapter, so a custom source
+ * cannot silently emit relative links.
  */
 export async function getSourcePage(route: string, event: H3Event): Promise<AgentPage | null> {
   const page = await source?.get(route, event)
@@ -93,24 +73,17 @@ export async function getSourcePage(route: string, event: H3Event): Promise<Agen
   return { ...page, markdown: absolutizeMarkdownLinks(page.markdown, getAgentSiteUrl(event)) }
 }
 
-/**
- * The generated landing page, in the same shape `getSourcePage` returns, for
- * a consumer rendering `/` on an adapter with no `/` entry. The raw route
- * reaches the same document through `getAgentDocument`'s own fallback.
- */
+/** The generated landing page in the shape `getSourcePage` returns, for an adapter with no `/` entry. */
 export async function generatedIndexPage(event: H3Event): Promise<AgentPage> {
   const index = await generatedIndex(event, getAgentSiteUrl(event))
   return { title: index.title, description: index.description, markdown: index.markdown }
 }
 
 /**
- * The `/` body with the discovery resources appended, shared by
- * `getAgentDocument` and the `llms-full.txt` builder so the homepage reads
- * identically wherever it is served. An empty body stays empty, so a
- * placeholder `/` entry keeps contributing nothing to `llms-full.txt`, a
- * registry with no titled links leaves the body alone, and so does a body
- * already carrying the heading: a homepage that rendered the registry by hand
- * before the module did is not listed twice.
+ * The `/` body with the discovery resources appended, shared by `getAgentDocument`
+ * and the `llms-full.txt` builder so the homepage reads identically wherever it is
+ * served. An empty body stays empty, and a body already carrying the heading is
+ * left alone: a homepage rendering the registry by hand is not listed twice.
  */
 export function appendAgentResources(event: H3Event, markdown: string): string {
   if (!markdown.trim() || hasAgentResourcesHeading(markdown)) {
@@ -120,18 +93,15 @@ export function appendAgentResources(event: H3Event, markdown: string): string {
   return resources ? `${markdown.replace(/\n*$/, '\n\n')}${resources}` : markdown
 }
 
-// CommonMark: up to three spaces of indentation on a heading or a fence, four
-// make an indented code block; a closing `#` run needs a space before it.
+// CommonMark: up to three spaces of indentation on a heading or a fence, four make
+// an indented code block. A closing `#` run needs a space before it.
 const AGENT_RESOURCES_HEADING_LINE = new RegExp(`^ {0,3}#{1,6}[ \\t]+${AGENT_RESOURCES_HEADING}(?:[ \\t]+#+)?[ \\t]*$`)
 const CODE_FENCE = /^ {0,3}(`{3,}|~{3,})/
-// A closing fence carries no info string, so a line opening a fence of the
-// same kind inside a block is content, not its end.
+// A closing fence carries no info string, so a line opening a fence of the same
+// kind inside a block is content, not its end.
 const CLOSING_CODE_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
 
-/**
- * Whether the body carries the heading outside a fenced code block: a page
- * quoting the block it expects has not rendered it.
- */
+/** Whether the body carries the heading outside a fenced code block: a page quoting it has not rendered it. */
 function hasAgentResourcesHeading(markdown: string): boolean {
   let fence: string | undefined
   for (const line of markdown.split(/\r?\n/)) {
@@ -143,8 +113,7 @@ function hasAgentResourcesHeading(markdown: string): boolean {
       continue
     }
     const opening = CODE_FENCE.exec(line)
-    // A backtick fence's info string may not contain a backtick: such a line
-    // is text, and a tilde fence's may.
+    // A backtick fence's info string may not contain a backtick, a tilde fence's may.
     if (opening && !(opening[1]!.startsWith('`') && line.slice(opening[0].length).includes('`'))) {
       fence = opening[1]
       continue
@@ -157,46 +126,34 @@ function hasAgentResourcesHeading(markdown: string): boolean {
 }
 
 /**
- * Resolves a page route to the exact document `/raw/<path>.md` serves.
+ * Resolves a page route to the exact document `/raw/<path>.md` serves. The HTTP
+ * route is a thin shell over this, so an MCP `get-page` tool returns the same
+ * bytes as the URL without `$fetch`ing the site from inside its own function.
  *
- * The HTTP route is a thin shell over this so that anything else reaching for
- * a page's markdown, an MCP `get-page` tool most of all, returns the same
- * bytes as the URL. Sites currently do that by `$fetch`ing their own raw
- * route from inside a serverless function, which pays for a second request to
- * reach code already loaded in the same process, and drifts the moment the
- * two disagree.
- *
- * Returns `null` for a route with no markdown representation. `redirect` is a
- * path that names a section rather than a page, where the section's first
- * document is the answer.
+ * Returns `null` for a route with no markdown representation. `redirect` names a
+ * section rather than a page, where the section's first document is the answer.
  */
 export async function getAgentDocument(event: H3Event, route: string, options: AgentDocumentOptions = {}): Promise<AgentDocument | { redirect: string } | null> {
   const config = useAgentDiscoveryConfig(event)
 
   const path = normalizeAgentRoute(route)
 
-  // The same filter every listing applies, so the raw route (a thin shell
-  // over this) answers 404 where `sitemap.md`, `llms.txt` and
-  // `listAgentPages()` say the page does not exist. Serving it anyway made
-  // the exclusion look like an indexing choice when it is the module-wide
-  // definition of "not a page".
+  // Exclusion is the module-wide definition of "not a page", not an indexing hint,
+  // so the raw route 404s wherever the listings say the page does not exist.
   if (!options.includeExcluded && isExcluded(path, config)) {
     return null
   }
 
   const siteUrl = getAgentSiteUrl(event)
-  // Re-encoded because `normalizeAgentRoute` decoded the path above, and this
-  // URL lands in a `Link` header, where Node rejects anything above U+00FF.
-  // Per segment: `encodeURI` would leave a `#` or `?` in a slug alone, and
-  // either one cuts the URL short right there.
-  const canonicalUrl = `${siteUrl}${path === '/' ? '' : encodeAgentRoute(path)}` || siteUrl
+  // Re-encoded because `normalizeAgentRoute` decoded the path above, and a `Link`
+  // header rejects anything above U+00FF. Per segment, since `encodeURI` leaves a
+  // `#` or `?` in a slug alone and either one cuts the URL short.
+  const canonicalUrl = `${siteUrl}${path === '/' ? '' : encodeAgentRoute(path)}`
 
   const page = await getSourcePage(path, event)
   if (!page) {
-    // A path that names a section rather than a page (`/getting-started` with
-    // no index) resolves to the section's first document, the same as the
-    // HTML page does. Anything else is a genuine 404, except `/`, which falls
-    // through to the generated index below.
+    // A path naming a section rather than a page resolves to its first document,
+    // the same as the HTML page does. `/` falls through to the generated index.
     const leaf = path === '/' ? null : await source?.firstLeaf?.(path, event)
     if (leaf && leaf !== path) {
       return { redirect: leaf }
@@ -208,8 +165,7 @@ export async function getAgentDocument(event: H3Event, route: string, options: A
 
   const index = page ? undefined : await generatedIndex(event, siteUrl)
 
-  // An empty key reads as a value the page deliberately set to nothing, so a
-  // missing title or description is left out rather than emitted as `""`.
+  // An empty key reads as a value the page set to nothing, not a missing one.
   const title = page?.title || index?.title
   const description = page?.description || index?.description
   const frontmatter = [
@@ -225,13 +181,10 @@ export async function getAgentDocument(event: H3Event, route: string, options: A
     return { markdown: frontmatter + index.markdown, title, description, canonicalUrl }
   }
 
-  // Absolute, like the links inside the body: this file is read detached from
-  // the site.
   const sitemap = config.links.some(link => link.href === '/sitemap.md')
     ? `\n\n## Sitemap\n\nSee the full [sitemap](${siteUrl}/sitemap.md) for all pages.\n`
     : '\n'
 
-  // `/` mirrors the generated index: body, the discovery resources, footer.
   const body = path === '/' ? appendAgentResources(event, page!.markdown) : page!.markdown
   const markdown = frontmatter + body + sitemap
 

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -165,7 +165,7 @@ export async function getAgentDocument(event: H3Event, route: string, options: A
 
   const index = page ? undefined : await generatedIndex(event, siteUrl)
 
-  // An empty key reads as a value the page set to nothing, not a missing one.
+  // An empty title or description is left out rather than emitted as `""`.
   const title = page?.title || index?.title
   const description = page?.description || index?.description
   const frontmatter = [

--- a/src/runtime/server/utils/openapi.ts
+++ b/src/runtime/server/utils/openapi.ts
@@ -6,16 +6,11 @@ import type { AgentRoute, NegotiationConfig } from '../../shared/types'
 
 /**
  * The discovery layer as OpenAPI fragments, for sites that publish an
- * `openapi.json`.
+ * `openapi.json`. Derived from the route config, which hand-written paths drift
+ * from as soon as `routes` or `rawPrefix` changes.
  *
- * These paths are identical across every site running this module by
- * construction: they all negotiate the same way, serve the same raw twins and
- * advertise the same documents. Hand-writing them means restating the route
- * config in a second place, where it drifts the moment `routes` or
- * `rawPrefix` changes.
- *
- * Returns fragments rather than a whole document. A site owns its `info`,
- * `servers` and its own endpoints, and merges these in:
+ * A site owns its `info`, `servers` and its own endpoints, and merges these in,
+ * spreading its own values last so it can replace any path here:
  *
  * ```ts
  * const discovery = agentDiscoveryOpenApi(event, { paths: myPaths })
@@ -24,51 +19,27 @@ import type { AgentRoute, NegotiationConfig } from '../../shared/types'
  *   info: { ... },
  *   tags: [...discovery.tags, ...myTags],
  *   paths: { ...discovery.paths, ...myPaths },
- *   components: {
- *     headers: discovery.components.headers,
- *     responses: discovery.components.responses,
- *     schemas: { ...discovery.components.schemas, ...mySchemas }
- *   }
+ *   components: { ...discovery.components, schemas: { ...discovery.components.schemas, ...mySchemas } }
  * }
  * ```
  *
- * Spreading the site's own values last means any path here can be replaced
- * with a richer, site-specific description.
- *
  * Every call builds its fragments from scratch, so what comes back is the
- * caller's to edit in place. Nothing is shared with the next call.
+ * caller's to edit in place.
  *
- * Pass the `paths` being merged in and every `operationId` in them is claimed
- * before one is derived here, so a site's own operation keeps its name and the
- * generated one takes a numeric suffix. Without it the two namespaces are
- * decided independently and a duplicate is only caught by a linter, if the
- * site runs one. `reserved` does the same for a document assembled where this
- * call cannot see it.
- *
- * The namespace, for a site picking names by hand:
- *
- * - a page pattern gets `get<PascalRoute>`, its raw twin
- *   `get<PascalRoute>Markdown`. `/` is `getHomepage`/`getHomepageMarkdown`,
- *   a wildcard pattern ends in `Page`, so `/docs/**` is `getDocsPage`
- * - the discovery documents get `getSitemapMarkdown`, `getSitemapXml`,
- *   `getLlmsTxt`, `getLlmsFullTxt`, `getApiCatalog`, `getMcpServerCard`,
- *   `getSkillsIndex` and `callMcpServer`, each only when the site serves it
+ * Operation ids: a page pattern gets `get<PascalRoute>` and its raw twin
+ * `get<PascalRoute>Markdown`, a wildcard pattern ends in `Page`, and each
+ * discovery document keeps a fixed id such as `getSitemapMarkdown`. Ids passed
+ * in `paths` and `reserved` are claimed first, so a generated one takes a
+ * numeric suffix on a clash.
  */
 
 type Json = Record<string, unknown>
 
 /** Options for {@link agentDiscoveryOpenApi}. */
 export interface AgentOpenApiOptions {
-  /**
-   * The `paths` object these fragments are being merged into. Every
-   * `operationId` in it is claimed first, so a generated id never lands on a
-   * name the site is already using.
-   */
+  /** The `paths` object these fragments are merged into. Every `operationId` in it is claimed first. */
   paths?: Record<string, unknown>
-  /**
-   * Operation ids to claim without a `paths` object to read them from, for a
-   * document assembled somewhere this call cannot see.
-   */
+  /** Operation ids to claim without a `paths` object to read them from. */
   reserved?: string[]
 }
 
@@ -76,13 +47,9 @@ export interface AgentOpenApiOptions {
 const METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
 
 /**
- * Operation ids of the discovery documents, by the registered link each one
- * follows.
- *
- * Claimed ahead of every route-derived id, so a page pattern deriving the same
- * name takes the suffix instead of these moving. A generated client calls
- * `getSitemapMarkdown()` on every site running this module, and that should not
- * change because one of them happens to configure a `/sitemap` page.
+ * Operation ids of the discovery documents, by registered link. Claimed ahead
+ * of every route-derived id: a generated client calls `getSitemapMarkdown()` on
+ * every site running this module, so a `/sitemap` page takes the suffix instead.
  */
 const DISCOVERY_OPERATIONS: Record<string, string> = {
   '/sitemap.md': 'getSitemapMarkdown',
@@ -122,14 +89,9 @@ function pascalCase(segment: string): string {
 
 /**
  * The `operationId` of a route pattern, which client generators turn into a
- * method name. Static segments are PascalCased, `*` becomes `Segment` and an
- * inner `**` becomes `Path`; a wildcard pattern ends in `Page`, with the
- * trailing `**` left implicit:
- *
- * `/` → `getHomepage`, `/about` → `getAbout`, `/docs/**` → `getDocsPage`, and a
- * locale wildcard in front of that last one → `getSegmentDocsPage`.
- *
- * Derived from the pattern alone, so an id only moves when that pattern does.
+ * method name. Static segments are PascalCased, `*` becomes `Segment`, an inner
+ * `**` becomes `Path`, and a wildcard pattern ends in `Page` with the trailing
+ * `**` implicit: `/` → `Homepage`, `/docs/**` → `DocsPage`.
  */
 function routeOperation(pattern: string): string {
   if (pattern === '/') {
@@ -146,12 +108,7 @@ function routeOperation(pattern: string): string {
   return wildcard ? `${name}Page` : name
 }
 
-/**
- * Every `operationId` in a caller's `paths` object.
- *
- * Only the fixed method fields are read: a path item also carries `summary`,
- * `parameters` and `servers`, none of which name an operation.
- */
+/** Every `operationId` in a caller's `paths` object. Only the fixed method fields name an operation. */
 function operationIds(paths: Record<string, unknown>): string[] {
   const ids: string[] = []
   for (const item of Object.values(paths)) {
@@ -170,15 +127,9 @@ function operationIds(paths: Record<string, unknown>): string[] {
 }
 
 /**
- * Two patterns can derive the same name (`/docs/api` and `/docs-api`), a
- * pattern can derive a discovery document's name (`/sitemap` derives
- * `getSitemapMarkdown`), and either can land on one the caller is already
- * using. Whichever claims a name first keeps it; the next one along takes a
- * numeric suffix.
- *
- * The order is caller first, then the discovery documents, then the routes in
- * the site's own config order, which makes the result stable for a given
- * config.
+ * Whichever name is claimed first keeps it, the next one along takes a numeric
+ * suffix. Two patterns can derive the same name (`/docs/api` and `/docs-api`),
+ * and either can land on one the caller or a discovery document already uses.
  */
 function claim(taken: Set<string>, name: string): string {
   let candidate = name
@@ -201,11 +152,7 @@ function pathParameters(params: string[], pattern: string): Json[] {
   }))
 }
 
-/**
- * A markdown response. Carries `Vary` like the negotiated page does: these URLs
- * serve markdown to every client, but they are where a negotiated page sends
- * one, so the header is on them too and the document has to say so.
- */
+/** A markdown response. Carries `Vary` because this is where a negotiated page sends a client. */
 function markdown(description: string): Json {
   return {
     description,
@@ -239,9 +186,7 @@ function negotiatedPage(config: NegotiationConfig, route: AgentRoute, operationI
             }
           },
           404: { $ref: '#/components/responses/NotFoundMarkdown' },
-          // Only the pages can refuse every representation, and only where the
-          // site turned that on. Left out otherwise rather than documented as
-          // a status nothing returns.
+          // Only where the site turned it on, rather than documenting a status nothing returns.
           ...(config.notAcceptable ? { 406: { $ref: '#/components/responses/NotAcceptable' } } : {})
         }
       }
@@ -283,21 +228,15 @@ interface DocumentRow {
   href: string
   summary: string
   description: string
-  /**
-   * Built per call, not stored. The document handed back is the caller's to
-   * merge into and edit, and a row holding one object would put that same
-   * reference in every document this module ever emits, so one caller's edit
-   * would land in the next request's response.
-   */
+  /** Built per call: the document is the caller's to edit, so no two callers may share an object. */
   response: () => Json
 }
 
 /**
  * The discovery documents that are a plain `href` → response mapping, in
- * insertion order. The MCP endpoint's own path is not one of these: it is a
- * `post` with a request body, not a document with a `get`, and it sits
- * between the api catalog and the server card below, so building `paths`
- * splits this table at {@link MCP_SPLIT} rather than walking it in one pass.
+ * insertion order. The MCP endpoint is a `post` with a request body and sits
+ * between the api catalog and the server card, so `paths` splits this table at
+ * {@link MCP_SPLIT} rather than walking it in one pass.
  */
 const DOCUMENTS: DocumentRow[] = [
   {
@@ -348,9 +287,7 @@ const DOCUMENTS: DocumentRow[] = [
 const MCP_SPLIT = DOCUMENTS.findIndex(document => document.href === '/.well-known/mcp/server-card.json')
 
 // Rename or drop that row and the split silently becomes `slice(0, -1)` and
-// `slice(-1)`, which are both valid: the skills index moves ahead of the other
-// documents and the MCP endpoint lands in the wrong place, with nothing to say
-// so. Cheaper to refuse to load.
+// `slice(-1)`, both valid and both wrong. Cheaper to refuse to load.
 if (MCP_SPLIT === -1) {
   throw new Error('nuxt-agent-discovery: no `/.well-known/mcp/server-card.json` row in the OpenAPI document table, so the MCP endpoint has nowhere to sit. Restore the row, or split the table on whatever replaced it.')
 }
@@ -359,15 +296,12 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
   const config = useAgentDiscoveryConfig(event)
   const has = (href: string) => config.links.some(link => link.href === href)
 
-  // Only a same-origin path, since `paths` is relative to `servers`. A card
-  // pointing at an endpoint on another host has nothing to describe here.
+  // Only a same-origin path, since `paths` is relative to `servers`.
   const mcp = useRuntimeConfig(event).agentDiscoveryMcp as { endpoint?: string } | undefined
   const mcpEndpoint = mcp?.endpoint?.startsWith('/') ? mcp.endpoint : undefined
 
-  // The caller's names first, so nothing generated here can take one of them.
-  // Then the discovery documents, whose ids are the same on every site running
-  // this module and should not move. The route-derived ids come last and take
-  // the suffix on a clash.
+  // The caller's names first, then the discovery documents, whose ids are the
+  // same on every site. Route-derived ids come last and take the suffix.
   const taken = new Set<string>([
     ...(options.reserved || []),
     ...(options.paths ? operationIds(options.paths) : [])
@@ -395,11 +329,8 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
       paths[document.href] = discoveryDocument(discovery[document.href]!, document.summary, document.description, document.response())
     }
   }
-  // The MCP endpoint itself, alongside the card that describes it. Not a route
-  // this module serves, the same as `/sitemap.xml` and the two llms documents
-  // above: what earns a path here is being in the discovery registry, not who
-  // answers it. Leaving this one out is what made every adopter hand-write the
-  // same JSON-RPC block.
+  // The MCP endpoint itself, alongside the card that describes it. What earns a
+  // path here is being in the discovery registry, not who answers it.
   if (mcpEndpoint) {
     paths[mcpEndpoint] = {
       post: {
@@ -502,9 +433,8 @@ export function agentDiscoveryOpenApi(event: H3Event, options: AgentOpenApiOptio
           description: 'The page does not exist. The body is a short Markdown document linking to the entry points an agent can recover from.',
           content: { 'text/markdown': { schema: { type: 'string' } } }
         },
-        // The body follows the same rules every other error does, so a browser
-        // `fetch()` keeps the JSON it was written against while an agent or a
-        // command-line client gets the Markdown one.
+        // The body negotiates like every other error: JSON for a browser
+        // `fetch()`, markdown for an agent or a command-line client.
         ...(config.notAcceptable
           ? {
               NotAcceptable: {

--- a/src/runtime/server/utils/pages.ts
+++ b/src/runtime/server/utils/pages.ts
@@ -3,7 +3,7 @@ import source from '#agent-discovery/source'
 import { getAgentSiteUrl, rawUrl, useAgentDiscoveryConfig } from './agent-discovery'
 import { encodeAgentRoute, isExcluded, normalizeAgentRoute } from '../../shared/negotiation'
 
-/** One page in a listing, with both URLs an agent might want. */
+/** One page in a listing. */
 export interface AgentPageListing {
   route: string
   title?: string
@@ -18,34 +18,27 @@ export interface AgentPageListing {
 
 export interface AgentPageListOptions {
   /**
-   * Keeps pages matching every whitespace-separated term, across the title,
-   * the path and the description. Every term rather than any, because a
-   * two-word query means both words on a docs site.
+   * Keeps pages matching every whitespace-separated term, across the title, the
+   * path and the description.
    */
   search?: string
   /** Keeps pages under this path prefix. */
   prefix?: string
   /**
    * List pages under excluded prefixes too. The same opt-in
-   * `getAgentDocument()` has, for the MCP tool listing what the site
-   * deliberately keeps out of `sitemap.md` and `llms.txt`.
+   * `getAgentDocument()` has.
    */
   includeExcluded?: boolean
 }
 
 /**
- * Every markdown-representable page, from whichever adapter is installed.
+ * Every markdown-representable page, from whichever adapter is installed. Both
+ * URLs come from the same `rawUrl()` the negotiation and the `llms.txt` bridge
+ * resolve.
  *
- * The listing an MCP `list-pages` tool wants, and the one `sitemap.md`
- * already builds. Sites write this by hand today against `queryCollection()`
- * or a navigation tree, which ties the tool to one backend and re-derives the
- * raw URL, so it drifts from the CDN rewrites the first time `rawPrefix` or
- * `routes` changes. Both URLs here come from the same `rawUrl()` the
- * negotiation and the `llms.txt` bridge resolve.
- *
- * An adapter that cannot enumerate its pages leaves `list()` off, and the
- * listing comes back empty. There is no fallback: rebuilding it out of `get()`
- * would cost a full render per page, and neither caller is worth that.
+ * An adapter that cannot enumerate its pages leaves `list()` off and the listing
+ * comes back empty. There is no fallback: rebuilding it out of `get()` would
+ * cost a full render per page.
  */
 export async function listAgentPages(event: H3Event, options: AgentPageListOptions = {}): Promise<AgentPageListing[]> {
   if (!source) {
@@ -59,15 +52,11 @@ export async function listAgentPages(event: H3Event, options: AgentPageListOptio
   const terms = options.search?.toLowerCase().split(/\s+/).filter(Boolean) || []
 
   return entries
-    // Normalized once, to the spelling `getAgentDocument` resolves and the
-    // exclusion list is written in. An adapter handing back an encoded or
-    // trailing-slashed route otherwise slips past the filters below and gets
-    // listed while its document resolves `null`.
+    // To the spelling `getAgentDocument` resolves and the exclusion list is
+    // written in. An encoded route would otherwise slip past the filters below.
     .map(entry => ({ ...entry, route: normalizeAgentRoute(entry.route) }))
-    // A path the module refuses to negotiate is not a page as far as the rest
-    // of the module is concerned, so listing it in `sitemap.md` or handing it
-    // to an MCP tool would advertise a markdown twin that does not exist. This
-    // is also how a site keeps a legacy docs version out of both.
+    // A path the module refuses to negotiate has no markdown twin, so listing it
+    // would advertise one that does not exist.
     .filter(entry => options.includeExcluded || !isExcluded(entry.route, config))
     .filter(entry => !options.prefix || entry.route.startsWith(options.prefix))
     .filter((entry) => {
@@ -82,9 +71,9 @@ export async function listAgentPages(event: H3Event, options: AgentPageListOptio
       title: entry.title,
       description: entry.description,
       section: entry.section,
-      // Encoded like `canonical_url`, so the two spellings of a non-ASCII
-      // page cannot diverge between the listing and the document itself.
-      url: `${siteUrl}${entry.route === '/' ? '' : encodeAgentRoute(entry.route)}` || siteUrl,
+      // Encoded like `canonical_url`, so the two spellings of a non-ASCII page
+      // cannot diverge between the listing and the document itself.
+      url: `${siteUrl}${entry.route === '/' ? '' : encodeAgentRoute(entry.route)}`,
       rawUrl: rawUrl(event, entry.route)
     }))
 }

--- a/src/runtime/shared/defaults.ts
+++ b/src/runtime/shared/defaults.ts
@@ -1,31 +1,17 @@
-/**
- * Defaults the runtime has to know about too, rather than only the build.
- *
- * The build merges these into `runtimeConfig` so `defaults.ts` stays the one
- * place a reader looks them up, but `runtimeConfig` is overridable per deploy
- * and an override replaces a list wholesale. Anything that has to hold whatever
- * the resolved config says lives here and is applied again at request time.
- */
+/* ---- defaults the runtime applies again at request time ---- */
 
 /**
  * MCP definition groups the public server card hides. Groups come from the
  * subdirectory a definition sits in under `server/mcp/tools`, and
- * `mcpServerCard.excludeGroups` extends this list rather than replacing it: a
- * site naming its own private group should not silently start publishing its
- * admin tools.
+ * `mcpServerCard.excludeGroups` extends this list rather than replacing it.
  */
 export const MCP_EXCLUDED_GROUPS = ['admin']
 
 /**
- * The groups a server card leaves out: the built-in defaults, plus whatever the
- * resolved config carries.
- *
- * The build already merges the two, so `extra` is normally the result of that
- * merge and the union is a no-op. It is not always: `runtimeConfig` is
- * env-overridable, and `NUXT_AGENT_DISCOVERY_MCP_EXCLUDE_GROUPS` replaces the
- * array rather than adding to it. A deploy naming its own groups would drop
- * `admin` off the end of the list and start advertising the admin tools, which
- * is the one thing this default exists to prevent.
+ * The groups a server card leaves out: the built-in defaults plus whatever the
+ * resolved config carries. `NUXT_AGENT_DISCOVERY_MCP_EXCLUDE_GROUPS` replaces
+ * that array rather than adding to it, so the union keeps a deploy-time
+ * override from publishing the admin tools.
  */
 export function mcpExcludedGroups(extra?: string[]): Set<string> {
   return new Set([...MCP_EXCLUDED_GROUPS, ...(extra || [])])

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -1,10 +1,4 @@
-/**
- * Markdown content negotiation core.
- *
- * Kept dependency-free on purpose: imported by the build-time module and
- * deploy presets (through the module bundle) and by the Nitro runtime
- * (middleware, error handler, routes). One source of truth for both.
- */
+/** Negotiation core. Dependency-free: shared by build time, presets and runtime. */
 
 import type { AgentRoute, DiscoveryLink, NegotiationConfig } from './types'
 
@@ -25,18 +19,14 @@ export function normalizePathname(path: string): string {
 /**
  * A raw route slug as the content backends spell it: decoded, without a
  * trailing slash, and with `/index` folded into the directory it indexes.
- *
- * The URL arrives percent-encoded while every backend stores decoded paths, so
- * without this `/docs/caf%C3%A9` has no markdown twin at all while its HTML
- * page renders. A malformed escape is left as it came: it matches nothing
- * either way, and throwing would turn a 404 into a 500.
+ * Backends store decoded paths, so `/docs/caf%C3%A9` would have no twin.
  */
 export function normalizeAgentRoute(route: string): string {
   let path = route
   try {
     path = decodeURIComponent(path)
   } catch {
-    // Not a valid escape sequence, so there is nothing to decode.
+    // Malformed escape: leave it as it came rather than turn a 404 into a 500.
   }
   if (path.length > 1 && path.endsWith('/')) {
     path = path.slice(0, -1)
@@ -48,12 +38,9 @@ export function normalizeAgentRoute(route: string): string {
 }
 
 /**
- * The inverse, for URLs this module emits: the decoded route re-encoded the
- * way a page URL is spelled. `encodeURI` alone leaves `#` and `?` in place,
- * where either one cuts a `Link` or `Location` header short, so those two are
- * escaped on top. Not `encodeURIComponent` per segment: that also escapes
- * sub-delims (`@`, `:`, `,`) the HTML page's own canonical keeps literal,
- * which would split the canonical signal into two spellings.
+ * The inverse, for URLs this module emits. `encodeURI` leaves `#` and `?` in
+ * place, where either one cuts a `Link` or `Location` header short. Not
+ * `encodeURIComponent`: it escapes sub-delims the page's canonical keeps.
  */
 export function encodeAgentRoute(path: string): string {
   return encodeURI(path).replace(/#/g, '%23').replace(/\?/g, '%3F')
@@ -76,13 +63,9 @@ const REGEX_SPECIALS = /[.+?^${}()|[\]\\]/
 
 /**
  * Compiles a route pattern to a regex source with one capture group per
- * wildcard: `*` matches one segment, `**` one or more.
- *
- * A trailing slash is matched but never captured. The runtime strips it in
- * `normalizePathname` before matching, but the CDN tests this pattern against
- * the raw request path, and a captured slash lands in the rewrite destination:
- * `/docs/x/` becoming `/raw/docs/x/.md`, which 404s. The `**` capture is lazy
- * so it yields the slash to that optional suffix rather than swallowing it.
+ * wildcard: `*` matches one segment, `**` one or more. A trailing slash is
+ * matched but never captured, because the CDN tests this against the raw
+ * request path and a captured slash rewrites `/docs/x/` to `/raw/docs/x/.md`.
  */
 export function compilePattern(pattern: string): { source: string, captures: number } {
   let source = ''
@@ -125,28 +108,18 @@ export function staticPrefix(pattern: string): string {
   return pattern.split('*')[0]!
 }
 
-/** `/docs/` → `/docs`, so a prefix compares equal to the exact path it covers. */
 function trimSlash(value: string): string {
   return value.length > 1 && value.endsWith('/') ? value.slice(0, -1) : value
 }
 
-/**
- * Whether `path` is `prefix` or sits under it, on a segment boundary. A plain
- * `startsWith` would put `/toolsx` under `/tools`.
- */
+/** `path` is `prefix` or under it on a segment boundary: `/toolsx` is not. */
 function isUnder(path: string, prefix: string): boolean {
   return path === prefix || path.startsWith(prefix === '/' ? '/' : `${prefix}/`)
 }
 
 /**
- * Whether two patterns can match the same path. Used to decide whether a route
- * rule's response cache covers a negotiated pattern, so it errs towards `true`:
- * a false positive costs a redirect where a rewrite would have done, a false
- * negative lets two representations share one cache entry.
- *
- * Static prefixes alone are too loose in two directions: an exact pattern
- * matches exactly one path, so a `/docs/**` rule says nothing about `/`, and a
- * bare string prefix crosses segment boundaries.
+ * Whether two patterns can match the same path. Errs towards `true`, since a
+ * false negative lets two representations share one route rule cache entry.
  */
 export function patternsOverlap(a: string, b: string): boolean {
   const left = trimSlash(staticPrefix(a))
@@ -164,15 +137,9 @@ export function patternsOverlap(a: string, b: string): boolean {
 }
 
 /**
- * Whether a `routeRules` key covers a path, read the way Nitro reads it rather
- * than the way this module's own patterns are read.
- *
- * Route rules are matched by radix3, where `**` stands for zero or more
- * segments: `/docs/**` applies to `/docs` itself, and `/**` applies to `/`.
- * `compilePattern` compiles `**` to `(.+)`, one or more, which is what a page
- * pattern needs (the capture feeds `/raw/$1.md`) and not what a cache rule
- * means. Reading a rule with the pattern matcher silently leaves the section
- * root uncached, which is where a rewrite poisons a cache that really exists.
+ * Whether a `routeRules` key covers a path, read the way radix3 reads it: `**`
+ * is zero or more segments, so `/docs/**` applies to `/docs` itself. The page
+ * patterns compile `**` to one or more, which a cache rule does not mean.
  */
 export function ruleMatchesPath(rule: string, pathname: string): boolean {
   if (rule.endsWith('**')) {
@@ -182,37 +149,21 @@ export function ruleMatchesPath(rule: string, pathname: string): boolean {
 }
 
 /**
- * Whether a cached rule covers *every* path a negotiated pattern matches, the
- * only condition under which the whole pattern may be demoted from a rewrite
- * to a 307. Anything narrower gets its own pair of routes emitted ahead of the
- * pattern instead.
- *
- * Errs towards `false`, the opposite bias to `patternsOverlap`: a pattern
- * wrongly left uncovered still gets that rule's own 307, while a pattern
- * wrongly covered turns every page under it into a redirect.
- *
- * A rule carrying a wildcard before its last segment, a locale prefix say,
- * reports `true` for anything under its static prefix, because `staticPrefix`
- * cuts at the first wildcard. That is the fail-safe direction and matches what
- * the preset did before, so it is left alone deliberately.
+ * Whether a cached rule covers every path a pattern matches, the only case
+ * where the pattern may be demoted from a rewrite to a 307. Errs towards
+ * `false`: a pattern wrongly covered turns its pages into redirects.
  */
 export function ruleCoversPattern(rule: string, pattern: string): boolean {
   if (rule === pattern) {
     return true
   }
-  // A `**` rule owns its whole subtree, so it covers any pattern rooted in it.
   if (rule.endsWith('**')) {
     return isUnder(trimSlash(staticPrefix(pattern)), trimSlash(staticPrefix(rule)))
   }
-  // Anything else matches a bounded set of paths, so it can only cover a
-  // pattern that is itself a single path the rule matches.
   return !pattern.includes('*') && ruleMatchesPath(rule, pattern)
 }
 
-/**
- * The raw markdown destination for a matched page. `raw` is only honoured on
- * exact patterns; wildcard patterns always map to `rawPrefix + path + '.md'`.
- */
+/** The raw markdown destination for a page. `raw` is only honoured on exact patterns. */
 export function rawDestination(config: NegotiationConfig, route: AgentRoute, pathname: string): string {
   if (route.raw && !route.path.includes('*')) {
     return route.raw
@@ -288,17 +239,9 @@ export function acceptQuality(entries: AcceptEntry[], target: string): number {
 
 /**
  * Whether the client explicitly asked for markdown: a literal `text/markdown`
- * entry with a non-zero q-value that html does not outrank. A wildcard on its
- * own never counts as asking, so wildcard-only clients keep HTML on pages.
- *
- * Unless it refused html outright. A client sending `text/html;q=0` alongside
- * a full wildcard has ruled out the only other representation there is, so
- * html hands it the one thing it said it could not read, and the page is not
- * unacceptable either: markdown rates through that wildcard, so there is
- * nothing for `notAcceptable` to refuse. Markdown is the only answer left.
- *
- * Narrow on purpose: a browser and a `fetch()` both rate html through their
- * own wildcard, so neither ever reaches this.
+ * entry with a non-zero q-value that html does not outrank. A wildcard alone
+ * never counts, so browsers and `fetch()` keep HTML. The exception is a client
+ * that refused html outright, where markdown is the only answer left.
  */
 export function acceptsMarkdown(accept?: string | null): boolean {
   const entries = parseAccept(accept)
@@ -311,15 +254,9 @@ export function acceptsMarkdown(accept?: string | null): boolean {
 }
 
 /**
- * Case-insensitive, so it agrees with the CDN `has` matchers: a real Vercel
- * edge has been observed anchoring the value and matching it
- * case-insensitively. The Build Output docs only document `caseSensitive` for
- * `src`, so the edge matchers spell both cases where a miss would matter
- * (`REFUSES_MARKDOWN`) and nothing depends on the observation. The origin
- * errs the same direction, towards matching.
- *
- * Lowered per call on purpose: Nitro klonas the runtime config per request,
- * so a cache keyed on the list's identity could never hit across requests.
+ * Case-insensitive, so it agrees with the CDN `has` matchers. Lowered per call
+ * because Nitro clones the runtime config per request, so a cache keyed on the
+ * list's identity could never hit across requests.
  */
 export function isAgentUserAgent(config: NegotiationConfig, userAgent?: string | null): boolean {
   if (!userAgent) {
@@ -332,11 +269,8 @@ export function isAgentUserAgent(config: NegotiationConfig, userAgent?: string |
 /* ------------------------------- negotiation ------------------------------ */
 
 /**
- * Resolves the raw markdown destination a request should be served from, or
- * `undefined` when the request is not asking for markdown.
- *
- * Mirrors the deploy-preset rewrites so the dev and Node servers behave like
- * the edge.
+ * The raw markdown destination a request should be served from, or `undefined`
+ * when it is not asking for markdown. Mirrors the deploy-preset rewrites.
  */
 export function negotiatedRawPath(config: NegotiationConfig, path: string, options: { accept?: string | null, userAgent?: string | null } = {}): string | undefined {
   const pathname = normalizePathname(path)
@@ -349,10 +283,8 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
     return undefined
   }
 
-  // An explicit `.md` twin URL is a markdown request, whatever the headers
-  // say. A bare `/.md` is not a twin, matching the CDN rewrites. Handled here
-  // rather than through `negotiableRoute`, whose dotted-segment rule would
-  // read the suffix as an asset.
+  // An explicit `.md` twin is a markdown request whatever the headers say. Not
+  // routed through `negotiableRoute`, which would read the suffix as an asset.
   if (pathname.endsWith('.md')) {
     const base = pathname.slice(0, -3)
     if (base.length <= 1) {
@@ -371,16 +303,10 @@ export function negotiatedRawPath(config: NegotiationConfig, path: string, optio
 }
 
 /**
- * The twin a page hands Nitro's prerender crawler while it is being rendered:
- * the raw destination of a negotiable path, or `undefined` for a URL with a
- * single representation and for a twin the site serves with a handler of its
- * own, which prerendering would freeze at build.
- *
- * Emitted from the page's own HTML response, because that is the only kind
- * Nitro reads `x-nitro-prerender` from: a hint on a `text/plain` response is
- * dropped with the rest of it, and `/` is not prerendered on every site (a
- * locale-prefixed one starts at `/en`). A twin is prerendered exactly when
- * its page is, whatever the crawl order.
+ * The twin a page hands Nitro's prerender crawler while it renders, or
+ * `undefined` for a single-representation URL and for a twin the site serves
+ * itself. Emitted from the page's own HTML response: Nitro drops
+ * `x-nitro-prerender` on a `text/plain` one, and `/` is not always prerendered.
  */
 export function prerenderTwin(config: NegotiationConfig, path: string): string | undefined {
   const pathname = normalizePathname(path)
@@ -394,21 +320,14 @@ export function prerenderTwin(config: NegotiationConfig, path: string): string |
 
 /**
  * Whether the site answers a raw twin with a handler of its own, so nothing
- * may prerender it: not the exact-route pass, not the llms bridge's hints and
- * not a page's own. The one predicate behind all three, on the handler
- * patterns `ownRawRoutes` carries, because a page matched by a wildcard route
- * has no build-time list of twins to compare against.
+ * may prerender it. Matched on handler patterns, since a page under a wildcard
+ * route has no build-time list of twins.
  */
 export function siteServesRaw(config: Pick<NegotiationConfig, 'ownRawRoutes'>, raw: string): boolean {
   return config.ownRawRoutes?.some(pattern => handlerRouteMatches(pattern, raw)) ?? false
 }
 
-/**
- * Whether a handler's route pattern covers a path, the way Nitro's router
- * reads it: `:name` and `*` match one segment, `**` the rest. An exact string
- * compare read `/raw/:name` as not owning the twin it serves, and the
- * prerender froze it anyway.
- */
+/** Whether a handler route covers a path: `:name` and `*` match one segment, `**` the rest. */
 export function handlerRouteMatches(pattern: string, path: string): boolean {
   if (!/[:*]/.test(pattern)) {
     return pattern === path
@@ -431,9 +350,7 @@ export function handlerRouteMatches(pattern: string, path: string): boolean {
 
 /**
  * The route a path negotiates through, whatever the client asked for.
- * `undefined` when the URL has a single representation: the raw prefix itself,
- * an excluded prefix, a dotted asset (`_payload.json`, images), or a path no
- * configured pattern covers.
+ * `undefined` when the URL has a single representation.
  */
 function negotiableRoute(config: NegotiationConfig, pathname: string): AgentRoute | undefined {
   if (isRawPath(config, pathname)) {
@@ -448,67 +365,35 @@ function negotiableRoute(config: NegotiationConfig, pathname: string): AgentRout
   return matchRoute(config.routes, pathname)
 }
 
-/**
- * Whether a normalized pathname is the raw prefix itself or sits under it.
- * The one definition of "this URL is a raw markdown twin", shared with the
- * sitemap plugin so every consumer agrees on it.
- */
+/** Whether a normalized pathname is the raw prefix itself or sits under it. */
 export function isRawPath(config: Pick<NegotiationConfig, 'rawPrefix'>, pathname: string): boolean {
   return isUnder(pathname, config.rawPrefix)
 }
 
 /**
- * Whether a URL has both an HTML and a markdown representation, so its
- * response genuinely depends on `Accept` and `User-Agent`.
- *
- * This is what `Vary` is set from. Deriving it here rather than from a route
- * rule glob is the only way to exclude the API surface and the assets: a
- * `routeRules` key cannot express a negative pattern, so a catch-all pattern
- * would label every response on the site.
+ * Whether a URL has both an HTML and a markdown representation. This is what
+ * `Vary` is set from, derived here because a `routeRules` key cannot express
+ * the negative pattern that keeps the API surface and the assets out.
  */
 export function isNegotiablePath(config: NegotiationConfig, path: string): boolean {
   return Boolean(negotiableRoute(config, normalizePathname(path)))
 }
 
-/**
- * The media types a negotiated page has a representation for, in the order the
- * 406 body lists them.
- */
+/** The media types a negotiated page has, in the order the 406 body lists them. */
 export const REPRESENTATIONS = ['text/html', 'text/markdown']
 
 /**
- * A media range as RFC 9110 spells one: a full wildcard, `type/*`, or
- * `type/subtype`, each half a non-empty token.
- *
- * `text/`, `/html` and `text/html/extra` are not media ranges, they are a
- * mangled header, and the difference matters: an unacceptable range is a 406
- * while a mangled one is ignored.
+ * A media range as RFC 9110 spells one. `text/` and `/html` are a mangled
+ * header, not a range: an unacceptable range is a 406, a mangled one ignored.
  */
 const MEDIA_RANGE = /^[a-z0-9!#$%&'*+.^_|~-]+\/[a-z0-9!#$%&'*+.^_|~-]+$/
 
 /**
- * Whether a negotiated page has to answer 406: the request carries an `Accept`
- * that rules out both of its representations, which is what RFC 9110 asks for
- * when a server cannot honour the header.
- *
- * Off unless a site turns it on, and narrow when it is on, because every false
- * positive here is a page that used to render turning into an error. So:
- *
- * - no `Accept` at all means the client takes anything, and the full wildcard
- *   a `fetch()` sends, or the one at `q=0.8` every browser sends, rates both
- *   representations through `acceptQuality`, so neither reaches the last check
- * - a `Sec-Fetch-Mode` of `navigate` is a real navigation, and keeps its page
- *   whatever it asked for, the same protection `prefersMarkdownError` gives
- * - a known agent gets markdown whatever its `Accept` says, so it can never be
- *   refused over a header it was not being read on anyway
- * - a header with no media range in it at all is malformed, and RFC 9110 says
- *   to ignore one of those rather than fail the request over it. `garbage` is
- *   one, and so is a half-mangled `text/` or `/html`, which is the shape a
- *   proxy rewriting the header leaves behind
- *
- * `Accept: text/markdown;q=0` reaches the last check and is a 406, on the same
- * reading that makes `Accept: application/xml` one: a quality of zero is a
- * refusal, and refusing both representations leaves nothing to send.
+ * Whether a negotiated page has to answer 406: the `Accept` rules out both of
+ * its representations, as RFC 9110 asks. Off unless a site turns it on, and
+ * narrow when it is, because a false positive turns a page that renders into
+ * an error. A missing `Accept`, a navigation, a known agent and an unparseable
+ * header all keep their page. `text/markdown;q=0` does not, zero is a refusal.
  */
 export function notAcceptable(config: NegotiationConfig, options: {
   method?: string
@@ -530,8 +415,7 @@ export function notAcceptable(config: NegotiationConfig, options: {
     return false
   }
 
-  // Only a URL with more than one representation can refuse them all. Rules
-  // out the assets, the excluded prefixes and the `.md` twins in one call.
+  // Only a URL with more than one representation can refuse them all.
   if (!isNegotiablePath(config, options.path)) {
     return false
   }
@@ -544,10 +428,8 @@ export function notAcceptable(config: NegotiationConfig, options: {
     return false
   }
 
-  // One intelligible range is enough to judge the request on. RFC 9110 says to
-  // ignore what cannot be parsed, so `application/xml, text/` is still a
-  // refusal of both representations while `text/` on its own is not a request
-  // this can read at all.
+  // RFC 9110 says to ignore what cannot be parsed, so `application/xml, text/`
+  // is still a refusal of both while `text/` on its own is unreadable.
   const entries = parseAccept(options.accept)
   if (!entries.some(entry => MEDIA_RANGE.test(entry.type))) {
     return false
@@ -558,7 +440,7 @@ export function notAcceptable(config: NegotiationConfig, options: {
 
 /**
  * Whether an error response should be rendered as markdown rather than the
- * HTML error page (or the JSON payload Nitro falls back to).
+ * HTML error page or Nitro's JSON fallback.
  */
 export function prefersMarkdownError(config: NegotiationConfig, options: {
   method?: string
@@ -583,12 +465,10 @@ export function prefersMarkdownError(config: NegotiationConfig, options: {
     return false
   }
 
-  // Explicit markdown URLs.
   if (pathname.endsWith('.md')) {
     return true
   }
 
-  // Assets and non-page documents: images, `.xml`, `.json`, `.js`, ...
   if (hasFileExtension(pathname)) {
     return false
   }
@@ -610,14 +490,13 @@ export function prefersMarkdownError(config: NegotiationConfig, options: {
     return false
   }
 
-  // A browser `fetch()` of any mode (`cors`, `no-cors`, `same-origin`) keeps
-  // the HTML or JSON error it was written against. Only navigations fall through.
+  // A browser `fetch()` of any mode keeps the HTML or JSON error it expects.
+  // Only navigations fall through.
   if (options.secFetchMode && options.secFetchMode.toLowerCase() !== 'navigate') {
     return false
   }
 
-  // `*/*`, an empty `Accept`, curl, or any other non-browser client asking for
-  // a page: markdown is the most useful thing we can hand back.
+  // curl and any other non-browser client asking for a page gets markdown.
   return true
 }
 
@@ -627,13 +506,8 @@ export function prefersMarkdownError(config: NegotiationConfig, options: {
 const MARKDOWN_LINK = /(\]\(|\]:[ \t]*)(\/(?!\/)[^\s)>]*)/g
 
 /**
- * The `</x>` autolink form, which the resource lists in the raw documents use.
- *
- * The path has to carry a second `/` or a `.` somewhere, or every HTML closing
- * tag in the document is one: `</div>` and `</Callout>` are indistinguishable
- * from an autolink otherwise, and rewriting them destroys the markup. The cost
- * is that a single-segment autolink like `</blog>` is left relative, which is
- * a great deal better than mangling every tag.
+ * The `</x>` autolink form. The path has to carry a second `/` or a `.`, or
+ * `</div>` and `</Callout>` match too and rewriting them destroys the markup.
  */
 const MARKDOWN_AUTOLINK = /<(\/(?!\/)[^\s<>]*)>/g
 
@@ -664,14 +538,8 @@ function absolutizeLine(line: string, siteUrl: string): string {
 }
 
 /**
- * Rewrites site-relative markdown links to absolute ones. A markdown document
- * is read detached from the site it came from, so a relative href in it points
- * nowhere.
- *
- * Every adapter has to do this or the same page reads differently depending on
- * which backend served it, so it lives here rather than in each one. Fenced
- * blocks and inline code spans are left alone: a docs site writing about
- * markdown must keep its examples verbatim.
+ * Rewrites site-relative markdown links to absolute ones, since the document
+ * is read detached from its site. Fenced blocks and code spans are left alone.
  */
 export function absolutizeMarkdownLinks(markdown: string, siteUrl: string): string {
   const base = siteUrl.replace(/\/$/, '')
@@ -693,11 +561,7 @@ export function absolutizeMarkdownLinks(markdown: string, siteUrl: string): stri
   }).join('\n')
 }
 
-/**
- * Prefixes a site-relative href with the site origin, leaving absolute and
- * protocol-relative ones alone. Every discovery surface renders its links
- * through this so they all agree on what "absolute" means.
- */
+/** Prefixes a site-relative href with the site origin, leaving others alone. */
 export function absolutizeHref(href: string, siteUrl: string): string {
   return href.startsWith('/') && !href.startsWith('//') ? `${siteUrl}${href}` : href
 }
@@ -705,14 +569,10 @@ export function absolutizeHref(href: string, siteUrl: string): string {
 const LINK_PROPS = ['href', 'src', 'to']
 
 /**
- * The same rewrite, one level earlier: on the document tree, before it is
- * stringified. Both built-in backends hand back `[tag, props, ...children]`
- * nodes, minimark for `@nuxt/content` and comark for `comark-content`, so one
- * walker serves both.
- *
- * Preferred over the string pass wherever a tree is available: it sees the
- * props of MDC components, which carry links a markdown-level scan cannot
- * find, and it can never touch prose that merely looks like a link.
+ * The same rewrite on the document tree, before it is stringified. Both
+ * backends hand back `[tag, props, ...children]` nodes, so one walker serves
+ * both. Preferred over the string pass: it sees MDC component props and never
+ * touches prose that merely looks like a link.
  */
 export function absolutizeTreeLinks(nodes: unknown[], siteUrl: string): void {
   const base = siteUrl.replace(/\/$/, '')
@@ -725,8 +585,6 @@ export function absolutizeTreeLinks(nodes: unknown[], siteUrl: string): void {
     if (props && typeof props === 'object') {
       for (const prop of LINK_PROPS) {
         const value = props[prop]
-        // Only site-relative paths. Protocol-relative, absolute and in-page
-        // anchors already resolve on their own.
         if (typeof value === 'string' && value.startsWith('/') && !value.startsWith('//')) {
           props[prop] = base + value
         }
@@ -737,30 +595,23 @@ export function absolutizeTreeLinks(nodes: unknown[], siteUrl: string): void {
 }
 
 /**
- * Whether the Vercel route table carries the canonical/alternate `Link` pair
- * for a raw markdown URL, mirroring the `config.siteUrl` block of
- * `vercelMarkdownRoutes` request-side: the raw handler skips its own copy
- * exactly there, or every origin-rendered raw response carries the pair
- * twice, doubling with each hop.
- *
- * Covered: the static twin of every exact pattern whose destination sits
- * under the raw prefix, the root twin, and the wildcard twins except the
- * `/index.md` spellings the preset's `noIndex` lookahead keeps out (their
- * capture would advertise a page URL the origin folds away). Everything else
- * (a twin outside every pattern, an exact destination outside the prefix)
- * reaches no pair route and keeps the handler's header.
+ * Whether the Vercel route table already carries the canonical/alternate
+ * `Link` pair for a raw URL, mirroring the `config.siteUrl` block of
+ * `vercelMarkdownRoutes`. The raw handler skips its own copy exactly there, or
+ * every origin-rendered raw response carries the pair twice. `/index.md` is
+ * out because the preset's `noIndex` lookahead keeps it out of the table.
  */
 export function hasCdnLinkPair(config: NegotiationConfig, rawPathname: string): boolean {
   if (!rawPathname.endsWith('.md')) {
     return false
   }
-  // The table matches the encoded request path, the config spells routes
-  // decoded; one spelling here, like `normalizeAgentRoute` without the folds.
+  // The table matches the encoded request path while the config spells routes
+  // decoded.
   let pathname = rawPathname
   try {
     pathname = decodeURIComponent(pathname)
   } catch {
-    // Not a valid escape sequence, so there is nothing to decode.
+    // Malformed escape: leave it as it came.
   }
 
   const rootTwin = `${config.rawPrefix}/index.md`
@@ -815,22 +666,16 @@ const STATUS_TEXT: Record<number, string> = {
 
 /**
  * Short markdown body for an error response, pointing agents at the discovery
- * resources they can recover from. Links are absolute so they resolve wherever
- * the body ends up.
+ * resources they can recover from. Links are absolute: the body travels.
  */
 export function errorMarkdown(config: NegotiationConfig, options: { path: string, status?: number, statusMessage?: string, siteUrl: string }): string {
   const status = options.status || 404
   const siteUrl = options.siteUrl.replace(/\/$/, '')
-  // The pathname is attacker-chosen and lands in a code span of a document
-  // written for agents, so drop anything that could close the span or smuggle
-  // markdown in. Newlines most of all: h3 has already decoded `%0A`, so without
-  // this a crafted path ends the paragraph and everything after it renders as
-  // first-class markdown, links included, in a document an agent will act on.
-  // Capped too, so a long path cannot bury the rest of the body.
+  // The pathname is attacker-chosen and lands in a code span of a document an
+  // agent will act on, so drop anything that could close the span and smuggle
+  // markdown in. Newlines most of all: h3 has already decoded `%0A`.
   const pathname = normalizePathname(options.path).replace(/[`\\\r\n]+/g, '').slice(0, 200)
-  // Server errors never surface their message. Client errors use the status
-  // message when there is one, stripped of anything that could break the
-  // heading or the frontmatter line.
+  // Server errors never surface their message.
   const statusMessage = status < 500
     ? options.statusMessage?.replace(/[\r\n\t`\\]+/g, ' ').trim()
     : undefined
@@ -838,8 +683,7 @@ export function errorMarkdown(config: NegotiationConfig, options: { path: string
     ? STATUS_TEXT[404]!
     : statusMessage || STATUS_TEXT[status] || (status < 500 ? 'Request Error' : 'Server Error')
 
-  // A 406 says which representations exist, which is the "list of available
-  // representation characteristics" RFC 9110 asks a 406 body to carry.
+  // RFC 9110 asks a 406 body to list the available representations.
   const intro = status === 404
     ? `The page \`${pathname}\` does not exist on ${siteUrl}.`
     : status === 406

--- a/src/runtime/shared/paths.ts
+++ b/src/runtime/shared/paths.ts
@@ -1,8 +1,4 @@
-/**
- * The Agent Skills well-known prefix. One constant, because the route
- * registration, the prerender list, the discovery links, the OpenAPI document
- * and the file route all have to agree on it.
- */
+/** The Agent Skills well-known prefix, shared by every surface that names it. */
 export const SKILLS_PREFIX = '/.well-known/skills/'
 
 /** The generated skills index document. */

--- a/src/runtime/shared/sections.ts
+++ b/src/runtime/shared/sections.ts
@@ -1,18 +1,7 @@
 /**
- * Narrows a markdown document to the `##` sections an agent asked for,
- * keeping the frontmatter, the title and the description.
- *
- * A docs page is often far longer than the part of it that answers a
- * question, and an agent that has to read all of it pays for the rest in
- * context. This is the function every site running an MCP `get-page` tool
- * ends up writing.
- *
- * Two copies of it exist in the wild and each fixed a bug the other still
- * has: one bounds the header scan at the first `##`, so a page with no
- * description doesn't swallow the whole document, but returns just the title
- * when nothing matched, which makes the agent fetch the page again; the other
- * falls back to the full document but lost the bound. This has both, plus the
- * frontmatter skip the raw route's output needs.
+ * Narrows a markdown document to the `##` sections an agent asked for, keeping
+ * the frontmatter, the title and the description. A docs page is often far
+ * longer than the part of it that answers a question.
  */
 export function extractSections(markdown: string, sectionTitles: string[]): string {
   const wanted = new Set(sectionTitles.map(title => title.toLowerCase().trim()))
@@ -24,9 +13,8 @@ export function extractSections(markdown: string, sectionTitles: string[]): stri
   const result: string[] = []
   let start = 0
 
-  // The raw route opens every document with a frontmatter block, and a YAML
-  // block scalar (`description: >`) inside it would otherwise read as the
-  // description blockquote and end the header scan early.
+  // A YAML block scalar (`description: >`) in the frontmatter would otherwise
+  // read as the description blockquote and end the header scan early.
   if (lines[0] === '---') {
     const close = lines.indexOf('---', 1)
     if (close !== -1) {
@@ -35,10 +23,8 @@ export function extractSections(markdown: string, sectionTitles: string[]): stri
     }
   }
 
-  // The title and the description, however few lines that turns out to be.
-  // Bounded by the first `##`: a page with no description blockquote would
-  // otherwise push its entire body in here and then repeat the matched
-  // sections below it.
+  // Title and description, bounded by the first `##`: a page with no description
+  // blockquote would otherwise push its entire body in here.
   for (let index = start; index < lines.length; index++) {
     const line = lines[index]!
     if (line.startsWith('## ')) {
@@ -77,9 +63,8 @@ export function extractSections(markdown: string, sectionTitles: string[]): stri
   }
   take()
 
-  // Nothing matched, so the agent named sections this page doesn't have.
-  // Handing back the title alone would just make it ask again without the
-  // argument; the whole document answers the question it was really asking.
+  // Nothing matched, so the agent named sections this page doesn't have. The
+  // title alone would just make it ask again without the argument.
   if (!matched) {
     return markdown
   }

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -1,78 +1,57 @@
 import type { H3Event } from 'h3'
 
-// Mirrored by the `agent-discovery/hooks.d.ts` template in `module.ts`, which
-// is what a consuming site sees. This copy is what type-checks the module's own
-// source; keep the two in step.
+// Mirrored by the `agent-discovery/hooks.d.ts` template in `module.ts`, which is
+// what a consuming site sees. Keep the two in step.
 declare module 'nitropack/types' {
   interface NitroRuntimeHooks {
     /**
-     * Transforms a page before the content adapter stringifies it. `page` is
-     * whatever the adapter works on, a minimark tree for `@nuxt/content` and
-     * the backend's own document elsewhere, so it is deliberately `any`: this
-     * module cannot know the shape, and a site should not have to cast to
-     * hand it to its own transformer.
+     * Transforms a page before the content adapter stringifies it. `page` is the
+     * backend's own document, a minimark tree for `@nuxt/content`, so it is `any`.
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     'agent-discovery:document': (event: H3Event, page: any) => void | Promise<void>
     /**
-     * Fills in the generated `/raw/index.md`, for a site whose landing page is
-     * a Vue page rather than a document. Set `title` and `description`, which
+     * Fills in the generated `/raw/index.md`. Set `title` and `description`, which
      * reach the frontmatter, and push markdown blocks onto `body`.
      */
     'agent-discovery:index': (event: H3Event, index: AgentIndex) => void | Promise<void>
     /** Enriches the served MCP server card with live tools, resources and prompts. */
     'agent-discovery:mcp-server-card': (event: H3Event, card: Record<string, unknown>) => void | Promise<void>
     /**
-     * Adds to `sitemap.md` before it is rendered, in the order the sections
-     * appear. Keys are the raw first path segment of the grouped routes
-     * (`docs`, `blog`; the second segment under an expanded prefix, `pages`
-     * for top-level ones), with `sitemapSections.labels` applied at render
-     * only. Extend an existing section through that key
-     * (`sections.get('docs')`); a new section may use any key, which renders
-     * capitalized unless `labels` overrides it.
+     * Adds to `sitemap.md` before it is rendered, in section order. Keys are the
+     * raw path segment a section groups, before `sitemapSections.labels` applies.
      */
     'agent-discovery:sitemap': (event: H3Event, sections: Map<string, { title: string, href: string }[]>) => void | Promise<void>
   }
 }
 
 /**
- * A page pattern the module negotiates markdown for.
- *
- * `path` accepts `*` (one segment) and `**` (one or more segments), so a
- * locale prefix is one wildcard segment in a single pattern and the generated
- * route table stays O(patterns), never O(pages).
+ * A page pattern the module negotiates markdown for. `path` accepts `*` (one
+ * segment) and `**` (one or more), so the route table stays O(patterns).
  */
 export interface AgentRoute {
   path: string
   /**
-   * Explicit raw markdown destination, required for exact paths whose `.md`
-   * twin is not `path + '.md'` (the homepage: `{ path: '/', raw: '/raw/index.md' }`).
-   * Defaults to `rawPrefix + path + '.md'`.
+   * Explicit raw markdown destination, for an exact path whose `.md` twin is not
+   * `path + '.md'` (`{ path: '/', raw: '/raw/index.md' }`). Defaults to
+   * `rawPrefix + path + '.md'`.
    */
   raw?: string
 }
 
 /**
- * A discovery resource, declared once and emitted everywhere: the `Link`
- * header on `/`, the `.well-known/api-catalog` linkset, the recovery links in
- * markdown error bodies and the "Resources for Agents" block.
+ * A discovery resource, emitted in the `Link` header on `/`, the
+ * `.well-known/api-catalog` linkset, markdown error bodies and the resources block.
  */
 export interface DiscoveryLink {
   /** Site-relative (`/llms.txt`) or absolute href. */
   href: string
-  /**
-   * IANA-registered link relation (or an absolute URI for an extension
-   * relation, per RFC 8288). Invented rels like `llms` fail the build.
-   */
+  /** IANA-registered relation, or an absolute URI for an extension relation per RFC 8288. Invented rels fail the build. */
   rel: string
   type?: string
   /** Human/agent readable label, used in error bodies and resource listings. */
   title?: string
-  /**
-   * Anchor for the api-catalog linkset (RFC 9727), site-relative or absolute.
-   * Only `service-desc` and `service-doc` links carrying an anchor are grouped
-   * into the catalog.
-   */
+  /** Anchor for the api-catalog linkset (RFC 9727). Only `service-desc` and `service-doc` links carrying one reach it. */
   anchor?: string
   /** Whether the link is emitted in the `Link` header on `/`. Default `true`. */
   header?: boolean
@@ -80,11 +59,7 @@ export interface DiscoveryLink {
 
 /** How `sitemap.md` groups pages into sections. */
 export interface SitemapSections {
-  /**
-   * Path prefixes whose children each get their own section, instead of the
-   * whole prefix being one. `['/docs']` turns a single "Docs" section into
-   * "Components", "Composables", ... while `/blog/**` stays one "Blog".
-   */
+  /** Path prefixes whose children each get their own section. `['/docs']` splits "Docs" into "Components", "Composables". */
   expand: string[]
   /** Label overrides, keyed by the path segment the section groups. */
   labels: Record<string, string>
@@ -103,22 +78,14 @@ export interface AgentPage {
   markdown: string
   title?: string
   description?: string
-  /**
-   * Last modification date. Adapters may supply it, and sites do, but nothing
-   * in the module reads it yet; it is reserved for freshness signals such as
-   * a sitemap `lastmod`.
-   */
+  /** Last modification date. Adapters may supply it, nothing reads it yet. */
   updatedAt?: string
 }
 
 /**
  * The generated `/raw/index.md`, handed to `agent-discovery:index` for a site
- * whose landing page is a Vue page rather than a document.
- *
- * `title` arrives pre-filled from `siteName` (or the host), and everything the
- * hook leaves alone is dropped from the frontmatter rather than emitted empty.
- * The metadata for a landing page like this lives wherever the site keeps it,
- * which is why the module cannot read it itself.
+ * whose landing page is a Vue page. `title` arrives pre-filled from `siteName`
+ * or the host, and anything the hook leaves alone is dropped from frontmatter.
  */
 export interface AgentIndex {
   /** Frontmatter `title`, and the document's `# ` heading. */
@@ -132,49 +99,27 @@ export interface AgentIndex {
 /** One page in a listing: the route plus whatever metadata is cheap to read. */
 export interface AgentListEntry extends Partial<AgentPage> {
   route: string
-  /**
-   * Group this page belongs to, used as the section title in `llms.txt` when
-   * the site declares no sections of its own. Adapters that have a natural
-   * grouping set it: the navigation tree for comark, the collection for
-   * `@nuxt/content`. `sitemap.md` does not read it, it groups by path segment
-   * through `sitemapSections`.
-   */
+  /** Group this page belongs to, the `llms.txt` section title when the site declares none. `sitemap.md` groups by path. */
   section?: string
 }
 
 /**
- * A `llms.sections` entry, handed to `list()` verbatim. The module never reads
- * it: `contentCollection`/`contentFilters` mean something to the `@nuxt/content`
- * adapter and nothing to the others, so each adapter picks out the keys it
- * declares and returns `null` for a selector that isn't its own.
+ * A `llms.sections` entry, handed to `list()` verbatim. Each adapter picks out
+ * the keys it declares and returns `null` for a selector that isn't its own.
  */
 export type AgentSectionSelector = Record<string, unknown>
 
-/**
- * The content adapter seam. The module never serves raw markdown itself, it
- * routes to whatever implements this.
- */
+/** The content adapter seam. The module never serves raw markdown itself, it routes to whatever implements this. */
 export interface AgentContentSource {
   /**
-   * Every markdown-representable page, with whatever metadata the backend has.
-   * `sitemap.md`, the `nuxt-llms` bridge and `listAgentPages()` all read it.
-   *
-   * With a `selector`, a `llms.sections` entry handed over verbatim, return
-   * only the pages it names, or `null` when the selector is not one this
-   * adapter understands.
-   *
-   * Optional, for a backend that can resolve a route but cannot enumerate its
-   * pages. Every listing then comes out empty: `/sitemap.md` and the `llms.txt`
-   * bridge list nothing, while the documents `get()` resolves keep working.
+   * Every markdown-representable page. With a `selector`, a `llms.sections` entry
+   * handed over verbatim, return only the pages it names, or `null` when it is not
+   * one this adapter understands. Left out, every listing comes out empty.
    */
   list?: (selector: AgentSectionSelector | undefined, event: H3Event) => Promise<AgentListEntry[] | null>
   /** Resolve one route to its markdown representation, `null` when unknown. */
   get: (route: string, event: H3Event) => Promise<AgentPage | null>
-  /**
-   * Optional: the first page under a section path, for a URL that names a
-   * directory rather than a page (`/getting-started` with no `index`). The raw
-   * route redirects to its markdown twin, mirroring what the HTML page does.
-   */
+  /** The first page under a section path, for a URL naming a directory. The raw route redirects to that page's twin. */
   firstLeaf?: (route: string, event: H3Event) => Promise<string | null>
 }
 
@@ -190,40 +135,34 @@ export interface NegotiationConfig {
   excludePrefixes: string[]
   links: DiscoveryLink[]
   /**
-   * Whether the discovery `Link` header is emitted on `/`. Carried here rather
-   * than read off the module options, because the deploy presets emit that
-   * header themselves and only ever see this config.
+   * Whether the discovery `Link` header is emitted on `/`. Carried here because
+   * the deploy presets emit that header themselves and only see this config.
    */
   linkHeader: boolean
   /** How `sitemap.md` groups pages into sections. */
   sitemapSections: SitemapSections
   /**
-   * Route-rule patterns with a response cache (`isr`, `swr`, `cache`) that
-   * cannot vary on `Accept`/`User-Agent`. The Nitro middleware skips
-   * negotiation there so a markdown response never poisons the cache; the
-   * CDN-level rewrites still apply because they run before the cache.
+   * Route-rule patterns with a response cache (`isr`, `swr`, `cache`) that cannot
+   * vary on `Accept`/`User-Agent`. The Nitro middleware skips negotiation there so
+   * a markdown response never poisons the cache. CDN rewrites run first and apply.
    */
   cachedRoutes: string[]
   /**
-   * Whether a negotiated page answers 406 to an `Accept` that allows neither
-   * of its two representations. Off unless the site asks for it: the strictly
-   * correct answer breaks any client sending a narrow `Accept` it did not mean.
+   * Whether a negotiated page answers 406 to an `Accept` that allows neither of
+   * its representations. Off unless the site asks for it, since it breaks any
+   * client sending a narrow `Accept` it did not mean.
    */
   notAcceptable: boolean
   /**
-   * Route patterns of the handlers the site serves under the raw prefix
-   * itself, as Nitro registers them (`/raw/modules.md`, `/raw/:name.md`,
-   * `/raw/**:slug.md`). The exact-route prerender pass, the llms bridge's
-   * crawler hints and a page's own hint all skip a twin one of them matches,
-   * so a twin backed by live data is never frozen at build.
+   * Route patterns of the handlers the site serves under the raw prefix itself,
+   * as Nitro registers them (`/raw/:name.md`). Prerendering and crawler hints skip
+   * a twin one of them matches, so a twin backed by live data is never frozen.
    */
   ownRawRoutes?: string[]
   /**
-   * Whether the deployed CDN route table injects the canonical/alternate
-   * `Link` pair on the raw markdown twins (the Vercel preset does, when a
-   * site URL is configured). The raw handler then skips its own copy where
-   * `hasCdnLinkPair` says the table covers the URL, or every origin-rendered
-   * response carries the pair twice.
+   * Whether the deployed CDN route table injects the canonical/alternate `Link`
+   * pair on the raw markdown twins. The raw handler skips its own copy where the
+   * table covers the URL, or the pair goes out twice.
    */
   cdnLinkPairs?: boolean
 }

--- a/src/runtime/virtual.d.ts
+++ b/src/runtime/virtual.d.ts
@@ -1,8 +1,6 @@
 /**
- * `@nuxt/content`'s collection manifest. Declared, not typed: the shape belongs
- * to that module, and the one call site casts it. Only the module's own
- * type-check sees this, since a site building against `@nuxt/content` resolves
- * the real declaration.
+ * `@nuxt/content`'s collection manifest, declared but not typed. Only the
+ * module's own type-check sees this, since a site resolves the real declaration.
  */
 declare module '#content/manifest' {
   const collections: unknown
@@ -14,10 +12,7 @@ declare module '#agent-discovery/source' {
   export default source
 }
 
-/**
- * `@nuxtjs/mcp-toolkit`'s listing API when the site runs it, `null` otherwise.
- * The module picks the alias target, so the runtime null-checks it.
- */
+/** `@nuxtjs/mcp-toolkit`'s listing API when the site runs it, `null` otherwise. */
 declare module '#agent-discovery/mcp' {
   export const listMcpDefinitions: ((options?: { event?: import('h3').H3Event }) => Promise<{
     tools: { name: string, description?: string, group?: string }[]

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -6,13 +6,8 @@ import type { ConsolaInstance } from 'consola'
 import type { SkillEntry } from './runtime/shared/types'
 
 /**
- * Agent Skills discovery.
- *
- * A skill is a directory holding a `SKILL.md` with `name` and `description`
- * frontmatter, plus any number of reference files. The catalog is scanned at
- * build time so `/.well-known/skills/index.json` is generated rather than
- * hand-maintained, which is where the three sites that ship skills today all
- * drift: a reference file gets added and the index keeps listing the old set.
+ * Agent Skills discovery. A skill is a directory holding a `SKILL.md` with
+ * `name` and `description` frontmatter, plus any number of reference files.
  *
  * Naming follows the Agent Skills spec: lowercase alphanumeric and single
  * hyphens, 64 characters at most, matching the directory name.
@@ -27,12 +22,9 @@ interface Frontmatter {
 }
 
 /**
- * The frontmatter mapping, or why it could not be read.
- *
- * The reason is carried out rather than collapsed to `null` because the
- * failures read nothing alike: an unquoted `description` holding a `: ` is a
- * YAML syntax error, and reporting that as a missing description sends you to
- * the wrong line of the wrong file.
+ * The frontmatter mapping, or why it could not be read. The reason is carried
+ * out rather than collapsed to `null` so a YAML syntax error is not reported
+ * as a missing description.
  */
 function parseFrontmatter(content: string): { data: Frontmatter } | { error: string } {
   const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/)
@@ -71,10 +63,8 @@ async function listFiles(dir: string, base = ''): Promise<string[]> {
   const files: string[] = []
   for (const entry of await readdir(dir, { withFileTypes: true })) {
     const path = base ? `${base}/${entry.name}` : entry.name
-    // A symlink reports neither directory nor regular file here, so listing it
-    // would publish whatever it points at: the catalog is the allowlist the
-    // runtime route checks against, so a link to `../../.env` would be served.
-    // Skipped rather than resolved, because a skill has no reason to hold one.
+    // The catalog is the allowlist the runtime route checks against, so listing
+    // a symlink would serve whatever it points at, `../../.env` included.
     if (entry.isSymbolicLink()) {
       continue
     }
@@ -101,9 +91,8 @@ export async function scanSkills(dir: string, logger: ConsolaInstance): Promise<
 
     const skillDir = join(dir, entry.name)
     const skillMd = join(skillDir, 'SKILL.md')
-    // `lstat`, not `existsSync`, which follows the link: `SKILL.md` is added to
-    // the catalog unconditionally below, so a symlinked one would publish
-    // whatever it points at. The reference files are filtered the same way.
+    // `lstat`, not `existsSync`, which follows the link: `SKILL.md` goes into
+    // the catalog unconditionally below.
     const stats = await lstat(skillMd).catch(() => null)
     if (!stats?.isFile()) {
       continue

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -6,8 +6,9 @@ import type { ConsolaInstance } from 'consola'
 import type { SkillEntry } from './runtime/shared/types'
 
 /**
- * Agent Skills discovery. A skill is a directory holding a `SKILL.md` with
- * `name` and `description` frontmatter, plus any number of reference files.
+ * Agent Skills discovery. A skill is a directory holding a `SKILL.md` whose
+ * frontmatter carries a `description` and, optionally, a `name` defaulting to
+ * the directory name, plus any number of reference files.
  *
  * Naming follows the Agent Skills spec: lowercase alphanumeric and single
  * hyphens, 64 characters at most, matching the directory name.


### PR DESCRIPTION
Comment lines across \`src/\` go from 2098 to 1090. What stays is the hook-ordering and third-party-quirk reasoning; history, restatements and flourishes are gone. JSDoc on exported symbols is kept but tightened to one or two lines.

A few small code cleanups landed in the same pass, all behavior-preserving:

- \`module.ts\`: the raw-loop check runs on the real \`config\` instead of a partial cast, \`staticBuild\` is computed once, the \`seen.has() && seen.add()\` filter is a plain loop merged into the rel validation, and the \`siteUrl\` parse no longer goes through \`undefined\` before throwing.
- \`negotiate.ts\`: the cached-route redirect computed the query string twice.
- \`llms.ts\`: \`LlmsSection\` is a \`type\`, which removes two \`as unknown as Record<string, unknown>\` casts.
- \`pipeline.ts\`: the related-links filter carried five inline casts, now one narrowing in a loop.
- \`content.ts\`: \`pageCollections()\` was called twice in \`list()\`.
- \`api-catalog.ts\`, \`document.ts\`, \`pages.ts\`, \`sitemap.md.ts\`: dead \`anchor === '/'\` ternaries, dead \`|| siteUrl\` fallbacks on template literals that start with \`siteUrl\`, a hostname computed twice.

Lint, typecheck and the test suite pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration, content discovery, Markdown handling, canonical links, sitemap generation, robots rules, MCP behavior, OpenAPI output, caching, and error responses.
  * Expanded guidance for integrations, adapters, presets, skills, virtual modules, and public extension points.

* **Bug Fixes**
  * Preserved original query parameters when redirecting negotiated routes.
  * Improved handling of invalid related links while retaining valid labels and destinations.
  * Standardized URL resolution for catalog and sitemap links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->