### PR TITLE
fix(sections): ignore headings inside fenced blocks

### DIFF
--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -519,8 +519,11 @@ const INLINE_CODE = /(`+)[\s\S]*?\1/g
 
 const OPEN_FENCE = /^ {0,3}(`{3,}|~{3,})/
 
-/** A closing fence carries no info string, so a nested ` ```js ` line is content. */
-const CLOSE_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
+/**
+ * A closing fence carries no info string, so a nested ` ```js ` line is content.
+ * The trailing `\r` is a CRLF document split on `\n`.
+ */
+const CLOSE_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*\r?$/
 
 /**
  * Feed it a document's lines in order; it answers whether the line just fed

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -519,6 +519,28 @@ const INLINE_CODE = /(`+)[\s\S]*?\1/g
 
 const OPEN_FENCE = /^ {0,3}(`{3,}|~{3,})/
 
+/**
+ * Feed it a document's lines in order; it answers whether the line just fed
+ * belongs to a fenced block, the fence lines themselves included.
+ */
+export function createFenceTracker(): (line: string) => boolean {
+  let fence: string | undefined
+  return (line) => {
+    const opening = OPEN_FENCE.exec(line)?.[1]
+    if (fence) {
+      if (opening && opening.startsWith(fence[0]!) && opening.length >= fence.length) {
+        fence = undefined
+      }
+      return true
+    }
+    if (opening) {
+      fence = opening
+      return true
+    }
+    return false
+  }
+}
+
 function absolutizeProse(text: string, siteUrl: string): string {
   return text
     .replace(MARKDOWN_LINK, (_match, prefix: string, path: string) => `${prefix}${siteUrl}${path}`)
@@ -543,22 +565,9 @@ function absolutizeLine(line: string, siteUrl: string): string {
  */
 export function absolutizeMarkdownLinks(markdown: string, siteUrl: string): string {
   const base = siteUrl.replace(/\/$/, '')
-  let fence: string | undefined
+  const inFence = createFenceTracker()
 
-  return markdown.split('\n').map((line) => {
-    const opening = OPEN_FENCE.exec(line)?.[1]
-    if (fence) {
-      if (opening && opening.startsWith(fence[0]!) && opening.length >= fence.length) {
-        fence = undefined
-      }
-      return line
-    }
-    if (opening) {
-      fence = opening
-      return line
-    }
-    return absolutizeLine(line, base)
-  }).join('\n')
+  return markdown.split('\n').map(line => inFence(line) ? line : absolutizeLine(line, base)).join('\n')
 }
 
 /** Prefixes a site-relative href with the site origin, leaving others alone. */

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -519,6 +519,9 @@ const INLINE_CODE = /(`+)[\s\S]*?\1/g
 
 const OPEN_FENCE = /^ {0,3}(`{3,}|~{3,})/
 
+/** A closing fence carries no info string, so a nested ` ```js ` line is content. */
+const CLOSE_FENCE = /^ {0,3}(`{3,}|~{3,})[ \t]*$/
+
 /**
  * Feed it a document's lines in order; it answers whether the line just fed
  * belongs to a fenced block, the fence lines themselves included.
@@ -526,13 +529,14 @@ const OPEN_FENCE = /^ {0,3}(`{3,}|~{3,})/
 export function createFenceTracker(): (line: string) => boolean {
   let fence: string | undefined
   return (line) => {
-    const opening = OPEN_FENCE.exec(line)?.[1]
     if (fence) {
-      if (opening && opening.startsWith(fence[0]!) && opening.length >= fence.length) {
+      const closing = CLOSE_FENCE.exec(line)?.[1]
+      if (closing && closing.startsWith(fence[0]!) && closing.length >= fence.length) {
         fence = undefined
       }
       return true
     }
+    const opening = OPEN_FENCE.exec(line)?.[1]
     if (opening) {
       fence = opening
       return true

--- a/src/runtime/shared/sections.ts
+++ b/src/runtime/shared/sections.ts
@@ -1,3 +1,5 @@
+import { createFenceTracker } from './negotiation'
+
 /**
  * Narrows a markdown document to the `##` sections an agent asked for, keeping
  * the frontmatter, the title and the description. A docs page is often far
@@ -25,13 +27,15 @@ export function extractSections(markdown: string, sectionTitles: string[]): stri
 
   // Title and description, bounded by the first `##`: a page with no description
   // blockquote would otherwise push its entire body in here.
+  const headerFence = createFenceTracker()
   for (let index = start; index < lines.length; index++) {
     const line = lines[index]!
-    if (line.startsWith('## ')) {
+    const fenced = headerFence(line)
+    if (!fenced && line.startsWith('## ')) {
       break
     }
     result.push(line)
-    if (line.startsWith('>')) {
+    if (!fenced && line.startsWith('>')) {
       result.push('')
       break
     }
@@ -49,9 +53,11 @@ export function extractSections(markdown: string, sectionTitles: string[]): stri
     }
   }
 
+  // A fenced example that documents headings starts lines with `## ` too.
+  const bodyFence = createFenceTracker()
   for (let index = start; index < lines.length; index++) {
     const line = lines[index]!
-    if (line.startsWith('## ')) {
+    if (!bodyFence(line) && line.startsWith('## ')) {
       take()
       current = line.slice(3).trim()
       section = [line]

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -892,6 +892,13 @@ describe('absolutizeMarkdownLinks', () => {
     expect(run(['````', '```', '[a](/x)', '````'].join('\n'))).toBe(['````', '```', '[a](/x)', '````'].join('\n'))
   })
 
+  it('does not close a fence on a nested fence line carrying an info string', () => {
+    // A closing fence has no info string, so ` ```js ` inside a ` ```mdc `
+    // block is content and the link after it stays fenced.
+    const markdown = ['```mdc', '```js', '[a](/x)', '```', '[b](/y)'].join('\n')
+    expect(run(markdown)).toBe(['```mdc', '```js', '[a](/x)', '```', '[b](https://example.com/y)'].join('\n'))
+  })
+
   it('leaves raw HTML alone: a closing tag is not an autolink', () => {
     // `</div>` is indistinguishable from `</path>` by shape, and the
     // `@nuxt/content` adapter stringifies with `format: 'markdown/html'`, so

--- a/test/unit/negotiation.test.ts
+++ b/test/unit/negotiation.test.ts
@@ -899,6 +899,13 @@ describe('absolutizeMarkdownLinks', () => {
     expect(run(markdown)).toBe(['```mdc', '```js', '[a](/x)', '```', '[b](https://example.com/y)'].join('\n'))
   })
 
+  it('closes a fence in a document with CRLF line endings', () => {
+    // The document is split on `\n`, so every line of a CRLF file carries a
+    // trailing `\r` the closing fence has to tolerate.
+    const markdown = ['```md', '[a](/x)', '```', '[b](/y)'].join('\r\n')
+    expect(run(markdown)).toBe(['```md', '[a](/x)', '```', '[b](https://example.com/y)'].join('\r\n'))
+  })
+
   it('leaves raw HTML alone: a closing tag is not an autolink', () => {
     // `</div>` is indistinguishable from `</path>` by shape, and the
     // `@nuxt/content` adapter stringifies with `format: 'markdown/html'`, so

--- a/test/unit/sections.test.ts
+++ b/test/unit/sections.test.ts
@@ -107,4 +107,15 @@ Styled.
     expect(extracted).toContain('after')
     expect(extracted).not.toContain('## Next')
   })
+
+  it('does not close a fence on a nested fence line carrying an info string', () => {
+    // A closing fence has no info string, so ` ```js ` inside a ` ```mdc `
+    // block is content and the heading after it is still fenced.
+    const doc = ['## Headings', '```mdc', '```js', '## Not a heading', '```', 'after', '## Next'].join('\n')
+    const extracted = extractSections(doc, ['Headings'])
+
+    expect(extracted).toContain('## Not a heading')
+    expect(extracted).toContain('after')
+    expect(extracted).not.toContain('## Next')
+  })
 })

--- a/test/unit/sections.test.ts
+++ b/test/unit/sections.test.ts
@@ -98,4 +98,13 @@ Styled.
     expect(extracted).toContain('Deep.')
     expect(extracted).not.toContain('Styled.')
   })
+
+  it('does not end a section on a heading inside a fence', () => {
+    const doc = ['## Headings', 'intro', '```mdc', '## Not a heading', '```', 'after', '## Next'].join('\n')
+    const extracted = extractSections(doc, ['Headings'])
+
+    expect(extracted).toContain('## Not a heading')
+    expect(extracted).toContain('after')
+    expect(extracted).not.toContain('## Next')
+  })
 })

--- a/test/unit/sections.test.ts
+++ b/test/unit/sections.test.ts
@@ -118,4 +118,14 @@ Styled.
     expect(extracted).toContain('after')
     expect(extracted).not.toContain('## Next')
   })
+
+  it('closes a fence in a document with CRLF line endings', () => {
+    // A fence that never closes would swallow every section after it.
+    const doc = ['# Title', '', '## Headings', '```mdc', '## Not a heading', '```', 'after', '', '## Next', 'Styled.'].join('\r\n')
+    const extracted = extractSections(doc, ['Headings'])
+
+    expect(extracted).toContain('## Not a heading')
+    expect(extracted).toContain('after')
+    expect(extracted).not.toContain('Styled.')
+  })
 })


### PR DESCRIPTION
`extractSections` scanned for `## ` at the start of a line and only tracked `>` blockquotes, so a fenced example that documents markdown headings ended the section early. On ui.nuxt.com, `get-documentation-page` with `path: /docs/typography/headers-and-text` and `headings: ["Headings"]` came back with Heading 1 and Heading 2 only, the ` ```mdc ` block carrying `## What's new in v4?` cut off Heading 3 and Heading 4.

- the fence tracking `absolutizeMarkdownLinks` already had moves into an exported `createFenceTracker()` next to `OPEN_FENCE`, and both callers use it. Three or more backticks or tildes, up to three spaces of indent, closed by a fence of the same character at least as long
- a closing fence has to be bare: a nested ` ```js ` line inside a ` ```mdc ` block is content per CommonMark, since a closing fence carries no info string. Only spaces, tabs and the `\r` of a CRLF document split on `\n` may follow it
- `extractSections` skips `## ` lines inside a fence in both the header scan and the section scan. The header scan also stops treating a `>` inside a fence as the description

Unit tests in `sections.test.ts` for a `## ` line inside a fence, for the nested info-string fence line and for CRLF line endings, plus the last two cases for `absolutizeMarkdownLinks` in `negotiation.test.ts`. Each one fails against the scanner it covers. `pnpm lint`, `pnpm typecheck` and the unit suite (354 across 15 files) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown headings inside fenced code blocks are no longer mistaken for document sections.
  * Links inside fenced code blocks are preserved without automatic rewriting.
  * Fenced blocks remain open when nested fence-like lines include info strings.
  * CRLF-formatted closing fences are recognized correctly.
  * Section extraction correctly recognizes headings that appear outside code blocks.

* **Tests**
  * Added regression coverage for fenced Markdown handling, including nested fences, CRLF line endings, headings, and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->