### PR TITLE
feat(skills): follow `llms.prerender` for the skills routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ coverage
 
 .claude
 
+.history
+
 .nuxt
 .output
 .data

--- a/README.md
+++ b/README.md
@@ -208,21 +208,7 @@ A single string works too. The blocks are joined with a blank line and rendered 
 
 ### Prerendering
 
-On a backend resolving content per request, prerendered agent documents go stale without a redeploy. `llms.prerender` turns that off ([nuxt-llms#53](https://github.com/nuxt-content/nuxt-llms/pull/53)), and this module's skill files follow the same switch, so one option governs the agent documents a site publishes:
-
-```ts
-export default defineNuxtConfig({
-  llms: {
-    prerender: false
-  }
-})
-```
-
-The skill files are bundled server assets either way, so turning their prerender off moves static files onto the server rather than making them fresher. It is there so one option covers both. A static build has no server to answer them per request, so `nuxt generate` prerenders them whatever the option says.
-
-Worth knowing before you set it: the crawler is handed the twins of pages that never render as HTML while `/llms.txt` is being prerendered, so opting `/llms.txt` out drops those twins from the build as well.
-
-That option is merged but unreleased, so on `nuxt-llms` 0.2.0 and earlier it governs the skill files only and `llms.txt` keeps prerendering. Until it ships, opt those two routes out directly:
+On a backend resolving content per request, prerendered agent documents go stale without a redeploy. `nuxt-llms` 0.2.0 prerenders `llms.txt` and `llms-full.txt` unconditionally, so opt them out through Nitro:
 
 ```ts
 export default defineNuxtConfig({
@@ -233,6 +219,22 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+`llms.prerender` replaces that once it ships ([nuxt-llms#53](https://github.com/nuxt-content/nuxt-llms/pull/53)), and this module's skill files already follow it, so one option covers `llms.txt` and the skills together:
+
+```ts
+export default defineNuxtConfig({
+  llms: {
+    prerender: false
+  }
+})
+```
+
+It is merged but unreleased, so on 0.2.0 and earlier it governs the skill files only, and it fails `nuxt typecheck` there since the released options carry no `prerender` key.
+
+The skill files are bundled server assets either way, so turning their prerender off moves static files onto the server rather than making them fresher. It is there so one option covers both. The raw twins and `/sitemap.md` keep their own rule and prerender whatever it says: they come from the built-in `@nuxt/content` source, which compiles the content into the build. A static build has no server at all, so `nuxt generate` prerenders the skill files however the option is set.
+
+Worth knowing before you set it: the crawler is handed the twins of pages that never render as HTML while `/llms.txt` is being prerendered, so opting `/llms.txt` out drops those twins from the build as well.
 
 ## Extending
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ export default defineNuxtConfig({
 - **`notAcceptable`** See [Strict content negotiation](#strict-content-negotiation).
 - **`sitemap.markdown`** Serve `/sitemap.md` from the content adapter. Pass an object to control grouping: `expand` lists prefixes whose children each get their own section, `labels` overrides derived headings.
 - **`llms.details`** Markdown blocks for the details section of `llms.txt`, the space llmstxt.org reserves between the blockquote and the first `##`. See [llms.txt sections](#llmstxt-sections).
-- **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with a `description` becomes a skill, its files listed from disk into a generated index. `false` to disable.
+- **`skills`** Agent Skills served under `/.well-known/skills/`. Each subdirectory of `dir` holding a `SKILL.md` with a `description` becomes a skill, its files listed from disk into a generated index. `false` to disable. The index and the files are prerendered unless `llms.prerender` is off, see [Prerendering](#prerendering).
 - **`robots.aiPolicy`** Feeds the user-agent list into `@nuxtjs/robots` when installed, otherwise generates `/robots.txt` (skipped when a static one exists). **`robots.contentSignal`** adds the `Content-Signal` line, `false` to omit. **`robots.disallow`** adds `Disallow` lines to the wildcard group, in the generated file and through `@nuxtjs/robots` alike. Wildcard only: the per-agent `Allow` groups exempt their agents from these rules, so what search engines skip stays reachable for the agents the site names.
 
 ## Routes
@@ -116,7 +116,7 @@ export default defineNuxtConfig({
 
 `/llms.txt` and `/llms-full.txt` belong to `nuxt-llms`; this module feeds them but never registers them.
 
-With the built-in `@nuxt/content` source, the raw twin of every exact route pattern (the locale roots of an i18n site included) and `/sitemap.md` are prerendered, and the `nuxt-llms` bridge hands Nitro's crawler every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. Whatever the source, every prerendered page hands the crawler its own twin, so a twin is frozen exactly when its page is. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is never prerendered, so it keeps answering per request instead of being frozen at build. A hinted twin the raw route cannot answer as markdown, a section redirecting to its first document or a page with no document behind it, is skipped rather than written or reported as a failed route.
+The skills index and the skill files are prerendered too, unless `llms.prerender` is off, see [Prerendering](#prerendering). With the built-in `@nuxt/content` source, the raw twin of every exact route pattern (the locale roots of an i18n site included) and `/sitemap.md` are prerendered, and the `nuxt-llms` bridge hands Nitro's crawler every twin `llms.txt` links when `/` is prerendered too. On a fully static build (`nuxt generate`) they are prerendered whatever the source, since there is no server to render them per request. Whatever the source, every prerendered page hands the crawler its own twin, so a twin is frozen exactly when its page is. A twin the site backs with a handler of its own (a `server/routes/raw/modules.md.get.ts` reading live data, or a handler another module registered on that route) is never prerendered, so it keeps answering per request instead of being frozen at build. A hinted twin the raw route cannot answer as markdown, a section redirecting to its first document or a page with no document behind it, is skipped rather than written or reported as a failed route.
 
 ### The raw route
 
@@ -206,7 +206,9 @@ export default defineNuxtConfig({
 
 A single string works too. The blocks are joined with a blank line and rendered after the blockquote, so they need `llms.description` set, which is what they follow. Headings are not allowed there: one would open a section and pull every link list under it, and the module warns at build when it finds one.
 
-On a backend resolving content per request, prerendered agent documents go stale without a redeploy. `llms.prerender` turns them off ([nuxt-llms#53](https://github.com/nuxt-content/nuxt-llms/pull/53)), and this module's skill files follow the same switch:
+### Prerendering
+
+On a backend resolving content per request, prerendered agent documents go stale without a redeploy. `llms.prerender` turns that off ([nuxt-llms#53](https://github.com/nuxt-content/nuxt-llms/pull/53)), and this module's skill files follow the same switch, so one option governs the agent documents a site publishes:
 
 ```ts
 export default defineNuxtConfig({
@@ -215,6 +217,10 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+The skill files are bundled server assets either way, so turning their prerender off moves static files onto the server rather than making them fresher. It is there so one option covers both. A static build has no server to answer them per request, so `nuxt generate` prerenders them whatever the option says.
+
+Worth knowing before you set it: the crawler is handed the twins of pages that never render as HTML while `/llms.txt` is being prerendered, so opting `/llms.txt` out drops those twins from the build as well.
 
 That option is merged but unreleased, so on `nuxt-llms` 0.2.0 and earlier it governs the skill files only and `llms.txt` keeps prerendering. Until it ships, opt those two routes out directly:
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,17 @@ export default defineNuxtConfig({
 
 A single string works too. The blocks are joined with a blank line and rendered after the blockquote, so they need `llms.description` set, which is what they follow. Headings are not allowed there: one would open a section and pull every link list under it, and the module warns at build when it finds one.
 
-`nuxt-llms` prerenders both documents unconditionally, so on a backend resolving content per request they go stale without a redeploy ([nuxt-llms#24](https://github.com/nuxtlabs/nuxt-llms/issues/24)). Until that lands, opt the two routes out yourself:
+On a backend resolving content per request, prerendered agent documents go stale without a redeploy. `llms.prerender` turns them off ([nuxt-llms#53](https://github.com/nuxt-content/nuxt-llms/pull/53)), and this module's skill files follow the same switch:
+
+```ts
+export default defineNuxtConfig({
+  llms: {
+    prerender: false
+  }
+})
+```
+
+That option is merged but unreleased, so on `nuxt-llms` 0.2.0 and earlier it governs the skill files only and `llms.txt` keeps prerendering. Until it ships, opt those two routes out directly:
 
 ```ts
 export default defineNuxtConfig({

--- a/src/module.ts
+++ b/src/module.ts
@@ -594,12 +594,13 @@ export {}
       addServerHandler({ route: SKILLS_INDEX, handler: resolve('./runtime/server/routes/skills-index') })
       addServerHandler({ route: `${SKILLS_PREFIX}**`, handler: resolve('./runtime/server/routes/skills-files') })
 
-      // The skill files follow `llms.prerender`, so one switch governs every
-      // agent document a site publishes. A static build has no server to answer
-      // them per request, so there everything advertised is prerendered
-      // whatever the option says, the same invariant the raw twins hold below.
-      // At `modules:done`, since the option is only settled once every module
-      // has installed.
+      // The skill files follow `llms.prerender`, so one switch covers them and
+      // `llms.txt` together. The raw twins and `/sitemap.md` keep their own rule
+      // below, where the built-in source compiles the content into the build
+      // anyway. A static build has no server to answer these per request, so
+      // there everything advertised is prerendered whatever the option says,
+      // the same invariant the raw twins hold. At `modules:done`, since the
+      // option is only settled once every module has installed.
       nuxt.hook('modules:done', () => {
         if (llmsOptions(nuxt).prerender === false && !staticBuild) {
           return

--- a/src/module.ts
+++ b/src/module.ts
@@ -571,10 +571,14 @@ export {}
 
       addServerHandler({ route: SKILLS_INDEX, handler: resolve('./runtime/server/routes/skills-index') })
       addServerHandler({ route: `${SKILLS_PREFIX}**`, handler: resolve('./runtime/server/routes/skills-files') })
-      addPrerenderRoutes([
-        SKILLS_INDEX,
-        ...skills.flatMap(skill => skill.files.map(file => `${SKILLS_PREFIX}${skill.name}/${file}`))
-      ])
+
+      const llmsOptions = (nuxt.options as { llms?: { prerender?: boolean } }).llms
+      if (llmsOptions?.prerender !== false) {
+        addPrerenderRoutes([
+          SKILLS_INDEX,
+          ...skills.flatMap(skill => skill.files.map(file => `${SKILLS_PREFIX}${skill.name}/${file}`))
+        ])
+      }
     }
 
     /* ---------------------------- nuxt-llms bridge ------------------------- */

--- a/src/module.ts
+++ b/src/module.ts
@@ -175,6 +175,28 @@ function hasActiveNuxtModule(nuxt: Nuxt, name: string, configKey: string): boole
   return moduleOptions !== false && moduleOptions?.enabled !== false
 }
 
+/** What this module reads off the `nuxt-llms` options, a subset of them. */
+interface LlmsOptions {
+  domain?: string
+  description?: string
+  full?: unknown
+  prerender?: boolean
+}
+
+/**
+ * The `nuxt-llms` options the way that module resolves them, which is
+ * `defu(inlineOptions, nuxt.options.llms)`. Nuxt merges inline module options
+ * back into the config key only for a module another module extended, so a site
+ * writing `modules: [['nuxt-llms', { ... }]]` leaves `nuxt.options.llms` unset
+ * and the key alone answers for a configuration nobody wrote. Call at
+ * `modules:done`: a module installed after this one may set the key.
+ */
+function llmsOptions(nuxt: Nuxt): LlmsOptions {
+  const entry = nuxt.options.modules?.find(module => Array.isArray(module) && module[0] === 'nuxt-llms')
+  const inline = Array.isArray(entry) ? entry[1] as LlmsOptions | undefined : undefined
+  return defu(inline || {}, (nuxt.options as { llms?: LlmsOptions }).llms || {})
+}
+
 /** What this module reads off `nuxt.options.i18n`, a subset of the `@nuxtjs/i18n` options. */
 interface I18nOptions {
   locales?: (string | { code?: string })[]
@@ -572,13 +594,21 @@ export {}
       addServerHandler({ route: SKILLS_INDEX, handler: resolve('./runtime/server/routes/skills-index') })
       addServerHandler({ route: `${SKILLS_PREFIX}**`, handler: resolve('./runtime/server/routes/skills-files') })
 
-      const llmsOptions = (nuxt.options as { llms?: { prerender?: boolean } }).llms
-      if (llmsOptions?.prerender !== false) {
+      // The skill files follow `llms.prerender`, so one switch governs every
+      // agent document a site publishes. A static build has no server to answer
+      // them per request, so there everything advertised is prerendered
+      // whatever the option says, the same invariant the raw twins hold below.
+      // At `modules:done`, since the option is only settled once every module
+      // has installed.
+      nuxt.hook('modules:done', () => {
+        if (llmsOptions(nuxt).prerender === false && !staticBuild) {
+          return
+        }
         addPrerenderRoutes([
           SKILLS_INDEX,
           ...skills.flatMap(skill => skill.files.map(file => `${SKILLS_PREFIX}${skill.name}/${file}`))
         ])
-      }
+      })
     }
 
     /* ---------------------------- nuxt-llms bridge ------------------------- */
@@ -659,12 +689,14 @@ export {}
     }
 
     nuxt.hook('modules:done', async () => {
+      const llms = llmsOptions(nuxt)
+
       // Prerendered documents bake the site URL in, so resolve it from the
       // site config or the llms domain. Request-time responses still fall
       // back to the incoming host.
-      const siteOptions = nuxt.options as { site?: { url?: string, name?: string }, llms?: { domain?: string } }
+      const siteOptions = nuxt.options as { site?: { url?: string, name?: string } }
       if (!config.siteUrl) {
-        config.siteUrl = (siteOptions.site?.url || siteOptions.llms?.domain || '').replace(/\/$/, '')
+        config.siteUrl = (siteOptions.site?.url || llms.domain || '').replace(/\/$/, '')
       }
       if (!config.siteName) {
         config.siteName = siteOptions.site?.name || ''
@@ -700,7 +732,7 @@ export {}
         if (llmsDetails.length) {
           // The details follow the blockquote, so without one there is nothing
           // for them to follow and `nuxt-llms` renders neither.
-          if ((nuxt.options as { llms?: { description?: string } }).llms?.description) {
+          if (llms.description) {
             config.llmsDetails = llmsDetails
           } else {
             logger.warn('`llms.details` needs `llms.description`, which is the blockquote the details section follows. Set it, or move the prose into a `llms.sections` entry.')
@@ -754,12 +786,11 @@ export {}
         }
       }
       if (hasLlms) {
-        const llms = (nuxt.options as { llms?: { full?: unknown } }).llms
         links.push(
           { href: '/llms.txt', rel: 'describedby', type: 'text/plain', title: 'llms.txt: index of the documentation for LLMs' },
           { href: '/llms.txt', rel: 'service-desc', type: 'text/plain', anchor: '/', header: false }
         )
-        if (llms?.full) {
+        if (llms.full) {
           links.push(
             { href: '/llms-full.txt', rel: 'describedby', type: 'text/plain', title: 'llms-full.txt: the full documentation as a single file' },
             { href: '/llms-full.txt', rel: 'service-desc', type: 'text/plain', anchor: '/', header: false }

--- a/test/fixtures/unit-skills/skills/not-a-skill/README.md
+++ b/test/fixtures/unit-skills/skills/not-a-skill/README.md
@@ -1,0 +1,1 @@
+ignored

--- a/test/fixtures/unit-skills/skills/writing/SKILL.md
+++ b/test/fixtures/unit-skills/skills/writing/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: writing
+description: Fixture agent skill for the module unit tests, which pin the prerender list.
+---
+
+# Writing
+
+Guidance an agent would load before working with this fixture.

--- a/test/fixtures/unit-skills/skills/writing/references/style.md
+++ b/test/fixtures/unit-skills/skills/writing/references/style.md
@@ -1,0 +1,3 @@
+# Style
+
+A reference file, listed in the generated index.

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -70,10 +70,13 @@ type FakeNuxt = ReturnType<typeof createNuxt>
 /**
  * One full module setup. `installLate` runs between `setup()` and
  * `modules:done`, which is where Nuxt installs a module's declarative
- * `moduleDependencies`.
+ * `moduleDependencies`. `nuxtOptions` is config another module owns, `llms` and
+ * `nitro.static` above all, which a site writes in `nuxt.config` and `setup()`
+ * reads back off `nuxt.options`.
  */
-async function runModule(options: Partial<ModuleOptions> = {}, routeRules: Record<string, unknown> = {}, installLate?: (nuxt: FakeNuxt) => void, preInstall?: (nuxt: FakeNuxt) => void): Promise<FakeNuxt> {
+async function runModule(options: Partial<ModuleOptions> = {}, routeRules: Record<string, unknown> = {}, installLate?: (nuxt: FakeNuxt) => void, preInstall?: (nuxt: FakeNuxt) => void, nuxtOptions: Record<string, unknown> = {}): Promise<FakeNuxt> {
   const nuxt = createNuxt(routeRules)
+  Object.assign(nuxt.options, nuxtOptions)
   // Stands in for a module listed before this one: its hooks register first.
   preInstall?.(nuxt)
   // `set`, not `callAsync`: unctx only restores an async context in code the
@@ -105,49 +108,71 @@ describe('module setup: notAcceptable', () => {
 })
 
 describe('module setup: skills', () => {
-  const dir = '../basic/skills'
+  // A fixture of its own: reaching into the `basic` e2e skills would tie these
+  // exact lists to a directory another suite is free to grow.
+  const dir = '../unit-skills/skills'
 
-  async function prerendered(llms?: { prerender?: boolean }): Promise<string[]> {
-    const nuxt = await runModule({ skills: { dir } }, {}, undefined, (nuxt) => {
-      if (llms) {
-        (nuxt.options as { llms?: unknown }).llms = llms
-      }
-    })
+  const queued = [
+    '/.well-known/skills/index.json',
+    '/.well-known/skills/writing/SKILL.md',
+    '/.well-known/skills/writing/references/style.md'
+  ]
+
+  function setupSkills(nuxtOptions: Record<string, unknown> = {}): Promise<FakeNuxt> {
+    return runModule({ skills: { dir } }, {}, undefined, undefined, nuxtOptions)
+  }
+
+  async function prerendered(nuxt: FakeNuxt): Promise<string[]> {
     const routes = new Set<string>()
     await nuxt.hooks.callHook('prerender:routes' as never, { routes } as never)
     return [...routes].filter(route => route.startsWith('/.well-known/skills'))
   }
 
   it('prerenders the index and every skill file by default', async () => {
-    expect(await prerendered()).toEqual([
-      '/.well-known/skills/index.json',
-      '/.well-known/skills/basic-site/SKILL.md',
-      '/.well-known/skills/basic-site/references/conventions.md'
-    ])
+    expect(await prerendered(await setupSkills())).toEqual(queued)
   })
 
-  it('queues nothing when `llms.prerender` is off', async () => {
-    expect(await prerendered({ prerender: false })).toEqual([])
+  it('prerenders when `llms` carries no `prerender`, and when it is on', async () => {
+    expect(await prerendered(await setupSkills({ llms: {} }))).toEqual(queued)
+    expect(await prerendered(await setupSkills({ llms: { prerender: true } }))).toEqual(queued)
   })
 
-  it('prerenders when `llms` is configured without `prerender`', async () => {
-    expect(await prerendered({})).toHaveLength(3)
-  })
-
-  it('still serves and advertises the skills when prerendering is off', async () => {
-    const nuxt = await runModule({ skills: { dir } }, {}, undefined, (nuxt) => {
-      (nuxt.options as { llms?: unknown }).llms = { prerender: false }
-    })
+  it('queues nothing when `llms.prerender` is off, and still serves and advertises the skills', async () => {
+    const nuxt = await setupSkills({ llms: { prerender: false } })
     const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
 
+    expect(await prerendered(nuxt)).toEqual([])
     expect(nuxt.options.serverHandlers.map(handler => handler.route)).toEqual(
       expect.arrayContaining(['/.well-known/skills/index.json', '/.well-known/skills/**'])
     )
     expect((nuxt.options.runtimeConfig.agentDiscoverySkills as { skills: { name: string }[] }).skills.map(skill => skill.name))
-      .toEqual(['basic-site'])
+      .toEqual(['writing'])
     expect(config.links.map(link => link.href)).toEqual(
-      expect.arrayContaining(['/.well-known/skills/index.json', '/.well-known/skills/basic-site/SKILL.md'])
+      expect.arrayContaining(['/.well-known/skills/index.json', '/.well-known/skills/writing/SKILL.md'])
     )
+  })
+
+  // `nuxt-llms` merges its inline module options over the config key, so a site
+  // configuring it there leaves `nuxt.options.llms` unwritten and the config key
+  // alone answers for a configuration nobody set.
+  it('reads `prerender` off the inline `nuxt-llms` module options', async () => {
+    expect(await prerendered(await setupSkills({ modules: [['nuxt-llms', { prerender: false }]] }))).toEqual([])
+  })
+
+  // A static build has no server to answer the routes the links keep
+  // advertising, so the option cannot take the files out of the output.
+  it('prerenders on a static build whatever `llms.prerender` says', async () => {
+    expect(await prerendered(await setupSkills({ llms: { prerender: false }, nitro: { static: true } }))).toEqual(queued)
+    expect(await prerendered(await setupSkills({ llms: { prerender: false }, _generate: true }))).toEqual(queued)
+  })
+
+  // The option is only settled once every module has installed: a theme listed
+  // after this one still gets to set it.
+  it('reads the option after every module has installed', async () => {
+    const nuxt = await runModule({ skills: { dir } }, {}, (nuxt) => {
+      (nuxt.options as { llms?: unknown }).llms = { prerender: false }
+    })
+    expect(await prerendered(nuxt)).toEqual([])
   })
 })
 

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { nuxtCtx } from '@nuxt/kit'
+import { defu } from 'defu'
 import module from '../../src/module'
 import { AGENT_USER_AGENTS, EXCLUDE_PREFIXES } from '../../src/defaults'
 import { vercelMarkdownRoutes } from '../../src/presets/vercel'
@@ -76,7 +77,9 @@ type FakeNuxt = ReturnType<typeof createNuxt>
  */
 async function runModule(options: Partial<ModuleOptions> = {}, routeRules: Record<string, unknown> = {}, installLate?: (nuxt: FakeNuxt) => void, preInstall?: (nuxt: FakeNuxt) => void, nuxtOptions: Record<string, unknown> = {}): Promise<FakeNuxt> {
   const nuxt = createNuxt(routeRules)
-  Object.assign(nuxt.options, nuxtOptions)
+  // Merged, not assigned: replacing `nitro` or `modules` wholesale would drop
+  // whatever else the fixture puts there.
+  Object.assign(nuxt.options, defu(nuxtOptions, nuxt.options))
   // Stands in for a module listed before this one: its hooks register first.
   preInstall?.(nuxt)
   // `set`, not `callAsync`: unctx only restores an async context in code the
@@ -157,6 +160,13 @@ describe('module setup: skills', () => {
   // alone answers for a configuration nobody set.
   it('reads `prerender` off the inline `nuxt-llms` module options', async () => {
     expect(await prerendered(await setupSkills({ modules: [['nuxt-llms', { prerender: false }]] }))).toEqual([])
+  })
+
+  // `nuxt-llms` merges its inline options over the config key, so a site
+  // setting both gets the answer that module acts on, not the other one.
+  it('lets the inline module options win over the `llms` config key', async () => {
+    expect(await prerendered(await setupSkills({ modules: [['nuxt-llms', { prerender: true }]], llms: { prerender: false } }))).toEqual(queued)
+    expect(await prerendered(await setupSkills({ modules: [['nuxt-llms', { prerender: false }]], llms: { prerender: true } }))).toEqual([])
   })
 
   // A static build has no server to answer the routes the links keep

--- a/test/unit/module.test.ts
+++ b/test/unit/module.test.ts
@@ -104,6 +104,53 @@ describe('module setup: notAcceptable', () => {
   })
 })
 
+describe('module setup: skills', () => {
+  const dir = '../basic/skills'
+
+  async function prerendered(llms?: { prerender?: boolean }): Promise<string[]> {
+    const nuxt = await runModule({ skills: { dir } }, {}, undefined, (nuxt) => {
+      if (llms) {
+        (nuxt.options as { llms?: unknown }).llms = llms
+      }
+    })
+    const routes = new Set<string>()
+    await nuxt.hooks.callHook('prerender:routes' as never, { routes } as never)
+    return [...routes].filter(route => route.startsWith('/.well-known/skills'))
+  }
+
+  it('prerenders the index and every skill file by default', async () => {
+    expect(await prerendered()).toEqual([
+      '/.well-known/skills/index.json',
+      '/.well-known/skills/basic-site/SKILL.md',
+      '/.well-known/skills/basic-site/references/conventions.md'
+    ])
+  })
+
+  it('queues nothing when `llms.prerender` is off', async () => {
+    expect(await prerendered({ prerender: false })).toEqual([])
+  })
+
+  it('prerenders when `llms` is configured without `prerender`', async () => {
+    expect(await prerendered({})).toHaveLength(3)
+  })
+
+  it('still serves and advertises the skills when prerendering is off', async () => {
+    const nuxt = await runModule({ skills: { dir } }, {}, undefined, (nuxt) => {
+      (nuxt.options as { llms?: unknown }).llms = { prerender: false }
+    })
+    const config = nuxt.options.runtimeConfig.agentDiscovery as NegotiationConfig
+
+    expect(nuxt.options.serverHandlers.map(handler => handler.route)).toEqual(
+      expect.arrayContaining(['/.well-known/skills/index.json', '/.well-known/skills/**'])
+    )
+    expect((nuxt.options.runtimeConfig.agentDiscoverySkills as { skills: { name: string }[] }).skills.map(skill => skill.name))
+      .toEqual(['basic-site'])
+    expect(config.links.map(link => link.href)).toEqual(
+      expect.arrayContaining(['/.well-known/skills/index.json', '/.well-known/skills/basic-site/SKILL.md'])
+    )
+  })
+})
+
 describe('module setup: shared defaults', () => {
   it('never mutates the module-level defaults, however many instances run', async () => {
     const first = await setupModule()


### PR DESCRIPTION
Aligned with https://github.com/nuxt-content/nuxt-llms/pull/53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable prerendering for skill documents through `llms.prerender`.
  - Skill documents remain available at runtime when prerendering is disabled.
  - Skills are prerendered by default and continue to be prerendered for static builds.
  - Configuration is consistently recognized whether set inline or through Nuxt options.

- **Documentation**
  - Expanded configuration guidance to describe skill delivery, static-server behavior, crawler effects, and related generated documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->