### PR TITLE
fix(vercel): keep the catch-all rewrite off cached routes

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'pathe'
 import { readFile, writeFile } from 'node:fs/promises'
 import type { Nitro } from 'nitropack'
-import { compilePattern, encodeAgentRoute, formatLinkHeader, isRawPath, matchRoute, patternsOverlap, rawDestination, ruleCoversPattern, MARKDOWN_VARY } from '../runtime/shared/negotiation'
+import { compilePattern, encodeAgentRoute, formatLinkHeader, isExcluded, isRawPath, matchRoute, patternsOverlap, rawDestination, ruleCoversPattern, MARKDOWN_VARY } from '../runtime/shared/negotiation'
 import type { NegotiationConfig } from '../runtime/shared/types'
 
 export interface VercelRoute {
@@ -228,6 +228,32 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   })
 
   /**
+   * `**` is zero or more segments to the rule matcher, so `/docs/**` caches
+   * `/docs` itself, while the pattern its pair compiles needs a segment after
+   * the slash. Left out, the section root is refused by the rewrites below and
+   * matched by no redirect, which puts it back on the origin this route table
+   * exists to keep it off.
+   *
+   * A root already answered elsewhere is skipped rather than answered twice: by
+   * an exact rule of its own, which sites pairing `/docs` with `/docs/**`
+   * write, or by a cached pattern the loop over `config.routes` demotes whole.
+   */
+  const exactRules = new Set(redirectedRules.filter(rule => !rule.includes('*')))
+  const sectionRoots: string[] = []
+  for (const rule of redirectedRules) {
+    const root = rule.endsWith('/**') ? rule.slice(0, -3) : ''
+    if (!root || exactRules.has(root) || sectionRoots.includes(root) || isExcluded(root, config)) {
+      continue
+    }
+    // No route matching it means no twin to send it to, and no rewrite claiming
+    // it either, since both compile from the same patterns.
+    const matched = matchRoute(config.routes, root)
+    if (matched && !patternCached(matched.path)) {
+      sectionRoots.push(root)
+    }
+  }
+
+  /**
    * Every path this function answers with a 307, as a lookahead a rewrite can
    * carry. `vercel build` rewrites the table it deploys: routes are regrouped
    * by kind, and a `check: true` rewrite is hoisted above the plain redirects
@@ -238,20 +264,16 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
    * alone. Naming the redirected paths inside the rewrite keeps the split
    * correct however the table is ordered.
    */
-  const redirected = [...redirectedRules, ...config.routes.filter(route => patternCached(route.path)).map(route => route.path)]
+  const redirected = [...redirectedRules, ...sectionRoots, ...config.routes.filter(route => patternCached(route.path)).map(route => route.path)]
   const redirectLookahead = (pattern: string) => {
     const overlapping = redirected.filter(entry => patternsOverlap(entry, pattern))
     if (!overlapping.length) {
       return ''
     }
-    // Non-capturing, or the lookahead's own groups would shift `$1` in the destination.
-    const sources = overlapping.flatMap((entry) => {
-      // `^body/?$` without the anchors or the trailing slash the alternation adds back.
-      const source = compilePattern(encodeAgentRoute(entry), { capture: false }).source.slice(1, -3)
-      // `**` is zero or more segments to the rule matcher, so `/docs/**` caches
-      // `/docs` too, while its compiled source needs a segment after the slash.
-      return entry.endsWith('/**') ? [source, escapeEncoded(entry.slice(0, -3))] : [source]
-    })
+    // Non-capturing, or the lookahead's own groups would shift `$1` in the
+    // destination. `^body/?$` without the anchors or the trailing slash the
+    // alternation adds back once for all of them.
+    const sources = overlapping.map(entry => compilePattern(encodeAgentRoute(entry), { capture: false }).source.slice(1, -3))
     return `(?!(?:${sources.join('|')})/?$)`
   }
 
@@ -267,6 +289,13 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
       : `${encodeAgentRoute(config.rawPrefix)}${patternDest(encodeAgentRoute(rule))}.md`
 
     pushNegotiated(src, dest, true)
+  }
+
+  // The section roots the pairs above cannot reach, each through the route that
+  // matches it, so the twin is the one that route would have rewritten to.
+  for (const root of sectionRoots) {
+    const matched = matchRoute(config.routes, root)!
+    pushNegotiated(`^${escapeEncoded(root)}/?$`, encodeAgentRoute(rawDestination(config, matched, root)), true)
   }
 
   for (const route of config.routes) {

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -281,9 +281,12 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     const wildcard = rule.includes('*')
     const matched = wildcard ? undefined : matchRoute(config.routes, rule)
 
+    // The trailing slash is optional on the exact form for the same reason the
+    // lookahead above spells it: what a rewrite refuses, a redirect has to
+    // answer, or the one spelling neither side claims goes to the origin.
     const src = wildcard
       ? `^${NO_DOTTED_LAST_SEGMENT}${excluded}${compilePattern(encodeAgentRoute(rule)).source.slice(1, -1)}$`
-      : `^${escapeEncoded(rule)}$`
+      : `^${escapeEncoded(rule)}/?$`
     const dest = matched
       ? encodeAgentRoute(rawDestination(config, matched, rule))
       : `${encodeAgentRoute(config.rawPrefix)}${patternDest(encodeAgentRoute(rule))}.md`

--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -213,21 +213,51 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
   // A cached rule narrower than the pattern covering it, `routeRules['/docs/**']`
   // under the default `/**`, gets its own 307 pair ahead of that pattern's
   // rewrite. Marking the whole pattern cached would demote every page on the site.
-  for (const rule of config.cachedRoutes) {
+  const redirectedRules = config.cachedRoutes.filter((rule) => {
     // An exact rule is only negotiable through the route it matches: without one
     // there is no twin, and an invented `rawPrefix + rule + '.md'` 307s to a 404.
     const wildcard = rule.includes('*')
-    const matched = wildcard ? undefined : matchRoute(config.routes, rule)
 
-    // This loop handles what a rule caches beyond the patterns it fully covers,
+    // This filter handles what a rule caches beyond the patterns it fully covers,
     // which are demoted wholesale below, or a path collects two redirects.
     if (wildcard) {
-      if (!config.routes.some(route => patternsOverlap(rule, route.path) && !patternCached(route.path))) {
-        continue
-      }
-    } else if (!matched || patternCached(matched.path)) {
-      continue
+      return config.routes.some(route => patternsOverlap(rule, route.path) && !patternCached(route.path))
     }
+    const matched = matchRoute(config.routes, rule)
+    return Boolean(matched) && !patternCached(matched!.path)
+  })
+
+  /**
+   * Every path this function answers with a 307, as a lookahead a rewrite can
+   * carry. `vercel build` rewrites the table it deploys: routes are regrouped
+   * by kind, and a `check: true` rewrite is hoisted above the plain redirects
+   * of the same phase. That put the catch-all rewrite in front of the 307 pair
+   * of every cached rule under it, so a cached page was rewritten instead,
+   * `check` found no static file for the twin, and the request fell through to
+   * the function, whose own 307 the response cache then stored under the path
+   * alone. Naming the redirected paths inside the rewrite keeps the split
+   * correct however the table is ordered.
+   */
+  const redirected = [...redirectedRules, ...config.routes.filter(route => patternCached(route.path)).map(route => route.path)]
+  const redirectLookahead = (pattern: string) => {
+    const overlapping = redirected.filter(entry => patternsOverlap(entry, pattern))
+    if (!overlapping.length) {
+      return ''
+    }
+    // Non-capturing, or the lookahead's own groups would shift `$1` in the destination.
+    const sources = overlapping.flatMap((entry) => {
+      // `^body/?$` without the anchors or the trailing slash the alternation adds back.
+      const source = compilePattern(encodeAgentRoute(entry), { capture: false }).source.slice(1, -3)
+      // `**` is zero or more segments to the rule matcher, so `/docs/**` caches
+      // `/docs` too, while its compiled source needs a segment after the slash.
+      return entry.endsWith('/**') ? [source, escapeEncoded(entry.slice(0, -3))] : [source]
+    })
+    return `(?!(?:${sources.join('|')})/?$)`
+  }
+
+  for (const rule of redirectedRules) {
+    const wildcard = rule.includes('*')
+    const matched = wildcard ? undefined : matchRoute(config.routes, rule)
 
     const src = wildcard
       ? `^${NO_DOTTED_LAST_SEGMENT}${excluded}${compilePattern(encodeAgentRoute(rule)).source.slice(1, -1)}$`
@@ -244,6 +274,9 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
     // handled above. The `.md` twins stay rewrites: that URL serves one variant.
     const cached = patternCached(route.path)
 
+    // A 307 needs no exclusion: it *is* what the redirected paths get.
+    const notRedirected = cached ? '' : redirectLookahead(route.path)
+
     if (route.path.includes('*')) {
       const body = compilePattern(encodeAgentRoute(route.path)).source.slice(1, -1)
       const dest = `${encodeAgentRoute(config.rawPrefix)}${patternDest(encodeAgentRoute(route.path))}.md`
@@ -252,7 +285,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
         dest,
         methods: METHODS
       })
-      pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${body}$`, dest, cached)
+      pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${notRedirected}${body}$`, dest, cached)
     } else {
       const dest = encodeAgentRoute(rawDestination(config, route, route.path))
       if (route.path !== '/') {
@@ -260,7 +293,7 @@ export function vercelMarkdownRoutes(config: NegotiationConfig): VercelRoute[] {
       }
       // The same two guards as the wildcard branch: `/faq.html` reads as an asset
       // and `/mcp` sits behind an excluded prefix, both refused by the runtime.
-      pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${escapeEncoded(route.path)}/?$`, dest, cached)
+      pushNegotiated(`^${NO_DOTTED_LAST_SEGMENT}${excluded}${notRedirected}${escapeEncoded(route.path)}/?$`, dest, cached)
     }
   }
 

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -65,6 +65,10 @@ export default defineEventHandler(async (event) => {
     && config.cachedRoutes.some(rule => ruleMatchesPath(rule, pathname))) {
     const index = event.path.indexOf('?')
     setResponseHeader(event, 'Vary', MARKDOWN_VARY)
+    // Reaching here means the CDN routes did not answer, so this response is
+    // about to enter the very cache the redirect exists to avoid: it would be
+    // stored under the path alone and replayed to browsers. Refuse the store.
+    setResponseHeader(event, 'Cache-Control', 'private, no-store')
     return sendRedirect(event, index === -1 ? rawPath : `${rawPath}${event.path.slice(index)}`, 307)
   }
 

--- a/src/runtime/server/middleware/negotiate.ts
+++ b/src/runtime/server/middleware/negotiate.ts
@@ -65,9 +65,14 @@ export default defineEventHandler(async (event) => {
     && config.cachedRoutes.some(rule => ruleMatchesPath(rule, pathname))) {
     const index = event.path.indexOf('?')
     setResponseHeader(event, 'Vary', MARKDOWN_VARY)
-    // Reaching here means the CDN routes did not answer, so this response is
-    // about to enter the very cache the redirect exists to avoid: it would be
-    // stored under the path alone and replayed to browsers. Refuse the store.
+    // Reaching here means no CDN route answered, so this redirect is about to
+    // enter the very cache it exists to avoid, stored under the path alone and
+    // replayed to browsers. The label is for the caches that read it: a shared
+    // cache in front of another preset, and the client. It is not a guard on
+    // Vercel, where a route backed by a prerender function stores on its own
+    // expiration and hands this same response back on a `HIT` (measured on a
+    // preview, 2026-09-09). The Build Output routes are what keep a cached page
+    // off this branch, see `vercelMarkdownRoutes`.
     setResponseHeader(event, 'Cache-Control', 'private, no-store')
     return sendRedirect(event, index === -1 ? rawPath : `${rawPath}${event.path.slice(index)}`, 307)
   }

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -84,7 +84,11 @@ export function compilePattern(pattern: string, options: { capture?: boolean } =
       } else {
         source += `${open}[^/]+)`
       }
-      captures++
+      // Counted only when it is really there, so the number always describes
+      // the source that came back with it.
+      if (options.capture !== false) {
+        captures++
+      }
     } else {
       source += REGEX_SPECIALS.test(char) ? `\\${char}` : char
     }

--- a/src/runtime/shared/negotiation.ts
+++ b/src/runtime/shared/negotiation.ts
@@ -66,18 +66,23 @@ const REGEX_SPECIALS = /[.+?^${}()|[\]\\]/
  * wildcard: `*` matches one segment, `**` one or more. A trailing slash is
  * matched but never captured, because the CDN tests this against the raw
  * request path and a captured slash rewrites `/docs/x/` to `/raw/docs/x/.md`.
+ *
+ * `capture: false` emits the same source with non-capturing groups, for the
+ * lookaheads the Vercel preset embeds in another pattern's `src`, where a
+ * capture of its own would shift the `$1` references in the destination.
  */
-export function compilePattern(pattern: string): { source: string, captures: number } {
+export function compilePattern(pattern: string, options: { capture?: boolean } = {}): { source: string, captures: number } {
+  const open = options.capture === false ? '(?:' : '('
   let source = ''
   let captures = 0
   for (let i = 0; i < pattern.length; i++) {
     const char = pattern[i]!
     if (char === '*') {
       if (pattern[i + 1] === '*') {
-        source += '(.+?)'
+        source += `${open}.+?)`
         i++
       } else {
-        source += '([^/]+)'
+        source += `${open}[^/]+)`
       }
       captures++
     } else {

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -181,21 +181,27 @@ describe('vercel build output', () => {
     const patterns = 2 // `routes: ['/', '/**']`
     const exact = 1 // `/`
     const cachedRules = 2 // `/docs/components/**`, plus `/docs/late/**` from `nitro:config`
+    const sectionRoots = 2 // `/docs/components` and `/docs/late`, which `**` covers
     const headerRoutes = 3 // `Vary` on the pages, `Vary` on the markdown twins, `Link`
     const refusals = 1 // `notAcceptable: true` in the fixture
     // Per pattern: an `Accept` route and a User-Agent route, plus a `.md` alias
     // for a wildcard. Per cached rule narrower than the pattern over it: its own
-    // redirect pair. The canonical pair on the twins sits in the `hit` phase at
-    // the end of the table, see below.
-    expect(count).toBe(headerRoutes + refusals + patterns * 2 + (patterns - exact) + cachedRules * 2)
+    // redirect pair, and a second one for the root its `**` covers but its
+    // compiled pattern cannot match. The canonical pair on the twins sits in the
+    // `hit` phase at the end of the table, see below.
+    expect(count).toBe(headerRoutes + refusals + patterns * 2 + (patterns - exact) + cachedRules * 2 + sectionRoots * 2)
   })
 
   // The cache-correctness path, asserted against real emitted output rather
   // than the pure function, because the module has to read the site's route
   // rules to know the section is cached at all.
   it('redirects the cached section and rewrites everything else', () => {
+    // Two rules, and each one needs a pair for what its `**` matches plus a
+    // pair for the section root, which `**` covers and the pattern cannot.
     const cached = routes.filter(route => route.status === 307)
-    expect(cached).toHaveLength(4)
+    expect(cached).toHaveLength(8)
+    expect(cached.filter(route => route.headers?.Location === '/raw/docs/components.md')).toHaveLength(2)
+    expect(cached.filter(route => route.headers?.Location === '/raw/docs/late.md')).toHaveLength(2)
 
     const components = cached.filter(route => route.headers?.Location === '/raw/docs/components/$1.md')
     expect(components).toHaveLength(2)
@@ -259,5 +265,73 @@ describe('vercel build output', () => {
     expect(existsSync(`${outputDir}static/raw/index.md`)).toBe(true)
     expect(existsSync(`${outputDir}static/sitemap.md`)).toBe(true)
     expect(existsSync(`${outputDir}static/llms.txt`)).toBe(true)
+  })
+})
+
+/**
+ * `vercel build` does not deploy this table as written. It regroups the routes
+ * ahead of the filesystem phase into `continue: true` first, then the
+ * `check: true` rewrites, then the rest, keeping the relative order inside each
+ * group. That hoisted the catch-all rewrite above the redirects of every cached
+ * rule under it, and a cached page went to the origin, whose own 307 the
+ * response cache stored under the path alone.
+ *
+ * Every assertion above reads the order the module wrote. These read the order
+ * Vercel serves, which is where that bug lived.
+ */
+describe('vercel build output: regrouped the way it is deployed', () => {
+  const kindOf = (route: VercelRoute) => route.continue ? 0 : route.check ? 1 : 2
+
+  function deployed(): VercelRoute[] {
+    const filesystem = routes.findIndex(route => route.handle === 'filesystem')
+    const initial = filesystem === -1 ? [...routes] : routes.slice(0, filesystem)
+    return [0, 1, 2].flatMap(kind => initial.filter(route => kindOf(route) === kind))
+  }
+
+  /**
+   * What a known agent's request lands on: the first route that stops routing
+   * and either matches on the user agent or takes no header matcher at all.
+   * The 406 is neither, since it names the agent under `missing`.
+   */
+  function agentAnswer(table: VercelRoute[], path: string): VercelRoute | undefined {
+    return table.find(route => !route.continue
+      && Boolean(route.src)
+      && (!route.has || route.has.some(entry => entry.key === 'user-agent'))
+      && new RegExp(route.src!).test(path))
+  }
+
+  it('sends every cached path to its redirect, not to the catch-all', () => {
+    const table = deployed()
+
+    // The section roots included: `**` caches them and the wildcard pattern
+    // cannot match them, so they need a redirect of their own to land on.
+    for (const path of ['/docs/components/button', '/docs/components', '/docs/late/x', '/docs/late']) {
+      const answer = agentAnswer(table, path)
+      expect(answer, path).toBeDefined()
+      expect(answer!.status, path).toBe(307)
+      expect(destinationOf(answer!), path).toMatch(/^\/raw\//)
+    }
+  })
+
+  it('still rewrites a page no cached rule covers', () => {
+    const answer = agentAnswer(deployed(), '/docs/getting-started')
+
+    expect(answer?.dest).toBe('/raw/$1.md')
+    expect(answer?.check).toBe(true)
+    expect(answer?.status).toBeUndefined()
+  })
+
+  // The invariant behind both, and the one that does not depend on knowing how
+  // the regrouping works: a rewrite never claims a path a redirect answers.
+  it('never lets a rewrite claim a path a redirect answers', () => {
+    const rewritesWithMatcher = routes.filter(route => route.dest?.startsWith('/raw/') && route.has)
+    const redirects = routes.filter(route => route.status === 307 && route.src)
+
+    for (const path of ['/docs/components/button', '/docs/components', '/docs/late/x', '/docs/late']) {
+      expect(redirects.some(route => new RegExp(route.src!).test(path)), path).toBe(true)
+      for (const rewrite of rewritesWithMatcher) {
+        expect(new RegExp(rewrite.src!).test(path), `${rewrite.src} claims ${path}`).toBe(false)
+      }
+    }
   })
 })

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -526,6 +526,42 @@ describe('vercelMarkdownRoutes: cached routes', () => {
     }
   })
 
+  // The lookahead spells the trailing slash, so a redirect that does not is a
+  // path both halves refuse, which lands on the origin the pair exists to
+  // spare. comark-docs writes an exact rule beside the wildcard for every
+  // content section, so that is a section root per section.
+  it('redirects an exact cached rule with or without its trailing slash', () => {
+    const alone = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/**' }],
+      cachedRoutes: ['/changelog']
+    }))
+
+    for (const path of ['/changelog', '/changelog/']) {
+      const hit = alone.filter(route => matches(route, path))
+      expect(hit.filter(route => route.dest), path).toHaveLength(0)
+      const redirects = hit.filter(route => route.status === 307)
+      expect(redirects, path).toHaveLength(2)
+      expect(redirects.every(route => route.headers?.Location === '/raw/changelog.md'), path).toBe(true)
+    }
+  })
+
+  it('redirects a section root with or without its trailing slash', () => {
+    // The exact rule answers the root here, so the wildcard beside it must not
+    // add a second pair on either spelling.
+    const paired = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/**' }],
+      cachedRoutes: ['/docs', '/docs/**']
+    }))
+
+    for (const path of ['/docs', '/docs/']) {
+      const hit = paired.filter(route => matches(route, path))
+      expect(hit.filter(route => route.dest), path).toHaveLength(0)
+      const redirects = hit.filter(route => route.status === 307)
+      expect(redirects, path).toHaveLength(2)
+      expect(redirects.every(route => route.headers?.Location === '/raw/docs.md'), path).toBe(true)
+    }
+  })
+
   it('leaves a section root that is answered already', () => {
     // An exact rule beside the wildcard, which is how a site that lists its
     // sections writes them, and the root must not collect two redirects.

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -477,6 +477,47 @@ describe('vercelMarkdownRoutes: cached routes', () => {
     expect(matches(cached[0]!, '/about')).toBe(false)
   })
 
+  // `vercel build` regroups the table it deploys and hoists a `check: true`
+  // rewrite above the plain redirects, so the catch-all used to swallow every
+  // cached page: `check` found no static twin, the request fell through to the
+  // function, and its 307 was cached under the path alone. The rewrite has to
+  // refuse those paths itself rather than trusting its position in the array.
+  it('keeps the catch-all rewrite off the paths a cached rule redirects', () => {
+    const routes = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/', raw: '/raw/index.md' }, { path: '/**' }],
+      cachedRoutes: ['/docs/**', '/changelog']
+    }))
+
+    const catchAll = routes.filter(route => route.dest === '/raw/$1.md' && route.has)
+    expect(catchAll).toHaveLength(2)
+    for (const route of catchAll) {
+      for (const path of ['/docs', '/docs/guide', '/docs/api/x', '/changelog']) {
+        expect(matches(route, path)).toBe(false)
+      }
+      // Everything else still rewrites, and the lookahead leaves `$1` alone.
+      expect(matches(route, '/about')).toBe(true)
+      expect(rewrite(route, '/about')).toBe('/raw/about.md')
+      expect(rewrite(route, '/blog/hello')).toBe('/raw/blog/hello.md')
+    }
+
+    // Each of those paths still has a redirect of its own to fall on.
+    for (const path of ['/docs/guide', '/changelog']) {
+      expect(routes.some(route => route.status === 307 && matches(route, path))).toBe(true)
+    }
+  })
+
+  it('leaves the rewrite alone when no cached rule overlaps it', () => {
+    const routes = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/blog/**' }],
+      cachedRoutes: ['/docs/**']
+    }))
+
+    const catchAll = routes.filter(route => route.dest === '/raw/blog/$1.md' && route.has)
+    expect(catchAll).toHaveLength(2)
+    expect(catchAll.every(route => !route.src.includes('(?!(?:'))).toBe(true)
+    expect(rewrite(catchAll[0]!, '/blog/hello')).toBe('/raw/blog/hello.md')
+  })
+
   it('redirects the whole pattern when the rule covers it', () => {
     const routes = vercelMarkdownRoutes(createConfig({
       routes: [{ path: '/docs/**' }],

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -468,10 +468,12 @@ describe('vercelMarkdownRoutes: cached routes', () => {
     expect(catchAll.every(route => !route.status)).toBe(true)
     expect(routes.filter(route => route.dest === '/raw/index.md').every(route => !route.status)).toBe(true)
 
-    // The cached section gets its own redirect pair, ahead of that rewrite.
+    // The cached section gets its own redirect pair, ahead of that rewrite,
+    // and a second one for the root the wildcard cannot reach.
     const cached = routes.filter(route => route.status === 307)
-    expect(cached).toHaveLength(2)
-    expect(cached.every(route => route.headers?.Location === '/raw/docs/$1.md')).toBe(true)
+    expect(cached).toHaveLength(4)
+    expect(cached.filter(route => route.headers?.Location === '/raw/docs/$1.md')).toHaveLength(2)
+    expect(cached.filter(route => route.headers?.Location === '/raw/docs.md')).toHaveLength(2)
     expect(routes.indexOf(cached[0]!)).toBeLessThan(routes.indexOf(catchAll[0]!))
     expect(matches(cached[0]!, '/docs/guide')).toBe(true)
     expect(matches(cached[0]!, '/about')).toBe(false)
@@ -500,10 +502,54 @@ describe('vercelMarkdownRoutes: cached routes', () => {
       expect(rewrite(route, '/blog/hello')).toBe('/raw/blog/hello.md')
     }
 
-    // Each of those paths still has a redirect of its own to fall on.
-    for (const path of ['/docs/guide', '/changelog']) {
+    // Each of those paths still has a redirect of its own to fall on. The bare
+    // section root included: refusing it in the rewrite without answering it
+    // here would put it back on the origin, which is what this refusal is for.
+    for (const path of ['/docs', '/docs/guide', '/docs/api/x', '/changelog']) {
       expect(routes.some(route => route.status === 307 && matches(route, path))).toBe(true)
     }
+  })
+
+  // `**` is zero or more segments to the rule matcher, so `/docs/**` caches
+  // `/docs`, while the pattern its redirect compiles wants a segment after the
+  // slash. The root needs an entry of its own or it falls between the two.
+  it('redirects the root of a cached section', () => {
+    const routes = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/**' }],
+      cachedRoutes: ['/docs/**']
+    }))
+
+    for (const path of ['/docs', '/docs/']) {
+      const hit = routes.filter(route => route.status === 307 && matches(route, path))
+      expect(hit).toHaveLength(2)
+      expect(hit.every(route => route.headers?.Location === '/raw/docs.md')).toBe(true)
+    }
+  })
+
+  it('leaves a section root that is answered already', () => {
+    // An exact rule beside the wildcard, which is how a site that lists its
+    // sections writes them, and the root must not collect two redirects.
+    const paired = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/**' }],
+      cachedRoutes: ['/docs', '/docs/**']
+    }))
+    expect(paired.filter(route => route.status === 307 && matches(route, '/docs'))).toHaveLength(2)
+
+    // No route matches the root, so there is no twin to send it to. No rewrite
+    // claims it either, since both compile from the same patterns.
+    const unrouted = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }],
+      cachedRoutes: ['/docs/**']
+    }))
+    expect(unrouted.filter(route => matches(route, '/docs') && (route.status === 307 || route.dest))).toHaveLength(0)
+
+    // An excluded root serves HTML only, so neither half should claim it.
+    const skipped = vercelMarkdownRoutes(createConfig({
+      routes: [{ path: '/' }, { path: '/**' }],
+      excludePrefixes: ['/_', '/api/', '/mcp', '/.well-known/', '/docs'],
+      cachedRoutes: ['/docs/**']
+    }))
+    expect(skipped.filter(route => matches(route, '/docs') && (route.status === 307 || route.dest))).toHaveLength(0)
   })
 
   it('leaves the rewrite alone when no cached rule overlaps it', () => {


### PR DESCRIPTION
`vercel build` doesn't deploy `.vercel/output/config.json` as we write it. It regroups the initial phase: `continue: true` routes first, then `check: true` rewrites, then everything else. A plain `nuxt build` leaves the array alone, so this only shows up on a real deployment.

That hoists the catch-all rewrite above the 307 pair we emit for every cached rule under it. A cached page gets rewritten to its raw twin, `check` finds no static file there because the twin is an ISR function, and the request falls through to Nitro. The runtime's own 307 then lands in the ISR cache, which keys on the path alone and ignores `Vary`, so the next browser gets redirected to markdown and the next agent gets the HTML shell.

Found on comark-docs, where 12 of 16 pages were in one of the two poisoned states during a single sweep. Only `/` still worked, because `^/(.+?)/?$` needs a segment after the slash.

## What changes

Every rewrite now carries a negative lookahead naming the paths the preset answers with a 307, so the split holds whatever order the table ends up in. `compilePattern` gained a `capture: false` option, since a capturing group inside that lookahead would shift `$1` in the destination.

Section roots get a redirect of their own. `**` is zero or more segments to the rule matcher, so `/docs/**` caches `/docs`, while the pattern its pair compiles needs a segment after the slash. Without an entry the root was refused by the rewrite and matched by no redirect, which put it straight back on the origin. A root already answered by an exact rule beside the wildcard, by a cached pattern, or excluded outright, is left alone rather than answered twice.

The redirects also spell the trailing slash the way the lookahead does. The lookahead ends `/?$`, so it refuses `/docs/` as well as `/docs`, while the exact-rule redirect was anchored without it. That left the slash form claimed by neither half and back on the origin, which is the state this PR exists to prevent. It bites hardest on a site that writes an exact rule beside the wildcard for every content section, which is what comark-docs does.

`negotiate.ts` sends `Cache-Control: private, no-store` on the fallback 307. Worth being precise about what that buys, because it is less than it looks: see below.

## How it was checked

Same build output, same reordered table, same project, one variable:

| table | `/docs/getting-started` as ClaudeBot |
| --- | --- |
| reordered, no lookahead | 307, `x-vercel-cache: MISS`, h3 meta refresh body |
| reordered, with lookahead | 307, no `x-vercel-cache`, `Redirecting...` |

The first row is the shape comark's preview returns. The second is an edge redirect. Partitioning the initial phase of a real `vercel build` output by kind gives `000000000112222…`, monotonic, which is the regrouping above.

`test/e2e/vercel.test.ts` now applies that same regrouping to the built table before asserting, since every other assertion in it reads the order the module wrote rather than the order Vercel serves. Disabling the lookahead fails two of the three new cases, so the guard has teeth.

## `no-store` is not a guard on Vercel

Measured on a preview with the edge negotiation stripped out, so the request reaches the function:

| request | result |
| --- | --- |
| ClaudeBot, fresh cache key | 307 to markdown, `x-vercel-cache: MISS`, `cache-control: private, no-store` |
| browser, same key | 307 to markdown, `x-vercel-cache: HIT`, `age: 2` |

A route backed by a prerender function stores on its own expiration and ignores the response header, which it still passes through to the client. So the header is worth keeping for shared caches in front of the other presets, but the Build Output routes are the only thing keeping a cached page off that branch. The comment in `negotiate.ts` says so rather than claiming a refusal it does not get.

## Scope

Needs a broad non-cached pattern whose rewrite overlaps a narrower cached rule, so the default `['/', '/**']` plus per-section ISR. comark-docs has exactly that. nuxt.com lists its routes explicitly with no catch-all and still redirects `/modules` and `/changelog` at the edge, and ui.nuxt.com and docus.dev are fine too. Checked all three live.

One thing I couldn't verify against Vercel's implementation: a failed `check` appears to skip the rest of the initial phase, which is why the redirect routes sitting after the catch-all never got a turn. The control above shows it behaviourally.

