### PR TITLE
feat: locale roots as homepages, twin Link pair in the Vercel hit phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default defineNuxtConfig({
 
 `/llms.txt` and `/llms-full.txt` belong to `nuxt-llms`; this module feeds them but never registers them.
 
-With the built-in `@nuxt/content` source, the raw twin of every exact route pattern and `/sitemap.md` are prerendered, and the `nuxt-llms` bridge hands Nitro's crawler every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. Whatever the source, every prerendered page hands the crawler its own twin, so a twin is frozen exactly when its page is. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is never prerendered, so it keeps answering per request instead of being frozen at build. A hinted twin the raw route cannot answer as markdown, a section redirecting to its first document or a page with no document behind it, is skipped rather than written or reported as a failed route.
+With the built-in `@nuxt/content` source, the raw twin of every exact route pattern (the locale roots of an i18n site included) and `/sitemap.md` are prerendered, and the `nuxt-llms` bridge hands Nitro's crawler every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. Whatever the source, every prerendered page hands the crawler its own twin, so a twin is frozen exactly when its page is. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is never prerendered, so it keeps answering per request instead of being frozen at build. A hinted twin the raw route cannot answer as markdown, a section redirecting to its first document or a page with no document behind it, is skipped rather than written or reported as a failed route.
 
 ### The raw route
 
@@ -129,9 +129,9 @@ canonical_url: "https://example.com/docs/getting-started"
 ---
 ```
 
-Then the page markdown, with every same-origin link absolutized. On `/` the discovery registry follows the body as a `## Resources for Agents` block, the same block the generated landing page carries, unless the body already has that heading. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
+Then the page markdown, with every same-origin link absolutized. On `/`, and on each locale root of a site running `@nuxtjs/i18n` (`/en`, `/fr`), the discovery registry follows the body as a `## Resources for Agents` block, the same block the generated landing page carries, unless the body already has that heading. When `/sitemap.md` is served, a `## Sitemap` section is appended pointing at it.
 
-A path naming a section rather than a page redirects 302 to the section's first document when the adapter implements `firstLeaf()`. Anything else missing answers a real 404 with the markdown error body, so an agent can tell an unknown URL from an empty one. `/` is the exception: with no `/` entry in the adapter, `/raw/index.md` falls through to a generated landing page, see [`agent-discovery:index`](#extending). The recommended way to author the agent homepage is a `/` document in the content source: the module wraps it with the resources block and the sitemap footer, and the generated page is the fallback for sites that have none.
+A path naming a section rather than a page redirects 302 to the section's first document when the adapter implements `firstLeaf()`, a locale root with no landing document included. Anything else missing answers a real 404 with the markdown error body, so an agent can tell an unknown URL from an empty one. `/` is the exception: with no `/` entry in the adapter, `/raw/index.md` falls through to a generated landing page, see [`agent-discovery:index`](#extending). The recommended way to author the agent homepage is a `/` document in the content source: the module wraps it with the resources block and the sitemap footer, and the generated page is the fallback for sites that have none.
 
 ## Content sources
 
@@ -303,12 +303,15 @@ Detected automatically, never a dependency, `@nuxtjs/seo`-installed included:
 - **`@nuxtjs/robots`** takes over `robots.txt`; the shared user-agent list and `contentSignal` are contributed through its `robots:config` hook.
 - **`@nuxtjs/mcp-toolkit`** owns `/mcp`; the MCP server card reads what it exposes, so it can't advertise a tool the server dropped.
 - **`@nuxtjs/sitemap`** owns `sitemap.xml`; the raw markdown twins are dropped from it, since they are alternate representations of pages already listed.
+- **`@nuxtjs/i18n`** makes the locale roots homepages: every `/<code>` under its `prefix` and `prefix_and_default` strategies, every one but the default locale under `prefix_except_default`, where that locale lives at `/`. On such a site `/` only redirects and the landing documents sit at `/en` and `/fr`, which is where `llms.txt` sends agents. Each root is negotiated as an exact route when no pattern covers it, its twin prerendered like `/raw/index.md`, and its document wrapped with the resources block and the sitemap footer. The generated landing page and `agent-discovery:index` stay `/`'s alone.
 
 ## Deployment
 
 ### Vercel
 
-On the `vercel` preset, a Nitro `compiled` hook prepends routes to `.vercel/output/config.json` (Build Output API v3): `continue: true` header routes carrying `Vary`, the discovery `Link` on `/` and the canonical/alternate pair for the prerendered twins, then, per configured pattern, a rewrite on `Accept: text/markdown` and one on the agent User-Agent list. Prerendered pages negotiate at the edge this way, before the CDN cache sees the request, and the table stays O(patterns), never O(pages).
+On the `vercel` preset, a Nitro `compiled` hook prepends routes to `.vercel/output/config.json` (Build Output API v3): `continue: true` header routes carrying `Vary` and the discovery `Link` on `/`, then, per configured pattern, a rewrite on `Accept: text/markdown` and one on the agent User-Agent list. Prerendered pages negotiate at the edge this way, before the CDN cache sees the request, and the table stays O(patterns), never O(pages).
+
+The canonical/alternate `Link` pair of the prerendered twins goes at the end of the table, in a `hit` phase, which only runs once a static file has been matched. A twin the function renders gets the pair from the raw handler instead, and a twin that does not exist answers its 404 without advertising a canonical for a page that does not exist.
 
 Full q-value precedence is not expressible in a matcher (Vercel runs RE2), so only the outright refusal `text/markdown;q=0` is covered at the edge. The known divergence: the matcher reads `Accept` by substring, so a prerendered page asked for with a low-q `text/markdown` next to a preferred `text/html` is rewritten to markdown, where the origin ranks per RFC 9110 and serves the HTML.
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Detected automatically, never a dependency, `@nuxtjs/seo`-installed included:
 - **`@nuxtjs/robots`** takes over `robots.txt`; the shared user-agent list and `contentSignal` are contributed through its `robots:config` hook.
 - **`@nuxtjs/mcp-toolkit`** owns `/mcp`; the MCP server card reads what it exposes, so it can't advertise a tool the server dropped.
 - **`@nuxtjs/sitemap`** owns `sitemap.xml`; the raw markdown twins are dropped from it, since they are alternate representations of pages already listed.
-- **`@nuxtjs/i18n`** makes the locale roots homepages: every `/<code>` under its `prefix` and `prefix_and_default` strategies, every one but the default locale under `prefix_except_default`, where that locale lives at `/`. On such a site `/` only redirects and the landing documents sit at `/en` and `/fr`, which is where `llms.txt` sends agents. Each root is negotiated as an exact route when no pattern covers it, its twin prerendered like `/raw/index.md`, and its document wrapped with the resources block and the sitemap footer. The generated landing page and `agent-discovery:index` stay `/`'s alone.
+- **`@nuxtjs/i18n`** makes the locale roots homepages: every `/<code>` under its `prefix` and `prefix_and_default` strategies, every one but the default locale under `prefix_except_default`, where that locale lives at `/`. On such a site `/` only redirects and the landing documents sit at `/en` and `/fr`, which is where `llms.txt` sends agents. Each root is negotiated as an exact route when no pattern covers it, its twin prerendered like `/raw/index.md` either way, and its document wrapped with the resources block and the sitemap footer. The generated landing page and `agent-discovery:index` stay `/`'s alone.
 
 ## Deployment
 

--- a/skills/migrate-to-nuxt-agent-discovery/SKILL.md
+++ b/skills/migrate-to-nuxt-agent-discovery/SKILL.md
@@ -40,7 +40,7 @@ Record:
 - **Content backend**: `@nuxt/content`, comark, or something else. Decides the `source` option.
 - **Deploy target**: Vercel gets edge negotiation, everything else gets the middleware only, where a prerendered page keeps serving HTML to agents.
 - **Route rules carrying `isr`, `swr` or `cache`**, and which page patterns they cover. The module detects these and switches those patterns to a 307, but you need to know which pages change behaviour.
-- **i18n locales**, which become a wildcard segment in a `routes` pattern rather than one pattern per locale.
+- **i18n locales**, which become a wildcard segment in a `routes` pattern rather than one pattern per locale. With `@nuxtjs/i18n` installed the module detects the locale roots (`/en`, `/fr`) itself and wraps their twins as homepages, so they need no entry either.
 - **Companion modules**: `@nuxtjs/robots` and `@nuxtjs/sitemap` take over `robots.txt` and `sitemap.xml`, and the module hands off to them automatically.
 - **Every existing agent-facing file**: negotiation utils, an `md-rewrite` module, a raw route, `.well-known` routes, `sitemap.md`, a static `public/robots.txt`, `vercel.json` rewrites, an error handler chained in `nitro:config`, a `useCanonical` composable, skills served from `publicAssets`, and any `index.md` handler.
 - **Standalone `.md` documents the site serves itself** (`/design.md` and friends). These need `excludePrefixes.extend` or the rewrites will send them to a raw twin that does not exist.
@@ -124,7 +124,7 @@ export default defineNitroPlugin((nitroApp) => {
 
 Three helpers replace hand-written equivalents:
 
-- `renderAgentResources(event)` renders the discovery registry as a markdown block, for a page the site renders by hand. The module appends it to the `/` document itself and leaves a body that already carries the heading alone, so a `/` document has no reason to render it.
+- `renderAgentResources(event)` renders the discovery registry as a markdown block, for a page the site renders by hand. The module appends it to the `/` document and to each locale landing document itself, and leaves a body that already carries the heading alone, so those documents have no reason to render it.
 - `agentDiscoveryOpenApi(event)` returns the discovery layer as OpenAPI fragments. Spread the site's own paths last so they win.
 - `rawUrl(event, href)` resolves a page URL to its markdown twin from the same route config, for links the site builds itself inside `llms:generate` hooks.
 
@@ -164,7 +164,7 @@ Two wrinkles. A tool that deliberately serves excluded content, say a nightly do
 
 Two that are easy to miss: the `Vary`/`Link` `routeRules` block, which now conflicts with what the module emits, and the `nitro:config` hook chaining the error handler, which the module does itself.
 
-Keep a hand-written `/raw/index.md` handler only when the site wants full control of that document. Otherwise prefer a `/` document in the content source, which the module wraps with the resources block and the sitemap footer, and keep the `agent-discovery:index` hook for metadata when no `/` document exists.
+Keep a hand-written `/raw/index.md` handler only when the site wants full control of that document. Otherwise prefer a `/` document in the content source, which the module wraps with the resources block and the sitemap footer, and keep the `agent-discovery:index` hook for metadata when no `/` document exists. On an i18n site the landing documents live at the locale roots, and the module wraps `content/en/index.md` and its siblings the same way; the hook only ever fills the generated `/`.
 
 ## Adopting `@nuxtjs/sitemap` in the same PR
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -654,9 +654,9 @@ export {}
       // On an i18n site `/` only redirects and the landing documents live at the
       // locale roots, which is where `llms.txt` sends agents, so those count as
       // homepages too: negotiated as an exact route where no pattern covers
-      // them already, their twin wrapped with the resources block like
-      // `/raw/index.md`. Detected here like the other companions, so a site
-      // pulling `@nuxtjs/i18n` in through a layer is covered.
+      // them already, their twin prerendered and wrapped with the resources
+      // block like `/raw/index.md` either way. Detected here like the other
+      // companions, so a site pulling `@nuxtjs/i18n` in through a layer is covered.
       const homepages = i18nHomepages(nuxt)
       for (const homepage of homepages) {
         if (!matchRoute(routes, homepage)) {
@@ -864,6 +864,19 @@ export {}
               if (!detectedRoutes.has(route.path)) {
                 queuedRawRoutes.add(raw)
               }
+            }
+          }
+        }
+        // A locale root a pattern covers has no exact entry of its own, and its
+        // twin is a homepage all the same: queued like `/raw/index.md` rather
+        // than left to whether the site prerenders the landing page, and never
+        // a build error, since the site named neither.
+        for (const homepage of config.homepages || []) {
+          const route = detectedRoutes.has(homepage) ? undefined : matchRoute(routes, homepage)
+          if (route) {
+            const raw = rawDestination(config, route, homepage)
+            if (!siteServesRaw(config, raw)) {
+              addPrerenderRoutes(raw)
             }
           }
         }

--- a/src/module.ts
+++ b/src/module.ts
@@ -162,6 +162,36 @@ function hasActiveNuxtModule(nuxt: Nuxt, name: string, configKey: string): boole
   return moduleOptions !== false && moduleOptions?.enabled !== false
 }
 
+/** What this module reads off `nuxt.options.i18n`, a subset of the `@nuxtjs/i18n` options. */
+interface I18nOptions {
+  locales?: (string | { code?: string })[]
+  defaultLocale?: string
+  strategy?: 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
+  differentDomains?: boolean
+}
+
+/**
+ * The locale roots `@nuxtjs/i18n` serves as landing pages, read the way its
+ * router does: every locale under `prefix` and `prefix_and_default`, every
+ * locale but the default under `prefix_except_default` (its default, where the
+ * default locale lives at `/`), none under `no_prefix` or across different
+ * domains, where each locale has a root of its own.
+ */
+function i18nHomepages(nuxt: Nuxt): string[] {
+  if (!hasActiveNuxtModule(nuxt, '@nuxtjs/i18n', 'i18n')) {
+    return []
+  }
+  const i18n = (nuxt.options as { i18n?: I18nOptions }).i18n
+  const strategy = i18n?.strategy || 'prefix_except_default'
+  if (!i18n?.locales?.length || strategy === 'no_prefix' || i18n.differentDomains) {
+    return []
+  }
+  const codes = new Set(i18n.locales.map(locale => typeof locale === 'string' ? locale : locale.code))
+  return [...codes]
+    .filter((code): code is string => Boolean(code) && (strategy !== 'prefix_except_default' || code !== i18n.defaultLocale))
+    .map(code => `/${code}`)
+}
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-agent-discovery',
@@ -213,6 +243,9 @@ export default defineNuxtModule<ModuleOptions>({
     const routes: AgentRoute[] = (options.routes?.length ? options.routes : ['/', '/**'])
       .map(route => typeof route === 'string' ? { path: route } : route)
       .map(route => ({ ...route, path: withLeadingSlash(route.path) }))
+    // Exact routes this module appends at `modules:done` rather than the site
+    // naming them, so a twin of theirs that 404s is skipped, not a build error.
+    const detectedRoutes = new Set<string>()
     for (const [name, option] of [['userAgents', options.userAgents], ['excludePrefixes', options.excludePrefixes]] as const) {
       if (option?.replace && option.extend?.length) {
         logger.warn(`\`${name}\` has both \`replace\` and \`extend\`; \`replace\` wins and the extended entries are dropped.`)
@@ -616,6 +649,25 @@ export {}
         addServerPlugin(resolve('./runtime/server/plugins/llms'))
       }
 
+      /* ------------------------------ homepages ----------------------------- */
+
+      // On an i18n site `/` only redirects and the landing documents live at the
+      // locale roots, which is where `llms.txt` sends agents, so those count as
+      // homepages too: negotiated as an exact route where no pattern covers
+      // them already, their twin wrapped with the resources block like
+      // `/raw/index.md`. Detected here like the other companions, so a site
+      // pulling `@nuxtjs/i18n` in through a layer is covered.
+      const homepages = i18nHomepages(nuxt)
+      for (const homepage of homepages) {
+        if (!matchRoute(routes, homepage)) {
+          routes.push({ path: homepage })
+          detectedRoutes.add(homepage)
+        }
+      }
+      if (homepages.length) {
+        config.homepages = homepages
+      }
+
       /* ------------------------------ registry ----------------------------- */
 
       // Advertised only when something serves it: this module does not
@@ -807,7 +859,11 @@ export {}
             const raw = rawDestination(config, route, route.path)
             if (!siteServesRaw(config, raw)) {
               addPrerenderRoutes(raw)
-              queuedRawRoutes.add(raw)
+              // A detected locale root may have no landing document, and its
+              // twin then answers a 404 the site never asked to be written.
+              if (!detectedRoutes.has(route.path)) {
+                queuedRawRoutes.add(raw)
+              }
             }
           }
         }

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -20,6 +20,11 @@ export interface VercelRoute {
   continue?: boolean
 }
 
+/** Opens a routing phase: every route after it in the table runs in that phase only. */
+export interface VercelHandle {
+  handle: 'filesystem' | 'resource' | 'miss' | 'rewrite' | 'hit' | 'error'
+}
+
 /** The negotiation middleware only answers GET/HEAD, so every emitted route carries the same restriction. */
 const METHODS = ['GET', 'HEAD']
 
@@ -111,7 +116,9 @@ function negotiatedRoute(src: string, dest: string, has: RouteMatcher[], cached:
  *
  * The two `Vary` routes come first and carry `continue: true`: Nitro emits its
  * own `routeRules` header routes after these and without `continue`, so they
- * never run for a request that gets rewritten to a prerendered file.
+ * never run for a request that gets rewritten to a prerendered file. The
+ * canonical pair on the twins is the one header kept out of here, see
+ * `vercelTwinLinkRoutes`.
  */
 export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   // Anchored at a media-range boundary: a bare substring also matches inside a
@@ -169,62 +176,6 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     methods: METHODS,
     continue: true
   })
-
-  // The canonical/alternate pair the raw handler sets, for prerendered twins the
-  // CDN answers off the filesystem. The value embeds the page URL, so it needs a
-  // configured site URL: the edge cannot know the request host at build time.
-  // Absent from the page rewrites, whose URLs also serve HTML.
-  if (config.siteUrl) {
-    const canonicalLink = (href: string) => formatLinkHeader([
-      { href, rel: 'canonical' },
-      { href, rel: 'alternate', type: 'text/html' }
-    ])
-    // Twins with a static entry of their own: exact patterns whose raw
-    // destination sits under `rawPrefix`, plus the root twin, whose wildcard
-    // capture would otherwise mis-derive the page as `/index`.
-    const isRaw = (raw: string) => isRawPath(config, raw)
-    const rootTwin = `${config.rawPrefix}/index.md`
-    const statics: { raw: string, href: string }[] = []
-    for (const route of config.routes) {
-      if (route.path.includes('*')) {
-        continue
-      }
-      const raw = rawDestination(config, route, route.path)
-      // Two exact routes can name the same twin, `/` and `/index` both mapping to
-      // the root one: one entry per `src`, or two conflicting headers.
-      if (!isRaw(raw) || statics.some(entry => entry.raw === raw)) {
-        continue
-      }
-      // The origin folds a trailing `/index` into the directory it indexes, so
-      // `/docs/index`'s twin advertises `/docs`, the URL that answers.
-      const page = route.path.endsWith('/index') ? route.path.slice(0, -6) || '/' : route.path
-      statics.push({ raw, href: page === '/' || raw === rootTwin ? config.siteUrl : `${config.siteUrl}${encodeAgentRoute(page)}` })
-    }
-    if (!statics.some(entry => entry.raw === rootTwin)) {
-      // `/raw/index.md` folds to `/` at the origin whatever the patterns say, so
-      // the wildcard capture must never read it as `/index`.
-      statics.push({ raw: rootTwin, href: config.siteUrl })
-    }
-    // The wildcard capture must not also match a statically-mapped twin.
-    const rawExclusion = statics.length ? `(?!(?:${statics.map(entry => escapeEncoded(entry.raw.slice(config.rawPrefix.length))).join('|')})$)` : ''
-    // A trailing `/index` folds away at the origin, so a capture reading
-    // `/docs/index.md` would advertise a page URL the handler never serves.
-    const noIndex = String.raw`(?!.*/index\.md$)`
-    for (const route of config.routes) {
-      if (route.path.includes('*')) {
-        const body = compilePattern(encodeAgentRoute(route.path)).source.slice(1, -1)
-        const link = canonicalLink(`${config.siteUrl}${patternDest(encodeAgentRoute(route.path))}`)
-        routes.push({ src: `^${excluded}${noIndex}${body}\\.md$`, headers: { Link: link }, methods: METHODS, continue: true })
-        routes.push({ src: `^${escapeEncoded(config.rawPrefix)}${rawExclusion}${noIndex}${body}\\.md$`, headers: { Link: link }, methods: METHODS, continue: true })
-      } else if (route.path !== '/' && !route.path.endsWith('/index') && isRaw(rawDestination(config, route, route.path))) {
-        // An index-shaped exact path folds the same way, so its twin gets no entry.
-        routes.push({ src: `^${escapeEncoded(route.path)}\\.md$`, headers: { Link: canonicalLink(`${config.siteUrl}${encodeAgentRoute(route.path)}`) }, methods: METHODS, continue: true })
-      }
-    }
-    for (const entry of statics) {
-      routes.push({ src: `^${escapeEncoded(entry.raw)}$`, headers: { Link: canonicalLink(entry.href) }, methods: METHODS, continue: true })
-    }
-  }
 
   // Opt-in: a negotiated page has exactly two representations, so an `Accept`
   // allowing neither is a 406 per RFC 9110. Emitted here as well as in the
@@ -317,6 +268,75 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
 }
 
 /**
+ * The canonical/alternate `Link` pair the raw handler sets, for the prerendered
+ * twins the CDN answers off the filesystem. Emitted in the `hit` phase of the
+ * Build Output table, which only runs once a static file has been matched, so
+ * the pair never lands on a function answer: the handler keeps setting it on the
+ * twins it renders, and a missing twin's 404 advertises no page. The value
+ * embeds the page URL, so it needs a configured site URL: the edge cannot know
+ * the request host at build time. Both twin URL spaces stay listed: the phase
+ * matches whichever path the `.md` alias rewrite left the request at.
+ */
+export function vercelTwinLinkRoutes(config: NegotiationConfig): VercelRoute[] {
+  const routes: VercelRoute[] = []
+  if (!config.siteUrl) {
+    return routes
+  }
+  const excluded = excludeLookahead(config)
+  const canonicalLink = (href: string) => formatLinkHeader([
+    { href, rel: 'canonical' },
+    { href, rel: 'alternate', type: 'text/html' }
+  ])
+  // Twins with a static entry of their own: exact patterns whose raw
+  // destination sits under `rawPrefix`, plus the root twin, whose wildcard
+  // capture would otherwise mis-derive the page as `/index`.
+  const isRaw = (raw: string) => isRawPath(config, raw)
+  const rootTwin = `${config.rawPrefix}/index.md`
+  const statics: { raw: string, href: string }[] = []
+  for (const route of config.routes) {
+    if (route.path.includes('*')) {
+      continue
+    }
+    const raw = rawDestination(config, route, route.path)
+    // Two exact routes can name the same twin, `/` and `/index` both mapping to
+    // the root one: one entry per `src`, or two conflicting headers.
+    if (!isRaw(raw) || statics.some(entry => entry.raw === raw)) {
+      continue
+    }
+    // The origin folds a trailing `/index` into the directory it indexes, so
+    // `/docs/index`'s twin advertises `/docs`, the URL that answers.
+    const page = route.path.endsWith('/index') ? route.path.slice(0, -6) || '/' : route.path
+    statics.push({ raw, href: page === '/' || raw === rootTwin ? config.siteUrl : `${config.siteUrl}${encodeAgentRoute(page)}` })
+  }
+  if (!statics.some(entry => entry.raw === rootTwin)) {
+    // `/raw/index.md` folds to `/` at the origin whatever the patterns say, so
+    // the wildcard capture must never read it as `/index`.
+    statics.push({ raw: rootTwin, href: config.siteUrl })
+  }
+  // The wildcard capture must not also match a statically-mapped twin.
+  const rawExclusion = statics.length ? `(?!(?:${statics.map(entry => escapeEncoded(entry.raw.slice(config.rawPrefix.length))).join('|')})$)` : ''
+  // A trailing `/index` folds away at the origin, so a capture reading
+  // `/docs/index.md` would advertise a page URL the handler never serves.
+  const noIndex = String.raw`(?!.*/index\.md$)`
+  for (const route of config.routes) {
+    if (route.path.includes('*')) {
+      const body = compilePattern(encodeAgentRoute(route.path)).source.slice(1, -1)
+      const link = canonicalLink(`${config.siteUrl}${patternDest(encodeAgentRoute(route.path))}`)
+      routes.push({ src: `^${excluded}${noIndex}${body}\\.md$`, headers: { Link: link }, methods: METHODS, continue: true })
+      routes.push({ src: `^${escapeEncoded(config.rawPrefix)}${rawExclusion}${noIndex}${body}\\.md$`, headers: { Link: link }, methods: METHODS, continue: true })
+    } else if (route.path !== '/' && !route.path.endsWith('/index') && isRaw(rawDestination(config, route, route.path))) {
+      // An index-shaped exact path folds the same way, so its twin gets no entry.
+      routes.push({ src: `^${escapeEncoded(route.path)}\\.md$`, headers: { Link: canonicalLink(`${config.siteUrl}${encodeAgentRoute(route.path)}`) }, methods: METHODS, continue: true })
+    }
+  }
+  for (const entry of statics) {
+    routes.push({ src: `^${escapeEncoded(entry.raw)}$`, headers: { Link: canonicalLink(entry.href) }, methods: METHODS, continue: true })
+  }
+
+  return routes
+}
+
+/**
  * Patches the Vercel Build Output config after Nitro compiles. We edit
  * `.vercel/output/config.json` (Build Output API v3), not `vercel.json`, which
  * has a different schema. https://vercel.com/docs/build-output-api/configuration
@@ -327,23 +347,26 @@ export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig, colle
   if (nitro.options.dev || nitro.options.static || !nitro.options.preset.includes('vercel')) {
     return
   }
-  // The emitted table injects the `Link` pair on the raw twins, so the raw
-  // handler has to skip its own copy or every origin-rendered raw response
-  // carries it twice. Set on Nitro's copy: the module-scope one was cloned away.
-  if (config.siteUrl) {
-    const runtime = nitro.options.runtimeConfig.agentDiscovery as NegotiationConfig | undefined
-    if (runtime) {
-      runtime.cdnLinkPairs = true
-    }
-  }
   nitro.hooks.hook('compiled', async () => {
     // The last read of the rule table before it decides rewrite or 307: an
     // inline `defineRouteRules({ isr })` only lands on it during the Nuxt build,
     // after every module hook has run.
     collectCachedRoutes?.(nitro.options.routeRules)
     const vcJSON = resolve(nitro.options.output.dir, 'config.json')
-    const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8'))
+    const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8')) as { routes: (VercelRoute | VercelHandle)[] }
     vcConfig.routes.unshift(...vercelMarkdownRoutes(config))
+    // Nitro emits no `hit` phase of its own, so the pair opens one at the end of
+    // the table. A phase is a position in the array, so one already there takes
+    // the routes instead of a second marker.
+    const twinLinks = vercelTwinLinkRoutes(config)
+    if (twinLinks.length) {
+      const hit = vcConfig.routes.findIndex(route => 'handle' in route && route.handle === 'hit')
+      if (hit === -1) {
+        vcConfig.routes.push({ handle: 'hit' }, ...twinLinks)
+      } else {
+        vcConfig.routes.splice(hit + 1, 0, ...twinLinks)
+      }
+    }
     await writeFile(vcJSON, JSON.stringify(vcConfig, null, 2), 'utf8')
   })
 }

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -7,7 +7,7 @@ import source from '#agent-discovery/source'
 import type { AgentListEntry, NegotiationConfig } from '../../shared/types'
 import { getAgentSiteUrl, useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { appendAgentResources, generatedIndexPage, getSourcePage } from '../utils/document'
-import { hasFileExtension, isExcluded, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination, siteServesRaw } from '../../shared/negotiation'
+import { hasFileExtension, isExcluded, isHomepage, matchRoute, normalizeAgentRoute, normalizePathname, rawDestination, siteServesRaw } from '../../shared/negotiation'
 
 type LlmsSection = {
   title: string
@@ -251,15 +251,14 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
     }
 
     // The same `get()` the raw route calls, so a page reads identically whether an
-    // agent fetches `/raw/**.md` or the full document. `/` alone has a fallback.
+    // agent fetches `/raw/**.md` or the full document. The homepages carry the
+    // resources block like their twins do, and `/` alone has a fallback.
     const pages = await mapLimit(routes, async (route) => {
       const page = await getSourcePage(route, event)
-      if (route !== '/') {
-        return page
+      if (page) {
+        return isHomepage(config, route) ? { ...page, markdown: appendAgentResources(event, page.markdown) } : page
       }
-      return page
-        ? { ...page, markdown: appendAgentResources(event, page.markdown) }
-        : await generatedIndexPage(event)
+      return route === '/' ? await generatedIndexPage(event) : null
     })
     for (const page of pages) {
       if (page?.markdown) {

--- a/src/runtime/server/routes/raw.ts
+++ b/src/runtime/server/routes/raw.ts
@@ -2,7 +2,7 @@ import { createError, defineEventHandler, sendRedirect, setResponseHeader } from
 import source from '#agent-discovery/source'
 import { useAgentDiscoveryConfig } from '../utils/agent-discovery'
 import { getAgentDocument } from '../utils/document'
-import { encodeAgentRoute, formatLinkHeader, hasCdnLinkPair, normalizePathname, MARKDOWN_VARY } from '../../shared/negotiation'
+import { encodeAgentRoute, formatLinkHeader, normalizePathname, MARKDOWN_VARY } from '../../shared/negotiation'
 
 /**
  * Serves the raw markdown representation of a page. `getAgentDocument()` builds
@@ -43,15 +43,12 @@ export default defineEventHandler(async (event) => {
 
   setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
 
-  // On Vercel the CDN header table already injects this pair on the twins it
-  // covers, origin-rendered responses included, so setting it here would ship
-  // it twice. Everywhere else this handler is the only source.
-  if (!(config.cdnLinkPairs && hasCdnLinkPair(config, pathname))) {
-    setResponseHeader(event, 'Link', formatLinkHeader([
-      { href: document.canonicalUrl, rel: 'canonical' },
-      { href: document.canonicalUrl, rel: 'alternate', type: 'text/html' }
-    ]))
-  }
+  // The Vercel table stamps the same pair on prerendered twins, in its `hit`
+  // phase, so a response this handler renders never carries it twice.
+  setResponseHeader(event, 'Link', formatLinkHeader([
+    { href: document.canonicalUrl, rel: 'canonical' },
+    { href: document.canonicalUrl, rel: 'alternate', type: 'text/html' }
+  ]))
 
   return document.markdown
 })

--- a/src/runtime/server/utils/document.ts
+++ b/src/runtime/server/utils/document.ts
@@ -4,7 +4,7 @@ import source from '#agent-discovery/source'
 import { getAgentSiteUrl, renderAgentResources, useAgentDiscoveryConfig } from './agent-discovery'
 import { AGENT_RESOURCES_HEADING } from '../../shared/defaults'
 import { extractSections } from '../../shared/sections'
-import { absolutizeMarkdownLinks, encodeAgentRoute, isExcluded, normalizeAgentRoute } from '../../shared/negotiation'
+import { absolutizeMarkdownLinks, encodeAgentRoute, isExcluded, isHomepage, normalizeAgentRoute } from '../../shared/negotiation'
 import type { AgentIndex, AgentPage } from '../../shared/types'
 
 /** A resolved markdown document, or where to go instead. */
@@ -80,10 +80,11 @@ export async function generatedIndexPage(event: H3Event): Promise<AgentPage> {
 }
 
 /**
- * The `/` body with the discovery resources appended, shared by `getAgentDocument`
- * and the `llms-full.txt` builder so the homepage reads identically wherever it is
- * served. An empty body stays empty, and a body already carrying the heading is
- * left alone: a homepage rendering the registry by hand is not listed twice.
+ * A homepage body with the discovery resources appended, shared by
+ * `getAgentDocument` and the `llms-full.txt` builder so `/` and the locale roots
+ * read identically wherever they are served. An empty body stays empty, and a
+ * body already carrying the heading is left alone: a homepage rendering the
+ * registry by hand is not listed twice.
  */
 export function appendAgentResources(event: H3Event, markdown: string): string {
   if (!markdown.trim() || hasAgentResourcesHeading(markdown)) {
@@ -185,7 +186,8 @@ export async function getAgentDocument(event: H3Event, route: string, options: A
     ? `\n\n## Sitemap\n\nSee the full [sitemap](${siteUrl}/sitemap.md) for all pages.\n`
     : '\n'
 
-  const body = path === '/' ? appendAgentResources(event, page!.markdown) : page!.markdown
+  // A homepage mirrors the generated index: body, the discovery resources, footer.
+  const body = isHomepage(config, path) ? appendAgentResources(event, page!.markdown) : page!.markdown
   const markdown = frontmatter + body + sitemap
 
   return {

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -595,44 +595,12 @@ export function absolutizeTreeLinks(nodes: unknown[], siteUrl: string): void {
 }
 
 /**
- * Whether the Vercel route table already carries the canonical/alternate
- * `Link` pair for a raw URL, mirroring the `config.siteUrl` block of
- * `vercelMarkdownRoutes`. The raw handler skips its own copy exactly there, or
- * every origin-rendered raw response carries the pair twice. `/index.md` is
- * out because the preset's `noIndex` lookahead keeps it out of the table.
+ * Whether a normalized route is wrapped as the agent homepage: `/`, or one of
+ * the locale roots `homepages` carries on an i18n site. The resources block
+ * lands on these and nowhere else.
  */
-export function hasCdnLinkPair(config: NegotiationConfig, rawPathname: string): boolean {
-  if (!rawPathname.endsWith('.md')) {
-    return false
-  }
-  // The table matches the encoded request path while the config spells routes
-  // decoded.
-  let pathname = rawPathname
-  try {
-    pathname = decodeURIComponent(pathname)
-  } catch {
-    // Malformed escape: leave it as it came.
-  }
-
-  const rootTwin = `${config.rawPrefix}/index.md`
-  for (const route of config.routes) {
-    if (route.path.includes('*')) {
-      continue
-    }
-    const raw = rawDestination(config, route, route.path)
-    if (raw === pathname && isRawPath(config, raw)) {
-      return true
-    }
-  }
-  if (pathname === rootTwin) {
-    return true
-  }
-
-  if (!isRawPath(config, pathname) || pathname.endsWith('/index.md')) {
-    return false
-  }
-  const page = pathname.slice(config.rawPrefix.length, -3)
-  return config.routes.some(route => route.path.includes('*') && patternRegExp(route.path).test(page))
+export function isHomepage(config: Pick<NegotiationConfig, 'homepages'>, route: string): boolean {
+  return route === '/' || (config.homepages?.includes(route) ?? false)
 }
 
 /* ------------------------------- Link header ------------------------------ */

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -160,9 +160,10 @@ export interface NegotiationConfig {
    */
   ownRawRoutes?: string[]
   /**
-   * Whether the deployed CDN route table injects the canonical/alternate `Link`
-   * pair on the raw markdown twins. The raw handler skips its own copy where the
-   * table covers the URL, or the pair goes out twice.
+   * Routes wrapped as the agent homepage besides `/`: the locale roots (`/en`,
+   * `/fr`) of a site running `@nuxtjs/i18n`, where `/` only redirects and the
+   * landing document lives under the locale. Their twins carry the resources
+   * block the way `/raw/index.md` does. The generated index stays `/`'s alone.
    */
-  cdnLinkPairs?: boolean
+  homepages?: string[]
 }

--- a/test/e2e/i18n.test.ts
+++ b/test/e2e/i18n.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { fetch, setup, useTestContext } from '@nuxt/test-utils/e2e'
-import { vercelMarkdownRoutes } from '../../src/presets/vercel'
+import { vercelMarkdownRoutes, vercelTwinLinkRoutes } from '../../src/presets/vercel'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
 import { CLAUDE_BOT, MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY } from './expected'
 
@@ -112,10 +112,13 @@ describe('O(1) route table', () => {
   it('keeps the locale a wildcard instead of enumerating the locales', async () => {
     const config = await resolved()
 
-    expect(config.routes.map(route => route.path)).toEqual(['/', '/*/docs/**'])
+    // The two locale roots are the homepages, appended by the module as one
+    // exact entry each since no pattern covers them, see `locale homepages`.
+    expect(config.routes.map(route => route.path)).toEqual(['/', '/*/docs/**', '/en', '/fr'])
+    expect(config.homepages).toEqual(['/en', '/fr'])
     // The twin file the site serves itself, as the pattern Nitro registers.
     expect(config.ownRawRoutes).toContain('/raw/en/docs/live.md')
-    // The fixture ships `en` and `fr`; neither may appear as a pattern.
+    // The fixture ships `en` and `fr`; no page under either may appear as a pattern.
     expect(config.routes.some(route => /\/(?:en|fr)\//.test(route.path))).toBe(false)
   })
 
@@ -126,11 +129,15 @@ describe('O(1) route table', () => {
     const glob = config.routes.filter(route => route.path.includes('*')).length
 
     // 3 header routes (`Vary` on the pages, `Vary` on the markdown twins,
-    // `Link`) + 3 per exact path (the negotiated pair and the canonical
-    // `Link` on its raw twin) + 5 per glob (three rewrites and the canonical
-    // `Link` pair on both twin spaces), and nothing that scales with the 5
-    // content files or the 2 locales.
-    expect(routes).toHaveLength(3 + exact * 3 + glob * 5)
+    // `Link`) + 2 per exact path (the negotiated pair) + 1 per exact path but
+    // the root (its `.md` alias) + 3 per glob (three rewrites), and nothing
+    // that scales with the 8 content files. The locale roots are exact paths
+    // here, one entry each, not one per page under them.
+    expect(routes).toHaveLength(3 + exact * 2 + (exact - 1) + glob * 3)
+    // The canonical `Link` pair on the twins, in the `hit` phase: one static
+    // entry per exact twin, the `.md` alias of each exact path but the root,
+    // and both twin spaces of a glob.
+    expect(vercelTwinLinkRoutes(config)).toHaveLength(exact + (exact - 1) + glob * 2)
   })
 
   it('captures the locale segment rather than enumerating locales', async () => {
@@ -148,12 +155,21 @@ describe('O(1) route table', () => {
     expect(routes.filter(route => route.dest === '/raw/index.md')).toHaveLength(2)
   })
 
-  it('never names a locale or a page', async () => {
-    const serialized = JSON.stringify(vercelMarkdownRoutes(await resolved()))
+  it('never names a page, and a locale only as its root', async () => {
+    const config = await resolved()
+    const routes = [...vercelMarkdownRoutes(config), ...vercelTwinLinkRoutes(config)]
+    const serialized = JSON.stringify(routes)
 
-    for (const fragment of ['/en', '/fr', 'getting-started', 'button', 'about']) {
+    for (const fragment of ['getting-started', 'button', 'about']) {
       expect(serialized).not.toContain(fragment)
     }
+    // A locale followed by a path segment would be a page under it. The
+    // compiled root patterns end in `/en/?`, which is the root itself.
+    expect(serialized).not.toMatch(/\/(?:en|fr)\/[^?]/)
+    // The locale roots are exact routes: their `.md` alias and their static
+    // twin entry, and nothing under them.
+    expect(routes.filter(route => route.src === '^/en\\.md$')).toHaveLength(2)
+    expect(routes.filter(route => route.src === '^/raw/en\\.md$')).toHaveLength(1)
   })
 
   it('stays smaller than a per-page table for the pages the fixture serves', async () => {
@@ -161,7 +177,7 @@ describe('O(1) route table', () => {
     const pages = sitemap.split('\n').filter(line => line.startsWith('- [')).length
     const routes = vercelMarkdownRoutes(await resolved())
 
-    expect(pages).toBeGreaterThanOrEqual(5)
+    expect(pages).toBeGreaterThanOrEqual(7)
     // A per-link table (two routes per page) would already be larger here and
     // would keep growing; this one does not move with the page count.
     expect(routes.length).toBeLessThan(pages * 2)
@@ -212,6 +228,15 @@ describe('prerender', () => {
     expect(built('/raw/fr/docs/getting-started.md')).toBe(false)
   })
 
+  it('prerenders the twin of each locale root like the root one', () => {
+    // Appended as exact routes, so their twins are queued like `/raw/index.md`
+    // whether or not the site prerenders the landing page itself: the French
+    // one is not, and its twin is written all the same.
+    expect(built('/raw/index.md')).toBe(true)
+    expect(built('/raw/en.md')).toBe(true)
+    expect(built('/raw/fr.md')).toBe(true)
+  })
+
   it('drops the twin of a section instead of storing its redirect as HTML', async () => {
     // `/en/docs/components` is a Vue page over a directory with no index
     // document, so its twin answers a 302 to the first document. Nitro reads
@@ -245,5 +270,83 @@ describe('prerender', () => {
     // Answered by the handler, not off a file: Nitro's asset layer would add
     // an `ETag`.
     expect(response.headers.get('etag')).toBe(null)
+  })
+})
+
+/**
+ * On this shape of site `/` only redirects browsers to a locale, `llms.txt`
+ * lists the locale roots, and `sitemap.md` puts them first: `/en` is the page
+ * agents actually land on. So the landing documents get the resources block
+ * `/raw/index.md` carries, through the same `appendAgentResources()`.
+ */
+describe('locale homepages', () => {
+  const BLOCK = `## Resources for Agents
+
+- [API catalog: every service document this site publishes](${SITE_URL}/.well-known/api-catalog)
+- [Sitemap (Markdown): every page on the site](${SITE_URL}/sitemap.md)
+- [llms.txt: index of the documentation for LLMs](${SITE_URL}/llms.txt)
+- [llms-full.txt: the full documentation as a single file](${SITE_URL}/llms-full.txt)
+`
+  const FOOTER = `\n\n## Sitemap\n\nSee the full [sitemap](${SITE_URL}/sitemap.md) for all pages.\n`
+
+  it('ends each locale root with the resources block and the sitemap footer', async () => {
+    for (const [locale, title] of [['en', 'Welcome'], ['fr', 'Bienvenue']]) {
+      const response = await fetch(`/raw/${locale}.md`)
+      expect(response.status).toBe(200)
+      expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
+
+      const body = await response.text()
+      expect(body).toContain(`canonical_url: "${SITE_URL}/${locale}"`)
+      expect(body).toContain(`# ${title}`)
+      expect(body.endsWith(BLOCK + FOOTER), body).toBe(true)
+      expect(body.match(/Resources for Agents/g)).toHaveLength(1)
+    }
+  })
+
+  it('negotiates the locale root itself, an exact route the module appended', async () => {
+    const response = await fetch('/en', { headers: { Accept: 'text/markdown' } })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(MARKDOWN_CONTENT_TYPE)
+    expect(await response.text()).toBe(await (await fetch('/raw/en.md')).text())
+  })
+
+  it('returns the same bytes from `getAgentDocument()`', async () => {
+    expect(await (await fetch('/agent-document.md?route=/en')).text()).toBe(await (await fetch('/raw/en.md')).text())
+  })
+
+  it('carries the same document into `llms-full.txt`, block included', async () => {
+    const document = await (await fetch('/agent-document.md?route=/en')).text()
+    const full = await (await fetch('/llms-full.txt')).text()
+
+    // Minus the envelope: the frontmatter and the sitemap footer belong to the
+    // raw route, the block to the document.
+    const body = document.split('---\n')[2]!.split('\n\n## Sitemap')[0]!
+    expect(body.endsWith(BLOCK)).toBe(true)
+    expect(full).toContain(body)
+  })
+
+  it('leaves the pages under a locale without the block', async () => {
+    const body = await (await fetch('/raw/en/docs/getting-started.md')).text()
+
+    expect(body).not.toContain('Resources for Agents')
+    expect(body.endsWith(FOOTER)).toBe(true)
+  })
+
+  it('lists the locale roots by their twins', async () => {
+    const sitemap = await (await fetch('/sitemap.md')).text()
+    const llms = await (await fetch('/llms.txt')).text()
+
+    for (const document of [sitemap, llms]) {
+      expect(document).toContain(`${SITE_URL}/raw/en.md`)
+      expect(document).toContain(`${SITE_URL}/raw/fr.md`)
+    }
+  })
+
+  it('keeps `/` wrapped once, as before', async () => {
+    const body = await (await fetch('/raw/index.md')).text()
+
+    expect(body).toContain('# i18n')
+    expect(body.match(/Resources for Agents/g)).toHaveLength(1)
   })
 })

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -182,12 +182,12 @@ describe('vercel build output', () => {
     const exact = 1 // `/`
     const cachedRules = 2 // `/docs/components/**`, plus `/docs/late/**` from `nitro:config`
     const headerRoutes = 3 // `Vary` on the pages, `Vary` on the markdown twins, `Link`
-    const canonicalLinks = 3 // canonical/alternate per twin space: two for `/**`, one for `/`
     const refusals = 1 // `notAcceptable: true` in the fixture
     // Per pattern: an `Accept` route and a User-Agent route, plus a `.md` alias
     // for a wildcard. Per cached rule narrower than the pattern over it: its own
-    // redirect pair.
-    expect(count).toBe(headerRoutes + canonicalLinks + refusals + patterns * 2 + (patterns - exact) + cachedRules * 2)
+    // redirect pair. The canonical pair on the twins sits in the `hit` phase at
+    // the end of the table, see below.
+    expect(count).toBe(headerRoutes + refusals + patterns * 2 + (patterns - exact) + cachedRules * 2)
   })
 
   // The cache-correctness path, asserted against real emitted output rather
@@ -224,11 +224,29 @@ describe('vercel build output', () => {
     expect(late.map(route => route.has?.[0]?.key)).toEqual(['accept', 'user-agent'])
   })
 
-  it('labels the prerendered twins with their canonical page', () => {
+  it('labels the prerendered twins with their canonical page, in the `hit` phase only', () => {
     // The raw handler sets this pair, but a prerendered twin never reaches
     // it, so the table has to carry the header for the CDN-answered files.
-    const linkRoutes = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    // In the phase that only runs once a static file matched: ahead of the
+    // filesystem it would land on every function answer too, and the 404 of
+    // a twin that does not exist advertised a canonical for a page that does
+    // not exist either.
+    const filesystem = routes.findIndex(route => route.handle === 'filesystem')
+    const hit = routes.findIndex(route => route.handle === 'hit')
+    expect(filesystem).toBeGreaterThan(0)
+    expect(hit).toBeGreaterThan(filesystem)
+    expect(routes.filter(route => route.handle === 'hit')).toHaveLength(1)
+    expect(routes.slice(0, hit).some(route => route.headers?.Link?.includes('rel="canonical"'))).toBe(false)
+
+    // The phase accepts nothing but header routes carrying `continue`.
+    const linkRoutes = routes.slice(hit + 1)
     expect(linkRoutes.length).toBeGreaterThanOrEqual(3)
+    for (const route of linkRoutes) {
+      expect(route.continue, route.src).toBe(true)
+      expect(route.dest, route.src).toBeUndefined()
+      expect(route.status, route.src).toBeUndefined()
+      expect(route.headers?.Link, route.src).toContain('rel="canonical"')
+    }
 
     const twin = linkRoutes.find(route => new RegExp(route.src!).test('/raw/docs/getting-started.md'))
     expect(twin).toBeDefined()

--- a/test/fixtures/i18n/content/en/index.md
+++ b/test/fixtures/i18n/content/en/index.md
@@ -1,0 +1,10 @@
+---
+title: Welcome
+description: The English landing page of the fixture.
+---
+
+# Welcome
+
+> The English landing page of the fixture.
+
+Read the [getting started guide](/en/docs/getting-started).

--- a/test/fixtures/i18n/content/fr/index.md
+++ b/test/fixtures/i18n/content/fr/index.md
@@ -1,0 +1,10 @@
+---
+title: Bienvenue
+description: La page d'accueil française de la fixture.
+---
+
+# Bienvenue
+
+> La page d'accueil française de la fixture.
+
+Lisez le [guide de démarrage](/fr/docs/getting-started).

--- a/test/fixtures/i18n/modules/i18n.ts
+++ b/test/fixtures/i18n/modules/i18n.ts
@@ -1,0 +1,12 @@
+import { defineNuxtModule } from '@nuxt/kit'
+
+/**
+ * Stands in for `@nuxtjs/i18n`: its module name and config key, none of its
+ * routing. The homepage detection reads `nuxt.options.i18n` off an installed
+ * module of that name and nothing else, and this fixture spells its locale
+ * routes out by hand under `pages/`, which the real module would prefix again.
+ */
+export default defineNuxtModule({
+  meta: { name: '@nuxtjs/i18n', configKey: 'i18n' },
+  setup() {}
+})

--- a/test/fixtures/i18n/nuxt.config.ts
+++ b/test/fixtures/i18n/nuxt.config.ts
@@ -19,12 +19,27 @@ export default defineNuxtConfig({
   agentDiscovery: {
     siteName: 'i18n',
     // One wildcard segment covers every locale, so the generated CDN route
-    // table stays O(patterns) instead of O(locales × pages).
+    // table stays O(patterns) instead of O(locales × pages). The locale roots
+    // are outside it on purpose: the module appends them itself.
     routes: [{ path: '/', raw: '/raw/index.md' }, '/*/docs/**']
+  },
+  // Read by the homepage detection off the stub module in `modules/i18n.ts`,
+  // which carries the `@nuxtjs/i18n` name. `prefix` is what Docus forces, so
+  // both locale roots are landing pages and `/` only redirects browsers.
+  i18n: {
+    locales: [{ code: 'en', name: 'English' }, { code: 'fr', name: 'Français' }],
+    defaultLocale: 'en',
+    strategy: 'prefix'
   },
   llms: {
     domain: 'https://i18n.example.com',
     title: 'i18n',
-    description: 'Fixture site with locale-prefixed documentation routes.'
+    description: 'Fixture site with locale-prefixed documentation routes.',
+    // The full document is where the locale landings have to carry their
+    // resources block too, byte for byte with their twins.
+    full: {
+      title: 'i18n',
+      description: 'Fixture site with locale-prefixed documentation routes.'
+    }
   }
 })

--- a/test/fixtures/i18n/server/routes/agent-document.md.get.ts
+++ b/test/fixtures/i18n/server/routes/agent-document.md.get.ts
@@ -1,0 +1,14 @@
+import { getAgentDocument } from '#agent-discovery'
+
+/**
+ * `getAgentDocument()` over HTTP, so a test can hold the served documents
+ * against the bytes the in-process resolver returns for the same route.
+ */
+export default defineEventHandler(async (event) => {
+  const document = await getAgentDocument(event, String(getQuery(event).route || '/'))
+  if (!document || 'redirect' in document) {
+    throw createError({ statusCode: 404, statusMessage: 'Page Not Found' })
+  }
+  setResponseHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+  return document.markdown
+})

--- a/test/unit/document.test.ts
+++ b/test/unit/document.test.ts
@@ -262,3 +262,78 @@ URL or send \`Accept: text/markdown\`.
     })
   })
 })
+
+describe('getAgentDocument: locale homepages', () => {
+  // On an i18n site `/` only redirects and the landing documents live at the
+  // locale roots, where `llms.txt` and the redirect send agents. The module
+  // lists those in `homepages`, and they wrap like `/` does.
+  const links = [
+    { href: '/sitemap.md', rel: 'sitemap', title: 'Sitemap (Markdown): every page on the site' },
+    { href: '/llms.txt', rel: 'describedby', title: 'llms.txt: index of the documentation for LLMs' }
+  ]
+
+  beforeEach(() => {
+    setRuntimeConfig({
+      agentDiscovery: {
+        siteUrl: 'https://example.com',
+        rawPrefix: '/raw',
+        routes: [{ path: '/', raw: '/raw/index.md' }, { path: '/**' }],
+        excludePrefixes: [],
+        links,
+        homepages: ['/en', '/fr']
+      }
+    })
+    setAgentContentSource({
+      async get(route) {
+        return route === '/en' || route === '/en/docs/guide' ? { title: route.slice(1), markdown: `# ${route.slice(1)}\n\nWelcome.\n` } : null
+      },
+      async firstLeaf(route) {
+        return route === '/fr' ? '/fr/docs/guide' : null
+      }
+    })
+  })
+
+  it('wraps a locale root the way it wraps `/`, footer included', async () => {
+    await expect(getAgentDocument(event, '/en')).resolves.toMatchObject({
+      canonicalUrl: 'https://example.com/en',
+      markdown: `---
+title: "en"
+canonical_url: "https://example.com/en"
+---
+# en
+
+Welcome.
+
+## Resources for Agents
+
+- [Sitemap (Markdown): every page on the site](https://example.com/sitemap.md)
+- [llms.txt: index of the documentation for LLMs](https://example.com/llms.txt)
+
+
+## Sitemap
+
+See the full [sitemap](https://example.com/sitemap.md) for all pages.
+`
+    })
+  })
+
+  it('leaves the pages under the locale without the block', async () => {
+    const document = await getAgentDocument(event, '/en/docs/guide') as { markdown: string }
+
+    expect(document.markdown).not.toContain('Resources for Agents')
+  })
+
+  it('keeps the generated index for `/` alone: a locale root with no document redirects like a section', async () => {
+    await expect(getAgentDocument(event, '/fr')).resolves.toEqual({ redirect: '/fr/docs/guide' })
+  })
+
+  it('reads a config with no locale roots as `/` alone', async () => {
+    setRuntimeConfig({
+      agentDiscovery: { siteUrl: 'https://example.com', rawPrefix: '/raw', routes: [{ path: '/**' }], excludePrefixes: [], links }
+    })
+
+    const document = await getAgentDocument(event, '/en') as { markdown: string }
+
+    expect(document.markdown).not.toContain('Resources for Agents')
+  })
+})

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -523,11 +523,32 @@ describe('module setup: i18n homepages', () => {
 
   it('leaves a locale root a pattern already covers to that pattern', async () => {
     // The default `/**` negotiates `/en` already; a second entry would only pad
-    // the CDN table. The twin still gets the block through `homepages`.
-    const config = resolved(await runModule({}, {}, i18n({ locales, strategy: 'prefix' })))
+    // the CDN table. The twin still gets the block through `homepages`, and is
+    // still queued for prerender like `/raw/index.md` rather than left to
+    // whether the site prerenders `/en` itself.
+    const nuxt = await runModule({}, {}, i18n({ locales, strategy: 'prefix' }))
+    const config = resolved(nuxt)
 
     expect(config.routes.map(route => route.path)).toEqual(['/', '/**'])
     expect(config.homepages).toEqual(['/en', '/fr'])
+
+    const ctx = { routes: new Set<string>() }
+    await nuxt.hooks.callHook('prerender:routes' as never, ctx as never)
+    expect(ctx.routes).toContain('/raw/index.md')
+    expect(ctx.routes).toContain('/raw/en.md')
+    expect(ctx.routes).toContain('/raw/fr.md')
+  })
+
+  it('leaves a covered locale twin the site serves itself alone', async () => {
+    const nuxt = await runModule({}, {}, (nuxt) => {
+      i18n({ locales, strategy: 'prefix' })(nuxt)
+      nuxt.options.serverHandlers.push({ route: '/raw/fr.md', handler: '/site/server/raw-fr.ts' })
+    })
+    const ctx = { routes: new Set<string>() }
+    await nuxt.hooks.callHook('prerender:routes' as never, ctx as never)
+
+    expect(ctx.routes).toContain('/raw/en.md')
+    expect(ctx.routes).not.toContain('/raw/fr.md')
   })
 
   it('skips the default locale under `prefix_except_default`, where it lives at `/`', async () => {
@@ -566,33 +587,37 @@ describe('module setup: i18n homepages', () => {
   })
 
   it('prerenders the locale twins without making a missing landing a build error', async () => {
-    // Appended rather than named by the site: a locale with docs but no landing
-    // document answers 404 on its twin, skipped the way a Vue page's twin is.
-    // The root twin the site did name keeps failing the build.
+    // Detected rather than named by the site, whether appended as an exact
+    // route or covered by a pattern: a locale with docs but no landing document
+    // answers 404 on its twin, skipped the way a Vue page's twin is. The root
+    // twin the site did name keeps failing the build.
     type Route = { route: string, contentType?: string, error?: Error & { statusCode: number, statusMessage: string }, skip?: boolean }
-    const nuxt = await runModule({ routes: ['/', '/*/docs/**'] }, {}, i18n({ locales, strategy: 'prefix' }))
-    const ctx = { routes: new Set<string>() }
-    await nuxt.hooks.callHook('prerender:routes' as never, ctx as never)
-    expect(ctx.routes).toContain('/raw/en.md')
-    expect(ctx.routes).toContain('/raw/fr.md')
-
-    const hooks: Record<string, (route: Route) => void> = {}
-    const nitro = {
-      options: { dev: false, static: false, preset: 'node-server', routeRules: {}, runtimeConfig: { agentDiscovery: {} } },
-      hooks: { hook: (name: string, callback: (route: Route) => void) => { hooks[name] = callback } }
-    }
-    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
     const failed = () => Object.assign(new Error('[404]'), { statusCode: 404, statusMessage: '' })
 
-    const missing: Route = { route: '/raw/fr.md', contentType: 'text/markdown; charset=utf-8', error: failed() }
-    hooks['prerender:generate']!(missing)
-    expect(missing.skip).toBe(true)
-    expect(missing.error).toBeUndefined()
+    for (const routes of [['/', '/*/docs/**'], ['/', '/**']]) {
+      const nuxt = await runModule({ routes }, {}, i18n({ locales, strategy: 'prefix' }))
+      const ctx = { routes: new Set<string>() }
+      await nuxt.hooks.callHook('prerender:routes' as never, ctx as never)
+      expect(ctx.routes).toContain('/raw/en.md')
+      expect(ctx.routes).toContain('/raw/fr.md')
 
-    const root: Route = { route: '/raw/index.md', contentType: 'text/markdown; charset=utf-8', error: failed() }
-    hooks['prerender:generate']!(root)
-    expect(root.skip).toBeUndefined()
-    expect(root.error?.statusCode).toBe(404)
+      const hooks: Record<string, (route: Route) => void> = {}
+      const nitro = {
+        options: { dev: false, static: false, preset: 'node-server', routeRules: {}, runtimeConfig: { agentDiscovery: {} } },
+        hooks: { hook: (name: string, callback: (route: Route) => void) => { hooks[name] = callback } }
+      }
+      await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
+
+      const missing: Route = { route: '/raw/fr.md', contentType: 'text/markdown; charset=utf-8', error: failed() }
+      hooks['prerender:generate']!(missing)
+      expect(missing.skip, routes.join(' ')).toBe(true)
+      expect(missing.error).toBeUndefined()
+
+      const root: Route = { route: '/raw/index.md', contentType: 'text/markdown; charset=utf-8', error: failed() }
+      hooks['prerender:generate']!(root)
+      expect(root.skip).toBeUndefined()
+      expect(root.error?.statusCode).toBe(404)
+    }
   })
 })
 

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -324,57 +324,6 @@ describe('module setup: cached routes', () => {
   })
 })
 
-describe('module setup: CDN link pairs', () => {
-  const vercelNitro = (config: NegotiationConfig, preset: string) => {
-    const dir = mkdtempSync(join(tmpdir(), 'agent-discovery-vercel-'))
-    writeFileSync(join(dir, 'config.json'), JSON.stringify({ routes: [] }))
-    const cloned = JSON.parse(JSON.stringify(config)) as NegotiationConfig
-    return {
-      cloned,
-      nitro: {
-        options: {
-          dev: false,
-          static: false,
-          preset,
-          output: { dir },
-          routeRules: {},
-          runtimeConfig: { agentDiscovery: cloned }
-        },
-        hooks: { hook: () => {} }
-      }
-    }
-  }
-
-  it('tells the runtime when the Vercel table carries the pairs', async () => {
-    // The raw handler otherwise emits the canonical/alternate `Link` a second
-    // time on every origin-rendered response, doubling with each hop.
-    const nuxt = await runModule({ siteUrl: 'https://example.com' })
-    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
-    const { cloned, nitro } = vercelNitro(config, 'vercel')
-    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
-
-    expect(cloned.cdnLinkPairs).toBe(true)
-  })
-
-  it('says nothing without a site URL, where the preset emits no pairs', async () => {
-    const nuxt = await runModule()
-    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
-    const { cloned, nitro } = vercelNitro(config, 'vercel')
-    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
-
-    expect(cloned.cdnLinkPairs).toBeUndefined()
-  })
-
-  it('says nothing off Vercel', async () => {
-    const nuxt = await runModule({ siteUrl: 'https://example.com' })
-    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
-    const { cloned, nitro } = vercelNitro(config, 'node-server')
-    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
-
-    expect(cloned.cdnLinkPairs).toBeUndefined()
-  })
-})
-
 describe('module setup: companion modules', () => {
   /** What Nuxt does with `@nuxtjs/seo`'s declarative `moduleDependencies`. */
   const installLate = (name: string) => (nuxt: FakeNuxt) => {
@@ -550,6 +499,100 @@ describe('module setup: companion modules', () => {
     })
 
     expect(nuxt.options.nitro.alias?.['#agent-discovery/mcp']).toContain('mcp/none')
+  })
+})
+
+describe('module setup: i18n homepages', () => {
+  // On a site running `@nuxtjs/i18n` the landing documents live at the locale
+  // roots and `/` only redirects, so `/raw/en.md` is the homepage agents are
+  // actually sent to. Detected at `modules:done` like the other companions,
+  // off the module's own config key.
+  const i18n = (options: Record<string, unknown>) => (nuxt: FakeNuxt) => {
+    nuxt.options._installedModules.push({ meta: { name: '@nuxtjs/i18n' } })
+    Object.assign(nuxt.options, { i18n: options })
+  }
+  const locales = [{ code: 'en', name: 'English' }, 'fr']
+  const resolved = (nuxt: FakeNuxt) => nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+
+  it('appends the locale roots as exact routes and wraps them as homepages', async () => {
+    const config = resolved(await runModule({ routes: ['/', '/*/docs/**'] }, {}, i18n({ locales, defaultLocale: 'en', strategy: 'prefix' })))
+
+    expect(config.routes.map(route => route.path)).toEqual(['/', '/*/docs/**', '/en', '/fr'])
+    expect(config.homepages).toEqual(['/en', '/fr'])
+  })
+
+  it('leaves a locale root a pattern already covers to that pattern', async () => {
+    // The default `/**` negotiates `/en` already; a second entry would only pad
+    // the CDN table. The twin still gets the block through `homepages`.
+    const config = resolved(await runModule({}, {}, i18n({ locales, strategy: 'prefix' })))
+
+    expect(config.routes.map(route => route.path)).toEqual(['/', '/**'])
+    expect(config.homepages).toEqual(['/en', '/fr'])
+  })
+
+  it('skips the default locale under `prefix_except_default`, where it lives at `/`', async () => {
+    // That module's own default, so an unset strategy reads the same way.
+    for (const strategy of ['prefix_except_default', undefined]) {
+      const config = resolved(await runModule({}, {}, i18n({ locales, defaultLocale: 'en', strategy })))
+      expect(config.homepages, String(strategy)).toEqual(['/fr'])
+    }
+  })
+
+  it('keeps the default locale under `prefix_and_default`, where both roots serve it', async () => {
+    const config = resolved(await runModule({}, {}, i18n({ locales, defaultLocale: 'en', strategy: 'prefix_and_default' })))
+
+    expect(config.homepages).toEqual(['/en', '/fr'])
+  })
+
+  it('detects nothing without prefixes, without locales, or across domains', async () => {
+    for (const options of [
+      { locales, strategy: 'no_prefix' },
+      { locales: [], strategy: 'prefix' },
+      { strategy: 'prefix' },
+      { locales, strategy: 'prefix', differentDomains: true }
+    ]) {
+      const config = resolved(await runModule({}, {}, i18n(options)))
+      expect(config.homepages, JSON.stringify(options)).toBeUndefined()
+      expect(config.routes.map(route => route.path)).toEqual(['/', '/**'])
+    }
+  })
+
+  it('ignores an `i18n` key with no module behind it', async () => {
+    const config = resolved(await runModule({}, {}, (nuxt) => {
+      Object.assign(nuxt.options, { i18n: { locales, strategy: 'prefix' } })
+    }))
+
+    expect(config.homepages).toBeUndefined()
+  })
+
+  it('prerenders the locale twins without making a missing landing a build error', async () => {
+    // Appended rather than named by the site: a locale with docs but no landing
+    // document answers 404 on its twin, skipped the way a Vue page's twin is.
+    // The root twin the site did name keeps failing the build.
+    type Route = { route: string, contentType?: string, error?: Error & { statusCode: number, statusMessage: string }, skip?: boolean }
+    const nuxt = await runModule({ routes: ['/', '/*/docs/**'] }, {}, i18n({ locales, strategy: 'prefix' }))
+    const ctx = { routes: new Set<string>() }
+    await nuxt.hooks.callHook('prerender:routes' as never, ctx as never)
+    expect(ctx.routes).toContain('/raw/en.md')
+    expect(ctx.routes).toContain('/raw/fr.md')
+
+    const hooks: Record<string, (route: Route) => void> = {}
+    const nitro = {
+      options: { dev: false, static: false, preset: 'node-server', routeRules: {}, runtimeConfig: { agentDiscovery: {} } },
+      hooks: { hook: (name: string, callback: (route: Route) => void) => { hooks[name] = callback } }
+    }
+    await nuxt.hooks.callHook('nitro:init' as never, nitro as never)
+    const failed = () => Object.assign(new Error('[404]'), { statusCode: 404, statusMessage: '' })
+
+    const missing: Route = { route: '/raw/fr.md', contentType: 'text/markdown; charset=utf-8', error: failed() }
+    hooks['prerender:generate']!(missing)
+    expect(missing.skip).toBe(true)
+    expect(missing.error).toBeUndefined()
+
+    const root: Route = { route: '/raw/index.md', contentType: 'text/markdown; charset=utf-8', error: failed() }
+    hooks['prerender:generate']!(root)
+    expect(root.skip).toBeUndefined()
+    expect(root.error?.statusCode).toBe(404)
   })
 })
 

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -8,8 +8,8 @@ import {
   compilePattern,
   errorMarkdown,
   formatLinkHeader,
-  hasCdnLinkPair,
   hasFileExtension,
+  isHomepage,
   isNegotiablePath,
   prerenderTwin,
   handlerRouteMatches,
@@ -937,62 +937,25 @@ describe('encodeAgentRoute', () => {
   })
 })
 
-describe('hasCdnLinkPair', () => {
-  // Mirrors the canonical/alternate pair the Vercel preset emits (see the
-  // `config.siteUrl` block in `vercelMarkdownRoutes`): the raw handler skips
-  // its own `Link` header exactly where the CDN already injected the pair, or
-  // every origin-rendered raw response carried it twice, doubling per hop.
-  const paired = createConfig({
-    routes: [
-      { path: '/', raw: '/raw/index.md' },
-      { path: '/about' },
-      { path: '/docs/index' },
-      { path: '/modules', raw: '/elsewhere/modules.md' },
-      { path: '/docs/**' }
-    ]
+describe('isHomepage', () => {
+  // The resources block lands on the homepages and nowhere else: `/` always,
+  // plus the locale roots the module detected from `@nuxtjs/i18n`, where `/`
+  // only redirects and `/en` is the page agents are sent to.
+  it('answers `/` on every config', () => {
+    expect(isHomepage(createConfig(), '/')).toBe(true)
+    expect(isHomepage(createConfig({ homepages: ['/en'] }), '/')).toBe(true)
   })
 
-  it('covers the static twin of every exact pattern under the raw prefix', () => {
-    expect(hasCdnLinkPair(paired, '/raw/index.md')).toBe(true)
-    expect(hasCdnLinkPair(paired, '/raw/about.md')).toBe(true)
+  it('answers the detected locale roots and nothing under them', () => {
+    const config = createConfig({ homepages: ['/en', '/fr'] })
+
+    expect(isHomepage(config, '/en')).toBe(true)
+    expect(isHomepage(config, '/fr')).toBe(true)
+    expect(isHomepage(config, '/en/docs/getting-started')).toBe(false)
+    expect(isHomepage(config, '/de')).toBe(false)
   })
 
-  it('covers the wildcard twins', () => {
-    expect(hasCdnLinkPair(paired, '/raw/docs/getting-started.md')).toBe(true)
-    expect(hasCdnLinkPair(paired, '/raw/docs/3.x/guide.md')).toBe(true)
-  })
-
-  it('spells a non-ASCII twin both ways the CDN sees it', () => {
-    expect(hasCdnLinkPair(paired, '/raw/docs/%E6%96%87%E6%A1%A3.md')).toBe(true)
-    expect(hasCdnLinkPair(paired, '/raw/docs/文档.md')).toBe(true)
-  })
-
-  it('leaves the index-shaped wildcard spellings alone, which get no edge pair', () => {
-    // The preset's `noIndex` lookahead: a `/index.md` capture would advertise
-    // a page URL the origin folds away, so those twins carry no CDN pair and
-    // the handler must keep setting its own.
-    expect(hasCdnLinkPair(paired, '/raw/docs/deep/index.md')).toBe(false)
-    // An index-shaped *exact* route gets a static entry with the folded page
-    // URL instead, so its twin is covered.
-    expect(hasCdnLinkPair(paired, '/raw/docs/index.md')).toBe(true)
-  })
-
-  it('leaves a twin outside every pattern alone', () => {
-    const narrow = createConfig({ routes: [{ path: '/docs/**' }] })
-
-    // Served request-time all the same (a curated llms section can point
-    // there), with only the handler to set the header.
-    expect(hasCdnLinkPair(narrow, '/raw/blog/post.md')).toBe(false)
-  })
-
-  it('leaves an exact twin outside the raw prefix alone', () => {
-    // `raw: /elsewhere/modules.md` gets no static entry in the preset, so the
-    // handler keeps the header wherever that document comes from.
-    expect(hasCdnLinkPair(paired, '/elsewhere/modules.md')).toBe(false)
-  })
-
-  it('answers false for anything that is not a raw markdown URL', () => {
-    expect(hasCdnLinkPair(paired, '/docs/getting-started')).toBe(false)
-    expect(hasCdnLinkPair(paired, '/raw/docs/image.png')).toBe(false)
+  it('reads a config with no locale roots as `/` alone', () => {
+    expect(isHomepage(createConfig(), '/en')).toBe(false)
   })
 })

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { vercelMarkdownRoutes } from '../../src/presets/vercel'
+import { vercelMarkdownRoutes, vercelTwinLinkRoutes } from '../../src/presets/vercel'
 import type { VercelRoute } from '../../src/presets/vercel'
-import { acceptsMarkdown, formatLinkHeader, hasCdnLinkPair, MARKDOWN_VARY } from '../../src/runtime/shared/negotiation'
+import { acceptsMarkdown, formatLinkHeader, MARKDOWN_VARY } from '../../src/runtime/shared/negotiation'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
 
 function createConfig(overrides: Partial<NegotiationConfig> = {}): NegotiationConfig {
@@ -240,26 +240,32 @@ describe('vercelMarkdownRoutes: route count', () => {
     const routes = vercelMarkdownRoutes(createConfig())
     expect(rewrites(routes).filter(route => route.dest === '/raw/docs/$1.md')).toHaveLength(3)
     expect(rewrites(routes).filter(route => route.dest === '/raw/index.md')).toHaveLength(2)
-    // 7 rewrites/headers plus the 3 canonical Link routes on the twins.
-    expect(routes).toHaveLength(10)
+    // 7 rewrites/headers. The 3 canonical Link routes on the twins sit in the
+    // `hit` phase, see `vercelTwinLinkRoutes`.
+    expect(routes).toHaveLength(7)
+    expect(vercelTwinLinkRoutes(createConfig())).toHaveLength(3)
   })
 
   it('emits 3 rewrites for an exact pattern that is not the root', () => {
     const routes = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/changelog' }] }))
     expect(rewrites(routes).filter(route => route.dest === '/raw/changelog.md')).toHaveLength(3)
-    // 5 rewrites/headers plus 3 canonical Link routes: the page twin, the raw
-    // twin, and the root twin the generated index serves on every config.
-    expect(routes).toHaveLength(8)
+    // 5 rewrites/headers, and 3 canonical Link routes in the `hit` phase: the
+    // page twin, the raw twin, and the root twin the generated index serves on
+    // every config.
+    expect(routes).toHaveLength(5)
+    expect(vercelTwinLinkRoutes(createConfig({ routes: [{ path: '/changelog' }] }))).toHaveLength(3)
   })
 
   it('stays O(patterns), never O(pages)', () => {
     const base = createConfig()
     const many = createConfig({ routes: [...base.routes, { path: '/blog/**' }, { path: '/*/docs/**' }] })
-    expect(vercelMarkdownRoutes(base)).toHaveLength(10)
+    expect(vercelMarkdownRoutes(base)).toHaveLength(7)
+    expect(vercelTwinLinkRoutes(base)).toHaveLength(3)
     // Each extra glob pattern adds 3 rewrites and 2 canonical Link routes.
-    expect(vercelMarkdownRoutes(many)).toHaveLength(10 + 5 + 5)
-    // Nothing in the table depends on the pages behind a pattern.
-    expect(JSON.stringify(vercelMarkdownRoutes(base))).not.toContain('foo')
+    expect(vercelMarkdownRoutes(many)).toHaveLength(7 + 3 + 3)
+    expect(vercelTwinLinkRoutes(many)).toHaveLength(3 + 2 + 2)
+    // Nothing in either table depends on the pages behind a pattern.
+    expect(JSON.stringify([...vercelMarkdownRoutes(base), ...vercelTwinLinkRoutes(base)])).not.toContain('foo')
   })
 })
 
@@ -577,7 +583,7 @@ describe('vercelMarkdownRoutes: methods', () => {
     // an unscoped edge route 406ed or rewrote a POST the origin would serve.
     const config = createConfig({ notAcceptable: true, cachedRoutes: ['/docs/**'], links: LINKS })
 
-    for (const route of vercelMarkdownRoutes(config)) {
+    for (const route of [...vercelMarkdownRoutes(config), ...vercelTwinLinkRoutes(config)]) {
       if (route.src === '^/$' && route.headers?.Link) {
         // The homepage Link route stands in for the `/` route rule, which the
         // origin applies to every method.
@@ -589,9 +595,23 @@ describe('vercelMarkdownRoutes: methods', () => {
   })
 })
 
-describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
-  const routes = vercelMarkdownRoutes(createConfig())
-  const linkRoutes = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+describe('vercelTwinLinkRoutes: canonical Link on the twins', () => {
+  // Emitted in the `hit` phase, which only runs once a static file matched:
+  // the pair reaches every prerendered twin and no function answer, so the
+  // raw handler keeps setting its own and a missing twin's 404 advertises no
+  // page. The phase accepts nothing but header routes carrying `continue`.
+  const linkRoutes = vercelTwinLinkRoutes(createConfig())
+
+  it('stays out of the leading table and header-only, as the `hit` phase requires', () => {
+    expect(vercelMarkdownRoutes(createConfig()).some(route => route.headers?.Link?.includes('rel="canonical"'))).toBe(false)
+    expect(linkRoutes.length).toBeGreaterThan(0)
+    for (const route of linkRoutes) {
+      expect(route.continue, route.src).toBe(true)
+      expect(route.dest, route.src).toBeUndefined()
+      expect(route.status, route.src).toBeUndefined()
+      expect(route.headers?.Link, route.src).toContain('rel="canonical"')
+    }
+  })
 
   it('labels both twin URL spaces of a wildcard pattern', () => {
     // A prerendered twin is answered off the filesystem, so the handler that
@@ -618,11 +638,11 @@ describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
   it('skips a raw destination the site serves itself', () => {
     // An exact `raw` under an excluded prefix is the site's own document: no
     // entry for it, and no garbage sliced into the wildcard's lookahead.
-    const routes = vercelMarkdownRoutes(createConfig({
+    const routes = vercelTwinLinkRoutes(createConfig({
       routes: [{ path: '/design', raw: '/design.md' }, { path: '/**' }],
       excludePrefixes: ['/_', '/api/', '/design.md']
     }))
-    const links = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    const links = routes
 
     expect(links.some(route => matches(route, '/design.md'))).toBe(false)
     expect(routes.some(route => route.src.includes('(?:ign'))).toBe(false)
@@ -630,8 +650,8 @@ describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
   })
 
   it('maps the root twin to the site URL when only a wildcard covers `/`', () => {
-    const routes = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/**' }] }))
-    const links = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    const routes = vercelTwinLinkRoutes(createConfig({ routes: [{ path: '/**' }] }))
+    const links = routes
     const index = links.filter(route => matches(route, '/raw/index.md'))
 
     expect(index).toHaveLength(1)
@@ -652,8 +672,8 @@ describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
     // The guard is keyed on the twin having an owner, not on a `/` route
     // existing: with a `raw` override the route no longer names
     // `/raw/index.md`, which the origin serves regardless.
-    const routes = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/', raw: '/raw/home.md' }, { path: '/**' }] }))
-    const links = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    const routes = vercelTwinLinkRoutes(createConfig({ routes: [{ path: '/', raw: '/raw/home.md' }, { path: '/**' }] }))
+    const links = routes
     const index = links.filter(route => matches(route, '/raw/index.md'))
 
     expect(index).toHaveLength(1)
@@ -665,8 +685,8 @@ describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
     // `/` and `/index` both map to `/raw/index.md`: two entries would stack
     // two conflicting headers on one response, and the origin folds `/index`
     // into `/` anyway.
-    const routes = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/' }, { path: '/index' }, { path: '/**' }] }))
-    const links = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    const routes = vercelTwinLinkRoutes(createConfig({ routes: [{ path: '/' }, { path: '/index' }, { path: '/**' }] }))
+    const links = routes
     const index = links.filter(route => matches(route, '/raw/index.md'))
 
     expect(index).toHaveLength(1)
@@ -677,8 +697,8 @@ describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
   it('folds an index-shaped exact route in its static entry', () => {
     // The origin folds `/docs/index` into `/docs`, so the twin's static
     // entry has to advertise the folded URL, the one that answers.
-    const routes = vercelMarkdownRoutes(createConfig({ routes: [{ path: '/docs/index' }, { path: '/**' }] }))
-    const links = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    const routes = vercelTwinLinkRoutes(createConfig({ routes: [{ path: '/docs/index' }, { path: '/**' }] }))
+    const links = routes
     const entry = links.filter(route => matches(route, '/raw/docs/index.md'))
 
     expect(entry).toHaveLength(1)
@@ -689,55 +709,7 @@ describe('vercelMarkdownRoutes: canonical Link on the twins', () => {
     // The value embeds the page URL and the edge cannot know the request
     // host at build time, so the origin-rendered responses keep the header
     // and the prerendered twins go without, the pre-existing behavior.
-    const bare = vercelMarkdownRoutes(createConfig({ siteUrl: '' }))
-
-    expect(bare.some(route => route.headers?.Link?.includes('rel="canonical"'))).toBe(false)
-  })
-})
-
-describe('vercelMarkdownRoutes: Link pair agreement with the runtime', () => {
-  // `hasCdnLinkPair` is what lets the raw handler skip its own `Link` header
-  // where the table already injects the pair. The two are separate
-  // implementations on purpose (one emits regexes, one answers per request),
-  // so this pins them to the same answer across every twin shape.
-  it('answers exactly where the emitted table carries a pair', () => {
-    const config = createConfig({
-      routes: [
-        { path: '/', raw: '/raw/index.md' },
-        { path: '/about' },
-        { path: '/docs/index' },
-        { path: '/modules', raw: '/elsewhere/modules.md' },
-        { path: '/文档' },
-        { path: '/docs/**' }
-      ]
-    })
-    const pairs = vercelMarkdownRoutes(config)
-      .filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
-
-    // The spellings the edge sees: Vercel matches `src` against the
-    // percent-encoded request path, so a non-ASCII twin only ever arrives
-    // encoded. The exact-pattern regexes used to be built from the decoded
-    // config path and could never match, while the predicate answered true,
-    // losing the pair entirely.
-    const samples = [
-      '/raw/index.md',
-      '/raw/about.md',
-      '/raw/docs/index.md',
-      '/raw/docs/getting-started.md',
-      '/raw/docs/3.x/guide.md',
-      '/raw/docs/deep/index.md',
-      '/raw/blog/post.md',
-      '/raw/docs/image.png',
-      '/raw/modules.md',
-      '/raw/%E6%96%87%E6%A1%A3.md',
-      '/raw/docs/%E6%96%87%E6%A1%A3.md'
-    ]
-    for (const path of samples) {
-      const cdn = pairs.some(route => new RegExp(route.src).test(path))
-      expect(hasCdnLinkPair(config, path), path).toBe(cdn)
-    }
-    // Pinned positively too, or an emitter matching nowhere would still agree.
-    expect(hasCdnLinkPair(config, '/raw/%E6%96%87%E6%A1%A3.md')).toBe(true)
+    expect(vercelTwinLinkRoutes(createConfig({ siteUrl: '' }))).toHaveLength(0)
   })
 })
 
@@ -766,7 +738,7 @@ describe('vercelMarkdownRoutes: non-ASCII exact patterns', () => {
     // The raw handler encodes `canonicalUrl` before it reaches a header;
     // the edge pair has to spell it the same way, and a raw UTF-8 header
     // value is invalid at the CDN anyway.
-    const pairs = routes.filter(route => route.continue && route.headers?.Link?.includes('rel="canonical"'))
+    const pairs = vercelTwinLinkRoutes(config)
     const twinPair = pairs.find(route => new RegExp(route.src).test('/raw/%E6%96%87%E6%A1%A3.md'))
     expect(twinPair?.headers?.Link).toContain('<https://example.com/%E6%96%87%E6%A1%A3>; rel="canonical"')
   })


### PR DESCRIPTION
Follow-ups to #22 and #24 from the docus migration (nuxt-content/docus#1435), both found by the verify skill on the preview.

## Locale roots count as homepages

On a site running `@nuxtjs/i18n` there is no `/` document: docus puts the landing pages at `/en` and `/fr`, prerenders those two, and `/` is a 302 to `/en`. So `/raw/index.md` (the generated page) carried the `## Resources for Agents` block while `/raw/en.md` and `/raw/fr.md`, the pages `llms.txt`, `sitemap.md` and the redirect actually send agents to, did not.

- `@nuxtjs/i18n` is detected at `modules:done` like `@nuxtjs/robots` and `@nuxtjs/sitemap`, and its locale roots become homepages, read the way its router does: every locale under `prefix` and `prefix_and_default`, every one but the default under `prefix_except_default` (its default, where the default locale lives at `/`), none under `no_prefix` or with `differentDomains`
- each root is appended to `routes` as an exact entry when no pattern covers it already, so it negotiates. A root a pattern already matches (the default `/**`) gets no second entry, keeping the table O(patterns). Either way its twin is queued for prerender like `/raw/index.md`, instead of depending on whether the site prerenders the landing page itself. A missing landing document 404s its twin the way a Vue page's does, skipped rather than a build error, since the site never named it
- the roots land in `homepages` on the runtime config, and one `isHomepage()` predicate drives `getAgentDocument()` and the `llms-full.txt` builder, both through the same `appendAgentResources()` so `/raw/en.md` and the `/en` entry of `llms-full.txt` stay byte for byte identical. The "already has that heading" guard from #24 applies. The generated index and `agent-discovery:index` keep applying to `/` only, and a locale root with no landing document redirects to its first page like any section
- no new site config: the i18n case is detected, and `homepages` is only a runtime field

## The canonical pair no longer lands on a missing twin

On the Vercel preset the `continue: true` `Link` routes on the twins ran ahead of `handle: filesystem`, so a `/raw/does-not-exist.md` 404 from the function still advertised a canonical for a page that does not exist. A header route there cannot see the upstream status, but the Build Output table has a phase that can: `hit` runs only once a static file has been matched, and accepts nothing but header routes with `continue`.

- the pair moves into `vercelTwinLinkRoutes()`, appended after a `{ handle: 'hit' }` marker at the end of `.vercel/output/config.json` (Nitro emits none of its own; an existing one takes the routes instead of a second marker)
- the raw handler always sets the pair again, since a function answer never gets the table's copy now. `cdnLinkPairs` and `hasCdnLinkPair()` go away with the double emission they guarded against
- the leading table shrinks by the pair routes, and the `vercel` e2e suite asserts the phase ordering and that nothing ahead of the filesystem carries a canonical

This one needs a preview check, since a local build cannot exercise the CDN: on a prerendered twin, both the direct `/raw/docs/x.md` request and the negotiated `/docs/x` with `Accept: text/markdown` should carry the pair, and `/raw/does-not-exist.md` should not.

## Which sites change bytes

- **docus i18n sites**: `/raw/en.md`, `/raw/fr.md` and the matching entries of `llms-full.txt` gain the block and the sitemap footer stays last. Their default `/**` already covers the roots, so `routes` and the leading route table do not change; the two twins were already prerendered through the landing pages' own hints and now are queued directly as well
- **nuxt.com and the nuxt/ui docs**: no i18n, so no document changes. On both, and on every Vercel site, `config.json` changes shape: the canonical pair routes move from the head of the table to a trailing `hit` phase, and a missing twin's 404 loses its `Link`

## Tests

- unit: homepage detection in `module.test.ts` next to the companion-module tests (routes appended or left to a covering pattern, the four strategies, `differentDomains`, an `i18n` key with no module, the prerender skip for a missing landing), `isHomepage` in `negotiation.test.ts`, locale roots in `document.test.ts`, and the hit-phase routes in `vercel.test.ts` in place of the removed `hasCdnLinkPair` agreement tests
- e2e (`i18n`): the fixture gains `content/en/index.md`, `content/fr/index.md`, a stub module carrying the `@nuxtjs/i18n` name so detection reads a real `nuxt.options.i18n`, and an `agent-document.md` route over `getAgentDocument()`. It asserts `/raw/en.md` ends with the block and the sitemap footer, that the `/en` entry of `llms-full.txt` matches `getAgentDocument(event, '/en')` minus its envelope, that `/raw/en/docs/getting-started.md` has no block, that `/en` negotiates, and that both locale twins are prerendered
- e2e (`vercel`): the pair sits after the single `hit` marker, header-only with `continue`, and nowhere ahead of the filesystem

`pnpm lint`, `pnpm typecheck` and `pnpm test` (516 across 24 files) green on this head.
