### PR TITLE
feat: app-side discovery registry and a details slot for llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ const resources = useAgentResources()
 </script>
 
 <template>
-  <a v-for="resource in resources" :key="resource.href" :href="resource.href">{{ resource.title }}</a>
+  <a v-for="resource in resources" :key="`${resource.rel} ${resource.href}`" :href="resource.href">{{ resource.title }}</a>
 </template>
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Markdown content negotiation, CDN-level rewrites, and discovery documents for AI
 - Vercel Build Output routes so prerendered pages negotiate at the edge, and a Nitro middleware for dev and every other host
 - Correct `Vary` and `Link` headers on both halves of a negotiated page, CDN-served files included
 - A raw markdown route driven by a pluggable content adapter: `@nuxt/content` built in, comark through a factory, or your own
-- A `nuxt-llms` bridge: adapter-backed sections and the full document come from the content adapter, hand-written links stay yours
+- A `nuxt-llms` bridge: adapter-backed sections and the full document come from the content adapter, hand-written links stay yours, plus the details section `nuxt-llms` has no field for
 - Markdown error bodies with recovery links for agents hitting a 404
 - `/.well-known/api-catalog` (RFC 9727), an optional MCP server card, and Agent Skills under `/.well-known/skills/`
 - `/sitemap.md`, a markdown index of every page, grouped into sections you control
@@ -99,6 +99,7 @@ export default defineNuxtConfig({
 - **`errors`** Answer errors with a markdown body carrying recovery links when the request prefers it.
 - **`notAcceptable`** See [Strict content negotiation](#strict-content-negotiation).
 - **`sitemap.markdown`** Serve `/sitemap.md` from the content adapter. Pass an object to control grouping: `expand` lists prefixes whose children each get their own section, `labels` overrides derived headings.
+- **`llms.details`** Markdown blocks for the details section of `llms.txt`, the space llmstxt.org reserves between the blockquote and the first `##`. See [llms.txt sections](#llmstxt-sections).
 - **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with a `description` becomes a skill, its files listed from disk into a generated index. `false` to disable.
 - **`robots.aiPolicy`** Feeds the user-agent list into `@nuxtjs/robots` when installed, otherwise generates `/robots.txt` (skipped when a static one exists). **`robots.contentSignal`** adds the `Content-Signal` line, `false` to omit. **`robots.disallow`** adds `Disallow` lines to the wildcard group, in the generated file and through `@nuxtjs/robots` alike. Wildcard only: the per-agent `Allow` groups exempt their agents from these rules, so what search engines skip stays reachable for the agents the site names.
 
@@ -187,6 +188,23 @@ export default defineAgentContentSource({
 ### llms.txt sections
 
 The module removes `@nuxt/content`'s llms feature and generates `llms.txt` and `llms-full.txt` from the adapter, so the documents agree with what `/raw/**.md` serves. Existing `llms.sections` config keeps working: each section is handed to the adapter, which reads the keys it declares (`contentCollection`/`contentFilters` for `@nuxt/content`, `navigation` for comark). A section carrying its own `links` is left alone, its same-origin page links rendered into the full document, and each link matching a configured route rewritten to its raw twin; off-site and data links pass through untouched. Declare no sections at all and pages are grouped by the `section` label the adapter returns.
+
+`llms.details` fills the details section, the space [llmstxt.org](https://llmstxt.org) reserves between the `>` blockquote and the first `##` for whatever a site needs to say before the link lists. `nuxt-llms` renders the title and the description and goes straight to the sections, so this is the field it leaves out:
+
+```ts
+export default defineNuxtConfig({
+  agentDiscovery: {
+    llms: {
+      details: [
+        'Every page is available as markdown by appending `.md` to its URL.',
+        'Reach for `llms-full.txt` when you need the whole documentation in one request.'
+      ]
+    }
+  }
+})
+```
+
+A single string works too. The blocks are joined with a blank line and rendered after the blockquote, so they need `llms.description` set, which is what they follow. Headings are not allowed there: one would open a section and pull every link list under it, and the module warns at build when it finds one.
 
 `nuxt-llms` prerenders both documents unconditionally, so on a backend resolving content per request they go stale without a redeploy ([nuxt-llms#24](https://github.com/nuxtlabs/nuxt-llms/issues/24)). Until that lands, opt the two routes out yourself:
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,19 @@ The same entry point exports `getAgentSiteUrl(event)` and `useAgentDiscoveryConf
 
 **`useCanonical()`** is the app-side half: a `rel="canonical"` link for the current route, and a `rel="alternate"; type="text/markdown"` one when you pass it a markdown path.
 
+**`useAgentResources()`** reads the same registry from a component, so an HTML error page can offer the recovery links its markdown twin already carries instead of hardcoding a list that drifts from what the site publishes. It returns the titled links, in the order `renderAgentResources()` renders them, with the hrefs spelled as registered:
+
+```vue
+<!-- error.vue -->
+<script setup lang="ts">
+const resources = useAgentResources()
+</script>
+
+<template>
+  <a v-for="resource in resources" :key="resource.href" :href="resource.href">{{ resource.title }}</a>
+</template>
+```
+
 **`agent-discovery:sitemap`** adds to `/sitemap.md` before it renders, for the pages the adapter cannot know about. The map is keyed by the raw first path segment of the grouped routes (`docs`, `blog`; the second segment under an expanded prefix, `pages` for top-level ones), and `sitemap.markdown.labels` only applies at render. So extending an existing section means using its key, while a new section can use any key and renders it capitalized unless `labels` overrides it:
 
 ```ts

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,7 @@ import { isValidRel } from './rels'
 import { scanSkills } from './skills'
 import { disableContentRawMarkdown, dropContentLlmsFeature, resolveContentSource } from './build/content'
 import { setupVercelPreset } from './presets/vercel'
-import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, siteServesRaw, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
+import { createFenceTracker, formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, siteServesRaw, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleHooks as RobotsModuleHooks } from '@nuxtjs/robots'
 import type { AgentResource, AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
@@ -98,6 +98,19 @@ export interface ModuleOptions {
   sitemap?: {
     /** Serve `/sitemap.md`. Pass an object to control how pages are grouped into sections. */
     markdown?: boolean | Partial<SitemapSections>
+  }
+  llms?: {
+    /**
+     * Markdown blocks for the details section of `llms.txt`, the space
+     * llmstxt.org reserves between the `>` blockquote and the first `##` for
+     * whatever a site needs to say before the link lists. Headings are not
+     * allowed there, since one would open a section.
+     *
+     * `nuxt-llms` renders the title and the description; this fills the gap it
+     * leaves. Needs `llms.description` to be set, which is what the block
+     * follows.
+     */
+    details?: string | string[]
   }
   robots?: {
     /**
@@ -571,6 +584,21 @@ export {}
       disableContentRawMarkdown(nuxt)
     }
 
+    // Blocks rendered between the `llms.txt` blockquote and its first `##`.
+    // Normalized here so the runtime joins a list it can trust.
+    const llmsDetails = (typeof options.llms?.details === 'string' ? [options.llms.details] : options.llms?.details || [])
+      .map(block => block.trim())
+      .filter(Boolean)
+    if (llmsDetails.length) {
+      // A heading in there opens a section, which moves every link list under
+      // it and leaves the details reading as that section's prose.
+      const fenced = createFenceTracker()
+      const heading = llmsDetails.join('\n\n').split('\n').find(line => !fenced(line) && /^#{1,6}\s/.test(line))
+      if (heading) {
+        logger.warn(`\`llms.details\` carries a heading (\`${heading.trim()}\`), which opens a section in \`llms.txt\`. The details section is prose only; put the heading in \`llms.sections\` instead.`)
+      }
+    }
+
     // Route-rule patterns with a response cache that a negotiated pattern
     // reaches; the CDN redirects there instead of rewriting. Collected three
     // times because rules keep arriving: at `modules:done` from
@@ -650,6 +678,18 @@ export {}
       if (hasLlms && sourcePath) {
         dropContentLlmsFeature(nuxt)
         addServerPlugin(resolve('./runtime/server/plugins/llms'))
+
+        if (llmsDetails.length) {
+          // The details follow the blockquote, so without one there is nothing
+          // for them to follow and `nuxt-llms` renders neither.
+          if ((nuxt.options as { llms?: { description?: string } }).llms?.description) {
+            config.llmsDetails = llmsDetails
+          } else {
+            logger.warn('`llms.details` needs `llms.description`, which is the blockquote the details section follows. Set it, or move the prose into a `llms.sections` entry.')
+          }
+        }
+      } else if (llmsDetails.length) {
+        logger.warn('`llms.details` does nothing without the `nuxt-llms` bridge, which needs `nuxt-llms` installed and a content source resolved.')
       }
 
       /* ------------------------------ homepages ----------------------------- */

--- a/src/module.ts
+++ b/src/module.ts
@@ -586,16 +586,30 @@ export {}
 
     // Blocks rendered between the `llms.txt` blockquote and its first `##`.
     // Normalized here so the runtime joins a list it can trust.
-    const llmsDetails = (typeof options.llms?.details === 'string' ? [options.llms.details] : options.llms?.details || [])
+    let llmsDetails = (typeof options.llms?.details === 'string' ? [options.llms.details] : options.llms?.details || [])
       .map(block => block.trim())
       .filter(Boolean)
     if (llmsDetails.length) {
-      // A heading in there opens a section, which moves every link list under
-      // it and leaves the details reading as that section's prose.
       const fenced = createFenceTracker()
-      const heading = llmsDetails.join('\n\n').split('\n').find(line => !fenced(line) && /^#{1,6}\s/.test(line))
-      if (heading) {
-        logger.warn(`\`llms.details\` carries a heading (\`${heading.trim()}\`), which opens a section in \`llms.txt\`. The details section is prose only; put the heading in \`llms.sections\` instead.`)
+      let heading: string | undefined
+      // Scanned to the last line whatever turns up, so the fence state below
+      // reflects the whole block rather than wherever a heading stopped it.
+      for (const line of llmsDetails.join('\n\n').split('\n')) {
+        if (!fenced(line) && !heading && /^#{1,6}\s/.test(line)) {
+          heading = line.trim()
+        }
+      }
+      // A blank line neither opens nor closes a fence, so the tracker reads it
+      // as fenced only while one is still open. An unclosed fence runs to the
+      // end of the document and renders every section after it as code, so the
+      // details are dropped rather than shipped breaking `llms.txt`.
+      if (fenced('')) {
+        logger.warn('`llms.details` leaves a code fence unclosed, which would swallow every `llms.txt` section after it. The details section is left out until the fence is closed.')
+        llmsDetails = []
+      } else if (heading) {
+        // A heading opens a section, which moves every link list under it and
+        // leaves the details reading as that section's prose.
+        logger.warn(`\`llms.details\` carries a heading (\`${heading}\`), which opens a section in \`llms.txt\`. The details section is prose only; put the heading in \`llms.sections\` instead.`)
       }
     }
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -24,9 +24,9 @@ import { setupVercelPreset } from './presets/vercel'
 import { formatLinkHeader, hasFileExtension, isRawPath, matchRoute, normalizePathname, patternsOverlap, rawDestination, siteServesRaw, staticPrefix, MARKDOWN_VARY } from './runtime/shared/negotiation'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleHooks as RobotsModuleHooks } from '@nuxtjs/robots'
-import type { AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
+import type { AgentResource, AgentRoute, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
-export type { AgentContentSource, AgentIndex, AgentListEntry, AgentPage, AgentRoute, AgentSectionSelector, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
+export type { AgentContentSource, AgentIndex, AgentListEntry, AgentPage, AgentResource, AgentRoute, AgentSectionSelector, DiscoveryLink, NegotiationConfig, SitemapSections, SkillEntry } from './runtime/shared/types'
 
 export interface McpServerCardOptions {
   /** MCP endpoint the card describes, e.g. `/mcp`. */
@@ -133,7 +133,7 @@ interface AgentDiscoveryRuntimeConfig {
 
 /** What this module puts in `runtimeConfig.public`. */
 interface AgentDiscoveryPublicRuntimeConfig {
-  agentDiscovery: { siteUrl: string, siteName: string, rawPrefix: string }
+  agentDiscovery: { siteUrl: string, siteName: string, rawPrefix: string, resources: AgentResource[] }
 }
 
 declare module '@nuxt/schema' {
@@ -426,7 +426,10 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    addImports({ name: 'useCanonical', from: resolve('./runtime/app/composables/useCanonical') })
+    addImports([
+      { name: 'useCanonical', from: resolve('./runtime/app/composables/useCanonical') },
+      { name: 'useAgentResources', from: resolve('./runtime/app/composables/useAgentResources') }
+    ])
 
     // Declares the Nitro runtime hooks so a site's server code needs no cast.
     const hookTypes = addTypeTemplate({
@@ -767,7 +770,13 @@ export {}
       runtimeConfig.public.agentDiscovery = {
         siteUrl: config.siteUrl,
         siteName: config.siteName,
-        rawPrefix
+        rawPrefix,
+        // Only the renderable links, the ones the error bodies and the homepage
+        // block already list. The rest are anchors and header flags no page can
+        // show, and this rides the payload of every page on the site.
+        resources: config.links
+          .filter((link): link is DiscoveryLink & { title: string } => Boolean(link.title))
+          .map(link => ({ href: link.href, rel: link.rel, title: link.title, ...(link.type ? { type: link.type } : {}) }))
       }
     })
 

--- a/src/runtime/app/composables/useAgentResources.ts
+++ b/src/runtime/app/composables/useAgentResources.ts
@@ -12,7 +12,7 @@ import type { AgentResource } from '../../shared/types'
  * hardcoding a set that drifts from what the site publishes.
  *
  * ```vue
- * <a v-for="resource in useAgentResources()" :key="resource.href" :href="resource.href">
+ * <a v-for="resource in useAgentResources()" :key="`${resource.rel} ${resource.href}`" :href="resource.href">
  *   {{ resource.title }}
  * </a>
  * ```

--- a/src/runtime/app/composables/useAgentResources.ts
+++ b/src/runtime/app/composables/useAgentResources.ts
@@ -1,0 +1,25 @@
+import { useRuntimeConfig } from '#imports'
+import type { AgentResource } from '../../shared/types'
+
+/**
+ * The discovery resources this site publishes, from the same registry the
+ * `Link` header and `/.well-known/api-catalog` are built from, hook
+ * contributions included.
+ *
+ * The same list, in the same order, that `renderAgentResources()` writes into
+ * the agent homepage and the markdown error bodies. So an HTML error page can
+ * offer the recovery links its markdown twin already carries instead of
+ * hardcoding a set that drifts from what the site publishes.
+ *
+ * ```vue
+ * <a v-for="resource in useAgentResources()" :key="resource.href" :href="resource.href">
+ *   {{ resource.title }}
+ * </a>
+ * ```
+ */
+export function useAgentResources(): readonly AgentResource[] {
+  // Through `unknown`: a site's generated `runtimeConfig` type narrows this to
+  // whatever literal shape it resolved, as `useCanonical` does.
+  const publicConfig = useRuntimeConfig().public.agentDiscovery as unknown as { resources?: AgentResource[] } | undefined
+  return publicConfig?.resources || []
+}

--- a/src/runtime/server/plugins/llms.ts
+++ b/src/runtime/server/plugins/llms.ts
@@ -17,6 +17,8 @@ type LlmsSection = {
 
 interface LlmsOptions {
   domain?: string
+  /** The `llms.txt` blockquote, and what the details section follows. */
+  description?: string
   sections: LlmsSection[]
 }
 
@@ -113,6 +115,17 @@ export default defineNitroPlugin((nitroApp: NitroApp) => {
   nitroApp.hooks.hook('llms:generate' as never, (async (event: H3Event, options: LlmsOptions) => {
     const config = useAgentDiscoveryConfig(event)
     const domain = options.domain || getAgentSiteUrl(event)
+
+    // The details section llmstxt.org reserves between the blockquote and the
+    // first `##`. `nuxt-llms` has no field for it, and the description is the
+    // only lever a hook has: the generator emits it as `> ${description}` and
+    // joins the document's blocks with a blank line, so everything after the
+    // first blank line lands outside the quote. The `basic` e2e suite pins the
+    // rendered header byte for byte, which turns a change upstream into a
+    // failing build here rather than a broken `llms.txt` on every site.
+    if (config.llmsDetails?.length && options.description) {
+      options.description = [options.description, ...config.llmsDetails].join('\n\n')
+    }
 
     if (source) {
       const adapter = source

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -57,6 +57,19 @@ export interface DiscoveryLink {
   header?: boolean
 }
 
+/**
+ * A discovery resource as app code reads it: the renderable half of a
+ * `DiscoveryLink`, without the `anchor` and `header` fields that only steer
+ * where the build emits it.
+ */
+export interface AgentResource {
+  href: string
+  rel: string
+  /** Always present: an untitled link has nothing to render, so it never reaches here. */
+  title: string
+  type?: string
+}
+
 /** How `sitemap.md` groups pages into sections. */
 export interface SitemapSections {
   /** Path prefixes whose children each get their own section. `['/docs']` splits "Docs" into "Components", "Composables". */

--- a/src/runtime/shared/types.ts
+++ b/src/runtime/shared/types.ts
@@ -173,6 +173,11 @@ export interface NegotiationConfig {
    */
   ownRawRoutes?: string[]
   /**
+   * Markdown blocks rendered into the details section of `llms.txt`, the space
+   * llmstxt.org reserves between the blockquote and the first `##`.
+   */
+  llmsDetails?: string[]
+  /**
    * Routes wrapped as the agent homepage besides `/`: the locale roots (`/en`,
    * `/fr`) of a site running `@nuxtjs/i18n`, where `/` only redirects and the
    * landing document lives under the locale. Their twins carry the resources

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -2,7 +2,7 @@ import { get } from 'node:http'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { fetch, setup, url } from '@nuxt/test-utils/e2e'
-import { BROWSER_ACCEPT, CLAUDE_BOT, MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY, SITE_URL } from './expected'
+import { BROWSER_ACCEPT, CLAUDE_BOT, INDEX_RESOURCES, MARKDOWN_CONTENT_TYPE, MARKDOWN_VARY, SITE_URL } from './expected'
 import { describeSharedDocuments } from './shared'
 
 /**
@@ -159,6 +159,24 @@ describe('errors', () => {
 
     expect(response.status).toBe(404)
     expect(response.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('offers the HTML 404 the same recovery links the markdown one carries', async () => {
+    const html = await (await fetch('/docs/nonexistent', {
+      headers: { 'Accept': BROWSER_ACCEPT, 'Sec-Fetch-Mode': 'navigate' }
+    })).text()
+    const markdown = await (await fetch('/docs/nonexistent', { headers: { 'User-Agent': CLAUDE_BOT } })).text()
+
+    // The fixture's `error.vue` renders `useAgentResources()`, so the two
+    // bodies list the same registry rather than a hand-kept copy of it. The
+    // markdown side absolutizes; the page keeps the hrefs a browser wants.
+    const recovery = markdown.split('## Where to look next')[1]!.split('\n##')[0]!
+    const titled = [...recovery.matchAll(/^- \[([^\]]+)\]\(([^)]+)\)$/gm)]
+    expect(titled.length).toBe(INDEX_RESOURCES.length)
+    for (const [, title, href] of titled) {
+      expect(html).toContain(`>${title}</a>`)
+      expect(html).toContain(`href="${href!.replace(SITE_URL, '')}"`)
+    }
   })
 })
 

--- a/test/e2e/basic.test.ts
+++ b/test/e2e/basic.test.ts
@@ -574,6 +574,31 @@ describe('nuxt-llms bridge', () => {
     expect(handwritten.split('\n').filter(line => line.startsWith('- '))).toHaveLength(1)
   })
 
+  it('renders `llms.details` between the blockquote and the first section', async () => {
+    const body = await (await fetch('/llms.txt')).text()
+    const header = body.split('\n## ')[0]!
+
+    // Byte-exact on purpose. `nuxt-llms` has no details field, so the module
+    // rides the description: it emits `> ${description}` and joins the
+    // document's blocks with a blank line, which puts everything after the
+    // first blank line outside the quote. A change to either upstream fails
+    // here rather than silently folding every site's details into its
+    // blockquote.
+    expect(header).toBe([
+      '# Basic',
+      '',
+      '> Fixture site for the nuxt-agent-discovery e2e tests.',
+      '',
+      'Fetch any page as markdown by appending `.md` to its URL.',
+      '',
+      '```sh',
+      'curl https://basic.example.com/docs/getting-started.md',
+      '```',
+      // The blank line `nuxt-llms` joins the next section on.
+      ''
+    ].join('\n'))
+  })
+
   it('emits each section once: `@nuxt/content`\'s llms plugin is gone', async () => {
     const body = await (await fetch('/llms.txt')).text()
     const headings = body.split('\n').filter(line => line.startsWith('## '))

--- a/test/fixtures/basic/error.vue
+++ b/test/fixtures/basic/error.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+defineProps<{ error: { statusCode: number } }>()
+
+// The HTML half of the markdown error body: same registry, no hardcoded list.
+const resources = useAgentResources()
+</script>
+
+<template>
+  <main>
+    <h1>{{ error.statusCode }}</h1>
+    <ul>
+      <li
+        v-for="resource in resources"
+        :key="`${resource.rel} ${resource.href}`"
+      >
+        <a
+          :href="resource.href"
+          :type="resource.type"
+        >{{ resource.title }}</a>
+      </li>
+    </ul>
+  </main>
+</template>

--- a/test/fixtures/basic/nuxt.config.ts
+++ b/test/fixtures/basic/nuxt.config.ts
@@ -59,6 +59,14 @@ export default defineNuxtConfig({
         labels: { components: 'UI Components' }
       }
     },
+    llms: {
+      // The details section: two blocks, one carrying a fenced example, so the
+      // rendered header pins both the join and the fence handling.
+      details: [
+        'Fetch any page as markdown by appending `.md` to its URL.',
+        '```sh\ncurl https://basic.example.com/docs/getting-started.md\n```'
+      ]
+    },
     discovery: {
       mcpServerCard: {
         endpoint: '/mcp',

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -9,7 +9,7 @@ import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from '../../src/defaults'
 import { vercelMarkdownRoutes } from '../../src/presets/vercel'
 import { prerenderTwin } from '../../src/runtime/shared/negotiation'
 import type { ModuleOptions } from '../../src/module'
-import type { NegotiationConfig } from '../../src/runtime/shared/types'
+import type { AgentResource, NegotiationConfig } from '../../src/runtime/shared/types'
 
 const rootDir = fileURLToPath(new URL('../fixtures/custom-source', import.meta.url))
 
@@ -996,5 +996,50 @@ describe('module setup: api-catalog', () => {
     })
 
     expect(config.links.some(link => link.href === '/.well-known/api-catalog')).toBe(true)
+  })
+})
+
+describe('module setup: app-side resources', () => {
+  const publicResources = async (options: Partial<ModuleOptions> = {}) => {
+    const nuxt = await runModule(options)
+    return (nuxt.options.runtimeConfig.public.agentDiscovery as { resources: AgentResource[] }).resources
+  }
+
+  it('carries the titled registry links, in registry order', async () => {
+    const nuxt = await runModule({
+      discovery: { links: [{ href: '/openapi.json', rel: 'service-desc', type: 'application/json', anchor: '/', title: 'OpenAPI' }] }
+    })
+    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+    const resources = (nuxt.options.runtimeConfig.public.agentDiscovery as { resources: AgentResource[] }).resources
+
+    // Same set, same order as `renderAgentResources()` and the error bodies,
+    // which filter the very same way: nothing for a site to hardcode.
+    expect(resources.map(resource => resource.href)).toEqual(config.links.filter(link => link.title).map(link => link.href))
+    expect(resources).toContainEqual({ href: '/openapi.json', rel: 'service-desc', type: 'application/json', title: 'OpenAPI' })
+  })
+
+  it('drops the untitled links and the fields only the build reads', async () => {
+    const resources = await publicResources({
+      discovery: { links: [{ href: '/internal.json', rel: 'service-desc', anchor: '/mcp' }] }
+    })
+
+    // An untitled link has nothing to show, and `anchor`/`header` steer the
+    // catalog and the `Link` header rather than a page. Both ride the payload
+    // of every page on the site, so neither is worth carrying.
+    expect(resources.some(resource => resource.href === '/internal.json')).toBe(false)
+    for (const resource of resources) {
+      expect(resource).toEqual({ href: resource.href, rel: resource.rel, title: resource.title, ...(resource.type ? { type: resource.type } : {}) })
+    }
+  })
+
+  it('includes what `agent-discovery:extend` contributed', async () => {
+    const nuxt = await runModule({}, {}, undefined, (nuxt) => {
+      nuxt.hook('agent-discovery:extend', ((registry: { links: { href: string, rel: string, title?: string }[] }) => {
+        registry.links.push({ href: '/corp.txt', rel: 'describedby', title: 'Corp' })
+      }) as never)
+    })
+    const resources = (nuxt.options.runtimeConfig.public.agentDiscovery as { resources: AgentResource[] }).resources
+
+    expect(resources).toContainEqual({ href: '/corp.txt', rel: 'describedby', title: 'Corp' })
   })
 })

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -1043,3 +1043,33 @@ describe('module setup: app-side resources', () => {
     expect(resources).toContainEqual({ href: '/corp.txt', rel: 'describedby', title: 'Corp' })
   })
 })
+
+describe('module setup: llms details', () => {
+  /** `nuxt-llms` visible from `setup()`, which is when the bridge is decided. */
+  const withLlms = (llms: Record<string, unknown> = { description: 'Docs' }) => (nuxt: FakeNuxt) => {
+    nuxt.options._installedModules.push({ meta: { name: 'nuxt-llms' } })
+    Object.assign(nuxt.options, { llms })
+  }
+
+  it('normalizes a string, a list and the blank entries into blocks', async () => {
+    const one = await runModule({ llms: { details: 'When to use this' } }, {}, undefined, withLlms())
+    const many = await runModule({ llms: { details: ['  When to use this  ', '', '  And how  '] } }, {}, undefined, withLlms())
+
+    expect((one.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails).toEqual(['When to use this'])
+    expect((many.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails).toEqual(['When to use this', 'And how'])
+  })
+
+  it('is left off without a description for the block to follow', async () => {
+    // `nuxt-llms` renders no blockquote without one, so the details would open
+    // the document where the description belongs.
+    const nuxt = await runModule({ llms: { details: 'When to use this' } }, {}, undefined, withLlms({ title: 'Docs' }))
+
+    expect((nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails).toBeUndefined()
+  })
+
+  it('is left off without the bridge that renders it', async () => {
+    const nuxt = await runModule({ llms: { details: 'When to use this' } })
+
+    expect((nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails).toBeUndefined()
+  })
+})

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -1059,6 +1059,25 @@ describe('module setup: llms details', () => {
     expect((many.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails).toEqual(['When to use this', 'And how'])
   })
 
+  it('drops the block when a code fence is left unclosed', async () => {
+    // An unclosed fence runs to the end of `llms.txt` and renders every
+    // section after it as code, so shipping the details breaks the document.
+    for (const fence of ['```sh', '~~~sh']) {
+      const nuxt = await runModule({ llms: { details: `${fence}\ncurl https://example.com/docs.md` } }, {}, undefined, withLlms())
+
+      expect((nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails, fence).toBeUndefined()
+    }
+  })
+
+  it('keeps a closed fence, headings inside it included', async () => {
+    for (const fence of ['```md', '~~~md']) {
+      const details = `${fence}\n# Not a section\n${fence.slice(0, 3)}`
+      const nuxt = await runModule({ llms: { details } }, {}, undefined, withLlms())
+
+      expect((nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig).llmsDetails, fence).toEqual([details])
+    }
+  })
+
   it('is left off without a description for the block to follow', async () => {
     // `nuxt-llms` renders no blockquote without one, so the details would open
     // the document where the description belongs.


### PR DESCRIPTION
Two additions that came out of the nuxt.com adoption, where site code was doing something the module is better placed to do. Both are additive.

## `useAgentResources()`

The module builds the recovery link list twice on the server, for the markdown error body and for `renderAgentResources()`, but there was no way to read it from a component. So a site that wants its HTML 404 to offer the same recovery links an agent gets from the markdown one has to hardcode them, and the hardcoded list drifts from what the site actually publishes.

```vue
<!-- error.vue -->
<script setup lang="ts">
const resources = useAgentResources()
</script>

<template>
  <a v-for="resource in resources" :key="resource.href" :href="resource.href">{{ resource.title }}</a>
</template>
```

Auto-imported next to `useCanonical()`. Returns `{ href, rel, title, type? }` from the same registry the `Link` header and `/.well-known/api-catalog` are built from, `agent-discovery:extend` contributions included, in the order `renderAgentResources()` renders them.

It's the titled links specifically, which is the same filter the error bodies and the homepage block already apply, so the four never disagree. Carried in `runtimeConfig.public` and filtered at build: the untitled links are duplicates or anchors, and `anchor`/`header` only steer where the build emits a link, so none of it is worth riding the payload of every page on the site.

The design of the error page stays with the site, this is just the data. The `basic` fixture has an `error.vue` using it, and an e2e test cross-checks the HTML 404's links against the markdown 404's.

## `agentDiscovery.llms.details`

llmstxt.org reserves the space between the blockquote and the first `##` for free prose. `nuxt-llms` renders `# title`, `> description` and goes straight to the sections, so there's no field for it. nuxt.com gets it today by appending paragraphs to `llms.description` and relying on the generator joining blocks with a blank line, which closes the quote.

```ts
export default defineNuxtConfig({
  agentDiscovery: {
    llms: {
      details: [
        'Every page is available as markdown by appending `.md` to its URL.',
        'Reach for `llms-full.txt` when you need the whole documentation in one request.'
      ]
    }
  }
})
```

**Pushback on the shape, since you asked for it: there is no real slot to build here.** `nuxt-llms` assembles `['# title', '> description', ...sections].join('\n\n')` and the `llms:generate` hook only ever sees that options object, so `description` is the single lever that reaches the space between the blockquote and the first `##`. A genuine slot means either a `details` field in `nuxt-llms` itself (a two-line change to `llms.txt.get.js`) or this module taking over `/llms.txt`, which is out of proportion for one prose block.

So the bridge still rides the description. What changes is that the assumption lives in one place instead of every site, and the `basic` e2e suite pins the rendered header byte for byte:

````md
# Basic

> Fixture site for the nuxt-agent-discovery e2e tests.

Fetch any page as markdown by appending `.md` to its URL.

```sh
curl https://basic.example.com/docs/getting-started.md
```
````

If `nuxt-llms` changes its join or starts quoting multi-line descriptions, CI here goes red instead of every consuming site's `llms.txt` silently folding its details into the blockquote. Renovate keeps `nuxt-llms` current in this repo, so that test actually runs against new versions.

Build-time warnings cover a heading in the block (fence-aware, since one would open a section and pull every link list under it), a `details` with no `llms.description` to follow, and one set with the bridge off.

I'd still send that `details` field upstream to `nuxt-llms` at some point, and this option can then just forward to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the details section of generated `llms.txt` files with Markdown content.
  - Added `useAgentResources()` for accessing registered discovery resources in Vue components.
  - Published titled discovery resources for consistent navigation and agent-facing resource access.
  - Added matching discovery links to HTML error pages.

- **Documentation**
  - Documented `llms.details` configuration and the `useAgentResources()` composable.

- **Bug Fixes**
  - Improved validation and formatting of `llms.txt` details content, including warnings for unsupported headings and unclosed code fences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->