### PR TITLE
fix(vercel): drop the duplicate homepage `Link` route

### DIFF
--- a/src/presets/vercel.ts
+++ b/src/presets/vercel.ts
@@ -337,6 +337,32 @@ export function vercelTwinLinkRoutes(config: NegotiationConfig): VercelRoute[] {
 }
 
 /**
+ * Nitro turns the `/` route rule this module sets into a header route of its
+ * own, and the CDN applies it on top of the `^/$` route above, so the homepage
+ * answers with the whole link set twice. The preset route is the one that stays:
+ * a homepage rewritten to its raw twin never reaches the route rule.
+ *
+ * Only an exact copy of our own header goes, so a site setting a `Link` of its
+ * own on `/` keeps it.
+ */
+export function dropDuplicateLinkRoutes(routes: (VercelRoute | VercelHandle)[], linkHeader: string): void {
+  if (!linkHeader) {
+    return
+  }
+  for (let index = routes.length - 1; index >= 0; index--) {
+    const route = routes[index]!
+    if ('handle' in route || route.src === '^/$' || route.headers?.Link !== linkHeader) {
+      continue
+    }
+    delete route.headers.Link
+    // A rule carrying nothing but the duplicate leaves an inert route behind.
+    if (!Object.keys(route.headers).length && !route.dest && !route.status) {
+      routes.splice(index, 1)
+    }
+  }
+}
+
+/**
  * Patches the Vercel Build Output config after Nitro compiles. We edit
  * `.vercel/output/config.json` (Build Output API v3), not `vercel.json`, which
  * has a different schema. https://vercel.com/docs/build-output-api/configuration
@@ -355,6 +381,7 @@ export function setupVercelPreset(nitro: Nitro, config: NegotiationConfig, colle
     const vcJSON = resolve(nitro.options.output.dir, 'config.json')
     const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8')) as { routes: (VercelRoute | VercelHandle)[] }
     vcConfig.routes.unshift(...vercelMarkdownRoutes(config))
+    dropDuplicateLinkRoutes(vcConfig.routes, config.linkHeader ? formatLinkHeader(config.links) : '')
     // Nitro emits no `hit` phase of its own, so the pair opens one at the end of
     // the table. A phase is a position in the array, so one already there takes
     // the routes instead of a second marker.

--- a/test/e2e/vercel.test.ts
+++ b/test/e2e/vercel.test.ts
@@ -114,6 +114,17 @@ describe('vercel build output', () => {
     expect(linkRoute!.headers?.Link).toContain('</>; rel="alternate"; type="text/markdown"')
   })
 
+  // Nitro turns the `/` route rule the module sets into a header route of its
+  // own, and the CDN applies both, so without the dedupe the homepage answers
+  // with every discovery link twice.
+  it('carries the homepage `Link` on exactly one route', () => {
+    const linkRoute = routes.find(route => route.src === '^/$' && route.continue === true)
+    const carrying = routes.filter(route => route.headers?.Link === linkRoute!.headers?.Link)
+
+    expect(carrying).toHaveLength(1)
+    expect(routes.some(route => route.src === '/' && route.headers?.Link)).toBe(false)
+  })
+
   it('negotiates on the `Accept` header', () => {
     // The 406 matches on `Accept` too, but to refuse rather than to resolve a
     // twin, so it is not one of the routes this asserts about.

--- a/test/unit/vercel.test.ts
+++ b/test/unit/vercel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { vercelMarkdownRoutes, vercelTwinLinkRoutes } from '../../src/presets/vercel'
-import type { VercelRoute } from '../../src/presets/vercel'
+import { dropDuplicateLinkRoutes, vercelMarkdownRoutes, vercelTwinLinkRoutes } from '../../src/presets/vercel'
+import type { VercelHandle, VercelRoute } from '../../src/presets/vercel'
 import { acceptsMarkdown, formatLinkHeader, MARKDOWN_VARY } from '../../src/runtime/shared/negotiation'
 import type { NegotiationConfig } from '../../src/runtime/shared/types'
 
@@ -232,6 +232,59 @@ describe('vercelMarkdownRoutes: Link', () => {
     // The canonical/alternate pairs on the twins stay; only the homepage
     // discovery route is keyed on the registry.
     expect(routes.filter(route => route.src === '^/$' && route.headers?.Link)).toHaveLength(0)
+  })
+})
+
+describe('dropDuplicateLinkRoutes', () => {
+  const linkHeader = formatLinkHeader(LINKS)
+
+  /** Our own routes, plus what Nitro emits for the `/` route rule the module sets. */
+  function table(): (VercelRoute | VercelHandle)[] {
+    return [
+      ...vercelMarkdownRoutes(createConfig({ links: LINKS })),
+      { src: '/', headers: { Link: linkHeader, Vary: MARKDOWN_VARY } },
+      { handle: 'filesystem' }
+    ]
+  }
+
+  it('leaves the homepage answering with the link set once', () => {
+    const routes = table()
+    dropDuplicateLinkRoutes(routes, linkHeader)
+
+    const carrying = routes.filter(route => !('handle' in route) && route.headers?.Link === linkHeader) as VercelRoute[]
+    expect(carrying).toHaveLength(1)
+    expect(carrying[0]!.src).toBe('^/$')
+  })
+
+  it('keeps the rest of the route rule it came from', () => {
+    const routes = table()
+    dropDuplicateLinkRoutes(routes, linkHeader)
+
+    const rule = routes.find(route => !('handle' in route) && route.src === '/') as VercelRoute
+    expect(rule.headers).toEqual({ Vary: MARKDOWN_VARY })
+  })
+
+  it('removes a route the duplicate leaves empty', () => {
+    const routes: (VercelRoute | VercelHandle)[] = [{ src: '/', headers: { Link: linkHeader } }]
+    dropDuplicateLinkRoutes(routes, linkHeader)
+
+    expect(routes).toHaveLength(0)
+  })
+
+  it('leaves a site\'s own homepage `Link` alone', () => {
+    const own = '</feed.xml>; rel="alternate"'
+    const routes: (VercelRoute | VercelHandle)[] = [{ src: '/', headers: { Link: own } }]
+    dropDuplicateLinkRoutes(routes, linkHeader)
+
+    expect(routes).toEqual([{ src: '/', headers: { Link: own } }])
+  })
+
+  it('does nothing when the header is off', () => {
+    const routes = table()
+    const before = structuredClone(routes)
+    dropDuplicateLinkRoutes(routes, '')
+
+    expect(routes).toEqual(before)
   })
 })
 


### PR DESCRIPTION
The module sets a `Link` route rule on `/`, and Nitro turns that into a header route of its own in the Build Output table. The CDN applies both that route and the `^/$` one the preset emits, so the homepage answers with the whole discovery link set twice.

Visible on the comark-docs preview today: `GET /` comes back with 20 link values, which is the same 10 repeated.

The preset route is the one that stays. A homepage rewritten to its raw twin never reaches the route rule, so dropping ours instead would lose the header exactly where it is still needed. Only an exact copy of our own header goes, so a site setting a `Link` of its own on `/` keeps it, and a route left carrying nothing else is removed rather than left inert.

Tests cover the four cases: the link set appears once, the rest of the route rule survives, an emptied route is dropped, and a site's own header is untouched.
